### PR TITLE
DOCSP-6493: Add missing tabid option to tab directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -214,6 +214,7 @@ inherit = "tabs"
 [directive.tab]
 argument_type = "string"
 content_type = "block"
+options.tabid = "string"
 
 [directive.index]
 argument_type = "string"

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -17,18 +17,20 @@ def test_tabs() -> None:
     assert ast_to_testing_string(page.ast) == "".join(
         (
             "<root>",
-            '<directive name="tabs" hidden="True"><directive name="tab"><text>bionic</text>',
+            '<directive name="tabs" hidden="True"><directive name="tab" tabid="bionic"><text>Ubuntu 18.04 (Bionic)</text>',
             "<paragraph><text>Bionic content</text></paragraph></directive>",
-            '<directive name="tab"><text>xenial</text><paragraph><text>',
+            '<directive name="tab" tabid="xenial"><text>Ubuntu 16.04 (Xenial)</text><paragraph><text>',
             "Xenial content</text></paragraph></directive>",
-            '<directive name="tab"><text>trusty</text><paragraph><text>',
+            '<directive name="tab" tabid="trusty"><text>Ubuntu 14.04 (Trusty)</text><paragraph><text>',
             "Trusty content</text></paragraph></directive></directive>",
-            '<directive name="tabs" tabset="platforms"><directive name="tab"><text>windows</text>',
+            '<directive name="tabs" tabset="platforms"><directive name="tab" tabid="windows">',
             "<paragraph><text>Windows content</text></paragraph></directive></directive>",
-            '<directive name="tabs" hidden="True"><directive name="tab">',
-            "<text>trusty</text><paragraph><text>",
+            '<directive name="tabs" tabset="platforms"><directive name="tab" tabid="windows">',
+            "<paragraph><text>Windows content</text></paragraph></directive></directive>",
+            '<directive name="tabs" hidden="True"><directive name="tab" tabid="trusty">',
+            "<text>Ubuntu 14.04 (Trusty)</text><paragraph><text>",
             "Trusty content</text></paragraph></directive>",
-            '<directive name="tab"><text>xenial</text><paragraph><text>',
+            '<directive name="tab" tabid="xenial"><text>Ubuntu 16.04 (Xenial)</text><paragraph><text>',
             "Xenial content</text></paragraph></directive></directive>",
             "</root>",
         )
@@ -37,7 +39,7 @@ def test_tabs() -> None:
     assert (
         len(diagnostics) == 1
         and diagnostics[0].message.startswith("Unexpected field")
-        and diagnostics[0].start[0] == 44
+        and diagnostics[0].start[0] == 54
     )
 
 

--- a/test_data/test_tabs.rst
+++ b/test_data/test_tabs.rst
@@ -29,13 +29,23 @@
            Windows content
 
 .. tabs::
+   :tabset: platforms
+
+   .. tab::
+      :tabid: windows
+
+      Windows content
+
+.. tabs::
    :hidden: true
 
-   .. tab:: trusty
+   .. tab:: Ubuntu 14.04 (Trusty)
+      :tabid: trusty
 
       Trusty content
 
-   .. tab:: xenial
+   .. tab:: Ubuntu 16.04 (Xenial)
+      :tabid: xenial
 
       Xenial content
 


### PR DESCRIPTION
With this change, tab nodes will provide the tabid in the `tabid` option, and the title if given in a directive_argument.

This is opposed to the old AST format where the argument could contain either a title or a tabid depending on whether the tabset was anonymous or not.