### PR TITLE
DOCSP-5504: Only match PAT_EXPLICIT_TILE if needed by role

### DIFF
--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -53,7 +53,9 @@ def test_step() -> None:
 
         '<directive name="step"><section><heading><text>Create a </text><literal><text>',
         '/etc/apt/sources.list.d/mongodb-org-3.4.list</text></literal><text> file for </text>',
-        '<role name="guilabel" label="MongoDB" target="MongoDB" raw="MongoDB"></role>',
+        '<role name="guilabel" label="',
+        '{\'type\': \'text\', \'value\': \'MongoDB\', \'position\': {\'start\': {\'line\': 1}}}',
+        '"></role>',
         '<text>.</text></heading>',
         '<section><heading><text>Optional: action heading</text></heading>'
         '<paragraph><text>Create the list file using the command appropriate for ',

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -139,9 +139,10 @@ class JSONVisitor:
             return
         elif node_name == 'role':
             doc['name'] = node['name']
-            doc['label'] = node['label']
-            doc['target'] = node['target']
-            doc['raw'] = node['raw']
+            if 'label' in node:
+                doc['label'] = node['label']
+            if 'target' in node:
+                doc['target'] = node['target']
         elif node_name == 'target':
             doc['type'] = 'target'
             doc['ids'] = node['ids']

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -267,142 +267,158 @@ inherit = "_guides-base"
 ###### Roles
 [role.guilabel]
 help = """Used to specify a label or button in a GUI."""
+type = "text"
 
 [role.abbr]
 help = """Abbreviation with hover text."""
+type = "text"
 
 [role.file]
 help = """Show a file path."""
+type = "text"
 
 [role.icon-fa5]
 help = """Show a FontAwesome 5 Solid icon."""
+type = "explicit_title"
 
 [role.icon]
 inherit = "icon-fa5"
+type = "explicit_title"
 
 [role.icon-fa5-brands]
 help = """Show a FontAwesome 5 Brand icon."""
+type = "explicit_title"
 
 [role.iconb]
 inherit = "icon-fa5-brands"
 
 [role.icon-mms]
 help = """Show an MMS icon."""
+type = "explicit_title"
 
 [role.icon-mms-org]
 help = """Show an MMS-org icon."""
+type = "explicit_title"
 
 [role.icon-charts]
 help = """Show a MongoDB Charts icon."""
+type = "explicit_title"
 
 [role.icon-fa4]
 help = """Show a FontAwesome 4 icon."""
+type = "explicit_title"
 
 [role.xml]
 help = """Use XML to create reStructuredText nodes."""
+type = "text"
 
 [role.rfc]
 help = """Reference an IETF RFC."""
+type = "explicit_title"
 
 [role.hardlink]
 help = """Link to a URL in the current project."""
+type = "explicit_title"
 
 [role.doc]
 help = """Link to a page in the current project."""
+type = "explicit_title"
 
 [role.manual]
 help = """Link to a page in the latest stable version of the MongoDB manual."""
-type = "link http://docs.mongodb.com/manual%s"
+type = {link = "https://docs.mongodb.com/manual%s"}
 
 [role.ref]
 help = """Link to a named target."""
+type = "explicit_title"
 
 [role.term]
 help = """Link to a term in the glossary."""
+type = "explicit_title"
 
 [role.issue]
 help = """Link to a JIRA ticket."""
-type = "link https://jira.mongodb.org/browse/%s"
+type = {link = "https://jira.mongodb.org/browse/%s"}
 
 [role.perl-api]
 help = "Link to a page in the Perl driver's CPAN API reference."
-type = "link https://metacpan.org/pod/MongoDB::%s"
+type = {link = "https://metacpan.org/pod/MongoDB::%s"}
 
 [role.node-docs]
 help = """Link to a page in the Node.js driver's documentation."""
-type = "link http://mongodb.github.io/node-mongodb-native/3.0/%s"
+type = {link = "http://mongodb.github.io/node-mongodb-native/3.0/%s"}
 
 [role.node-api]
 help = """Link to a page in the Node.js driver's API reference."""
-type = "link http://mongodb.github.io/node-mongodb-native/3.0/api/%s"
+type = {link = "http://mongodb.github.io/node-mongodb-native/3.0/api/%s"}
 
 [role.ruby-api]
 help = """Link to a page in the Ruby driver's API reference."""
-type = "link http://api.mongodb.com/ruby/current/Mongo/%s"
+type = {link = "http://api.mongodb.com/ruby/current/Mongo/%s"}
 
 [role.scala-api]
 help = """Link to a page in the Scala driver's API reference."""
-type = "link http://mongodb.github.io/mongo-scala-driver/2.2/scaladoc/org/mongodb/scala/MongoCollection.html#%s"
+type = {link = "http://mongodb.github.io/mongo-scala-driver/2.2/scaladoc/org/mongodb/scala/MongoCollection.html#%s"}
 
 [role.csharp-docs]
 help = """Link to a page in the C# driver's documentation."""
-type = "link https://mongodb.github.io/mongo-csharp-driver/2.5/reference/%s"
+type = {link = "https://mongodb.github.io/mongo-csharp-driver/2.5/reference/%s"}
 
 [role.csharp-api]
 help = """Link to a page in the C# driver's API reference."""
-type = "link https://mongodb.github.io/mongo-csharp-driver/2.5/apidocs/html/%s.htm"
+type = {link = "https://mongodb.github.io/mongo-csharp-driver/2.5/apidocs/html/%s.htm"}
 
 [role.java-async-docs]
 help = """Link to the async Java driver's documentation."""
-type = "link http://mongodb.github.io/mongo-java-driver/3.7/%s"
+type = {link = "http://mongodb.github.io/mongo-java-driver/3.7/%s"}
 
 [role.java-async-api]
 help = """Link to the async Java driver's API reference."""
-type = "link http://mongodb.github.io/mongo-java-driver/3.7/javadoc/%s"
+type = {link = "http://mongodb.github.io/mongo-java-driver/3.7/javadoc/%s"}
 
 [role.java-sync-api]
 help = """Link to the synchronous Java driver's API reference."""
-type = "link http://mongodb.github.io/mongo-java-driver/3.7/javadoc/%s"
+type = {link = "http://mongodb.github.io/mongo-java-driver/3.7/javadoc/%s"}
 
 [role.atlas]
 help = """Link to the synchronous Atlas documentation."""
-type = "link https://docs.atlas.mongodb.com/%s"
+type = {link = "https://docs.atlas.mongodb.com/%s"}
 
 [role."v2.2"]
-type = "link https://docs.mongodb.com/v2.2%s"
+type = {link = "https://docs.mongodb.com/v2.2%s"}
 
 [role."v2.4"]
-type = "link https://docs.mongodb.com/v2.4%s"
+type = {link = "https://docs.mongodb.com/v2.4%s"}
 
 [role."v2.6"]
-type = "link https://docs.mongodb.com/v2.6%s"
+type = {link = "https://docs.mongodb.com/v2.6%s"}
 
 [role."v3.0"]
-type = "link https://docs.mongodb.com/v3.0%s"
+type = {link = "https://docs.mongodb.com/v3.0%s"}
 
 [role."v3.2"]
-type = "link https://docs.mongodb.com/v3.2%s"
+type = {link = "https://docs.mongodb.com/v3.2%s"}
 
 [role."v3.4"]
-type = "link https://docs.mongodb.com/v3.4%s"
+type = {link = "https://docs.mongodb.com/v3.4%s"}
 
 [role."v3.6"]
-type = "link https://docs.mongodb.com/v3.6%s"
+type = {link = "https://docs.mongodb.com/v3.6%s"}
 
 [role."v4.0"]
-type = "link https://docs.mongodb.com/v4.0%s"
+type = {link = "https://docs.mongodb.com/v4.0%s"}
 
 [role.bic]
-type = "link https://docs.mongodb.com/bi-connector/current%s"
+type = {link = "https://docs.mongodb.com/bi-connector/current%s"}
 
 [role.k8s]
-type = "link https://docs.mongodb.com/kubernetes-operator/stable%s"
+type = {link = "https://docs.mongodb.com/kubernetes-operator/stable%s"}
 
 [role.product]
-type = "link http://www.mongodb.com/products/%s?jmp=docs"
+type = {link = "http://www.mongodb.com/products/%s?jmp=docs"}
 
 [role.dl]
-type = "link http://www.mongodb.com/download-center/%s?jmp=docs"
+type = {link = "http://www.mongodb.com/download-center/%s?jmp=docs"}
 
 ### Types of objects (directive & role pairs)
 [rstobject."py:class"]

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -17,6 +17,13 @@ class _Inheritable(Protocol):
     inherit: Optional[str]
 
 
+@checked
+@dataclass
+class LinkRoleType:
+    """Configuration for a role which links to a specific URL template."""
+    link: str
+
+
 _T = TypeVar('_T', bound=_Inheritable)
 SPEC_VERSION = 0
 StringOrStringlist = Union[List[str], str, None]
@@ -31,6 +38,14 @@ PrimitiveType = Enum('PrimitiveType', (
     'flag',
     'linenos'
 ))
+PrimitiveRoleType = Enum('PrimitiveRoleType', (
+    'text',
+    'explicit_title'
+))
+
+#: Spec definition of a role: this can be either a PrimitiveRoleType, or
+#: an object requiring additional configuration.
+RoleType = Union[PrimitiveRoleType, LinkRoleType]
 
 #: docutils option validation function for each of the above primitive types
 VALIDATORS: Dict[PrimitiveType, Callable[[Any], Any]] = {
@@ -83,7 +98,7 @@ class Role:
     inherit: Optional[str]
     help: Optional[str]
     example: Optional[str]
-    type: Optional[ArgumentType]
+    type: Optional[RoleType]
     deprecated: bool = field(default=False)
 
 
@@ -112,7 +127,7 @@ class RstObject:
             inherit=None,
             help=self.help,
             example=None,
-            type=None,
+            type=PrimitiveRoleType.explicit_title,
             deprecated=self.deprecated)
 
 

--- a/snooty/test_specparser.py
+++ b/snooty/test_specparser.py
@@ -21,6 +21,7 @@ def test_load() -> None:
 
     [role._parent]
     help = "test-role"
+    type = "text"
 
     [role.child]
     inherit = "_parent"
@@ -48,6 +49,7 @@ def test_load() -> None:
     # has a separate inheritance namespace
     assert spec.rstobject['child'].help == 'test-rstobject'
     assert spec.role['child'].help == 'test-role'
+    assert spec.role['child'].type == specparser.PrimitiveRoleType.text
 
     validator = spec.get_validator([specparser.PrimitiveType.nonnegative_integer, 'user_level'])
     assert validator('10') == 10

--- a/stubs/docutils/nodes.pyi
+++ b/stubs/docutils/nodes.pyi
@@ -68,3 +68,13 @@ class system_message(Element): ...
 
 class Text(Node):
     def __init__(self, data: object, rawsource: str=''): ...
+
+
+class Resolvable:
+    resolved: int
+
+
+class Referential(Resolvable): ...
+
+
+class reference(General, Inline, Referential, TextElement): ...

--- a/stubs/docutils/parsers/rst/roles.pyi
+++ b/stubs/docutils/parsers/rst/roles.pyi
@@ -1,3 +1,5 @@
+import docutils.nodes
+import docutils.parsers.rst.states
 from typing import Any, Callable, Dict, Tuple, Optional, List
 
 def role(role_name: str, language_module: object, lineno: int, reporter: object) -> Tuple[Optional[Callable[..., Any]], List[object]]: ...
@@ -9,6 +11,8 @@ def register_local_role(
         str,
         str,
         int,
-        object,
+        docutils.parsers.rst.states.Inliner,
         Dict[str, object],
-        List[object]], Tuple[List[object], List[object]]]) -> None: ...
+        List[object]], Tuple[
+                List[docutils.nodes.Node],
+                List[docutils.nodes.Node]]]) -> None: ...

--- a/stubs/docutils/parsers/rst/states.pyi
+++ b/stubs/docutils/parsers/rst/states.pyi
@@ -1,6 +1,7 @@
 import docutils.parsers.rst
 import docutils.parsers.rst.states
 import docutils.statemachine
+import docutils.utils
 import docutils
 from typing import Dict, List, Tuple, Iterable, Sequence, Pattern, Union
 
@@ -28,3 +29,7 @@ class Body:
     def parse_directive_arguments(self,
                                   directive: docutils.parsers.rst.Directive,
                                   arg_block: Iterable[str]) -> Sequence[str]: ...
+
+
+class Inliner:
+    reporter: docutils.utils.Reporter


### PR DESCRIPTION
This PR retools how rst roles are handled, and categorizes them in three ways:
* `text` roles only provide a `label` field in the AST
* `explicit_title` roles provide a `target` field in the AST, as well as optionally a `label` field
* `link` roles do not emit a `role` node at all; instead, they emit a `reference` with the refuri already set.