### PR TITLE
DOCSP-5545: Implement release specifications

### DIFF
--- a/snooty/gizaparser/__init__.py
+++ b/snooty/gizaparser/__init__.py
@@ -1,1 +1,1 @@
-from . import steps, extracts  # NoQA
+from . import steps, extracts, release  # NoQA

--- a/snooty/gizaparser/extracts.py
+++ b/snooty/gizaparser/extracts.py
@@ -57,9 +57,12 @@ class GizaExtractsCategory(GizaCategory[Extract]):
                  extracts: Sequence[Extract]) -> List[Page]:
         pages: List[Page] = []
         for extract in extracts:
+            assert extract.ref is not None
+            if extract.ref.startswith('_'):
+                continue
+
             page, rst_parser = page_factory()
             page.category = 'extracts'
-            assert extract.ref is not None
             page.output_filename = extract.ref
             page.ast = extract_to_page(page, extract, rst_parser)
             pages.append(page)

--- a/snooty/gizaparser/release.py
+++ b/snooty/gizaparser/release.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional, List, Tuple, Sequence
+from ..flutter import checked
+from ..types import Diagnostic, EmbeddedRstParser, SerializableType, Page
+from .parse import parse
+from .nodes import Inheritable, GizaCategory
+
+
+@checked
+@dataclass
+class ReleaseSpecification(Inheritable):
+    copyable: Optional[bool]
+    language: Optional[str]
+    code: Optional[str]
+
+    def render(self, page: Page, parse_rst: EmbeddedRstParser) -> SerializableType:
+        children: List[SerializableType] = []
+        if self.code:
+            children.append({
+                'type': 'code',
+                'lang': self.language,
+                'copyable': True if self.copyable is None else self.copyable,
+                'position': {'start': {'line': self.line}},
+                'value': self.code
+            })
+        return children
+
+
+def release_specification_to_page(page: Page,
+                                  node: ReleaseSpecification,
+                                  rst_parser: EmbeddedRstParser) -> SerializableType:
+    rendered = node.render(page, rst_parser)
+    return {
+        'type': 'directive',
+        'name': 'release_specification',
+        'position': {'start': {'line': node.line}},
+        'children': rendered
+    }
+
+
+class GizaReleaseSpecificationCategory(GizaCategory[ReleaseSpecification]):
+    def parse(self,
+              path: Path,
+              text: Optional[str] = None) -> Tuple[
+                  Sequence[ReleaseSpecification], str, List[Diagnostic]]:
+        nodes, text, diagnostics = parse(ReleaseSpecification, path, self.project_config, text)
+
+        def report_missing_ref(node: ReleaseSpecification) -> bool:
+            diagnostics.append(
+                Diagnostic.error(
+                    'Missing ref; all release specifications must define a ref', node.line))
+            return False
+
+        # All nodes must have an explicitly-defined ref ID
+        release_specifications = [node for node in nodes if node.ref or report_missing_ref(node)]
+        return release_specifications, text, diagnostics
+
+    def to_pages(self,
+                 page_factory: Callable[[], Tuple[Page, EmbeddedRstParser]],
+                 nodes: Sequence[ReleaseSpecification]) -> List[Page]:
+        pages: List[Page] = []
+        for node in nodes:
+            assert node.ref is not None
+            if node.ref.startswith('_'):
+                continue
+
+            page, rst_parser = page_factory()
+            page.category = 'release'
+            page.output_filename = node.ref
+            page.ast = release_specification_to_page(page, node, rst_parser)
+            pages.append(page)
+
+        return pages

--- a/snooty/gizaparser/test_nodes.py
+++ b/snooty/gizaparser/test_nodes.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
+from pathlib import Path
+from typing import List
 from . import nodes
+from ..types import Diagnostic, ProjectConfig
 
 
 @dataclass
@@ -30,44 +33,51 @@ def test_dependency_graph() -> None:
 
 
 def test_substitution() -> None:
+    diagnostics: List[Diagnostic] = []
     replacements = {
         'verb': 'test',
         'noun': 'substitution'
     }
     test_string = r'{{verb}}ing {{noun}}. {{verb}}.'
     substituted_string = 'testing substitution. test.'
-    assert nodes.substitute_text(test_string, replacements) == substituted_string
+    assert nodes.substitute_text(test_string, replacements, diagnostics) == substituted_string
 
     obj = object()
-    assert nodes.substitute(obj, replacements) is obj
+    assert nodes.substitute(obj, replacements, diagnostics) is obj
 
     # Test complex substitution
     node = SubstitutionTest(
         foo=test_string,
         foo2=test_string,
         child=Child(test_string))
-    substituted_node = nodes.substitute(node, replacements)
+    substituted_node = nodes.substitute(node, replacements, diagnostics)
     assert substituted_node == SubstitutionTest(
         foo=substituted_string,
         foo2=substituted_string,
         child=Child(substituted_string))
 
     # Make sure that no substitution == ''
+    assert diagnostics == []
     del replacements['noun']
-    assert nodes.substitute_text(test_string, replacements) == 'testing . test.'
+    assert nodes.substitute_text(test_string, replacements, diagnostics) == 'testing . test.'
+    assert len(diagnostics) == 1
 
     # Ensure the identity of the zero-substitutions case remains the same
+    diagnostics = []
     test_string = 'foo'
-    assert nodes.substitute_text(test_string, {}) is test_string
+    assert nodes.substitute_text(test_string, {}, diagnostics) is test_string
+    assert not diagnostics
 
 
 def test_inheritance() -> None:
+    project_config, diagnostics = ProjectConfig.open(Path('test_data'))
     parent = nodes.Inheritable('parent', {'foo': 'bar', 'old': ''}, source=None, inherit=None)
     child = nodes.Inheritable(
         'child',
         {'bar': 'baz', 'old': 'new'},
         source=nodes.Inherit('self.yaml', 'parent'),
         inherit=None)
-    child = nodes.inherit(child, parent)
+    child = nodes.inherit(project_config, child, parent, diagnostics)
 
     assert child.replacement == {'foo': 'bar', 'bar': 'baz', 'old': 'new'}
+    assert not diagnostics

--- a/snooty/gizaparser/test_release.py
+++ b/snooty/gizaparser/test_release.py
@@ -1,31 +1,30 @@
 from pathlib import Path, PurePath
 from typing import Dict, Tuple, List
-from .extracts import GizaExtractsCategory
+from .release import GizaReleaseSpecificationCategory
 from ..types import Diagnostic, Page, EmbeddedRstParser, ProjectConfig
 from ..parser import make_embedded_rst_parser
 from ..util import ast_to_testing_string
 
 
-def test_extract() -> None:
+def test_release_specification() -> None:
     project_config = ProjectConfig(Path('test_data'), '')
-    category = GizaExtractsCategory(project_config)
-    path = Path('test_data/extracts-test.yaml')
-    parent_path = Path('test_data/extracts-test-parent.yaml')
+    project_config.constants['version'] = '3.4'
+    category = GizaReleaseSpecificationCategory(project_config)
+    path = Path('test_data/release-specifications.yaml')
+    parent_path = Path('test_data/release-base.yaml')
 
     def add_main_file() -> List[Diagnostic]:
         extracts, text, parse_diagnostics = category.parse(path)
         category.add(path, text, extracts)
-        assert len(parse_diagnostics) == 1
-        assert parse_diagnostics[0].severity == Diagnostic.Level.error
-        assert parse_diagnostics[0].start == (21, 0)
-        assert len(extracts) == 5
+        assert len(parse_diagnostics) == 0
+        assert len(extracts) == 2
         return parse_diagnostics
 
     def add_parent_file() -> List[Diagnostic]:
         extracts, text, parse_diagnostics = category.parse(parent_path)
         category.add(parent_path, text, extracts)
         assert len(parse_diagnostics) == 0
-        assert len(extracts) == 1
+        assert len(extracts) == 2
         return parse_diagnostics
 
     all_diagnostics: Dict[PurePath, List[Diagnostic]] = {}
@@ -41,21 +40,26 @@ def test_extract() -> None:
 
     pages = category.to_pages(create_page, giza_node.data)
     assert [str(page.get_id()) for page in pages] == [
-        'test_data/extracts/installation-directory-rhel',
-        'test_data/extracts/broken-inherit',
-        'test_data/extracts/another-file',
-        'test_data/extracts/missing-substitution']
+        'test_data/release/untar-release-osx-x86_64',
+        'test_data/release/install-ent-windows-default']
 
+    assert all((not diagnostics for diagnostics in all_diagnostics.values()))
+
+    print(ast_to_testing_string(pages[0].ast))
     assert ast_to_testing_string(pages[0].ast) == ''.join((
-        '<directive name="extract"><paragraph><text>By default, MongoDB stores its data files in ',
-        '</text><literal><text>/var/lib/mongo</text></literal><text> and its\nlog files in </text>',
-        '<literal><text>/var/log/mongodb</text></literal><text>.</text></paragraph></directive>'
+        '<directive name="release_specification">',
+        '<code lang="sh" copyable="True">',
+        'tar -zxvf mongodb-macos-x86_64-3.4.tgz\n'
+        '</code>',
+        '</directive>'
     ))
 
-    assert ast_to_testing_string(pages[3].ast) == ''.join((
-        '<directive name="extract"><paragraph><text>Substitute</text></paragraph></directive>'
+    print(ast_to_testing_string(pages[1].ast))
+    assert ast_to_testing_string(pages[1].ast) == ''.join((
+        '<directive name="release_specification">',
+        '<code lang="bat" copyable="True">',
+        'msiexec.exe /l*v mdbinstall.log  /qb /i ',
+        'mongodb-win32-x86_64-enterprise-windows-64-3.4-signed.msi\n',
+        '</code>',
+        '</directive>'
     ))
-
-    # XXX: We need to track source file information for each property.
-    # Line number 1 here should correspond to parent_path, not path.
-    assert set(d.start[0] for d in all_diagnostics[path]) == set((21, 13, 1))

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -344,7 +344,8 @@ class Project:
 
         self.yaml_mapping: Dict[str, GizaCategory[Any]] = {
             'steps': gizaparser.steps.GizaStepsCategory(self.config),
-            'extracts': gizaparser.extracts.GizaExtractsCategory(self.config)
+            'extracts': gizaparser.extracts.GizaExtractsCategory(self.config),
+            'release': gizaparser.release.GizaReleaseSpecificationCategory(self.config),
         }
 
         username = pwd.getpwuid(os.getuid()).pw_name

--- a/test_data/extracts-test.yaml
+++ b/test_data/extracts-test.yaml
@@ -25,4 +25,8 @@ ref: another-file
 inherit:
   file: extracts-test-parent.yaml
   ref: a-parent-ref
+---
+ref: missing-substitution
+content: |
+  Substitute {{mongodDatadir}}
 ...

--- a/test_data/release-base.yaml
+++ b/test_data/release-base.yaml
@@ -1,0 +1,15 @@
+ref: _untar-release
+copyable: true
+language: 'sh'
+code: |
+  tar -zxvf mongodb-{{platform}}-{{builder}}-{{version}}.tgz
+---
+ref: _install-windows-ent
+copyable: true
+language: bat
+code: |
+   msiexec.exe /l*v mdbinstall.log  /qb /i mongodb-win32-x86_64-enterprise-windows-64-{{version}}-signed.msi
+
+# Adding SHOULD_INSTALL_COMPASS="0" since the install page states that this installs just what's specified in ADDLOCAL
+
+...

--- a/test_data/release-specifications.yaml
+++ b/test_data/release-specifications.yaml
@@ -1,0 +1,16 @@
+ref: untar-release-osx-x86_64
+source:
+  file: release-base.yaml
+  ref: _untar-release
+replacement:
+  platform: 'macos'
+  builder: 'x86_64'
+---
+ref: install-ent-windows-default
+source:
+  file: release-base.yaml
+  ref: _install-windows-ent
+replacement:
+  location: 'C:\Program Files\MongoDB\Server\{+version+}\'
+  addlocal: 'all'
+...


### PR DESCRIPTION
*  Adds a ReleaseSpecificationsGizaCategory class
* Merges source_constants into the giza substitutions system
* Adds tests
* Raises a diagnostic upon use of undefined giza substitutions

  This is a gentle breaking change: I think it's important for validation, but we use it in the corpus. So with this change, snooty logs a diagnostic, but replicates giza's behavior by inserting empty text.