### PR TITLE
DOCSP-6442: Parse repo-wide substitutions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -68,6 +68,18 @@ helper classes.
 ### `types.py`
 ### `util.py`
 
+# Developing Snooty
+Use [Flit](https://flit.readthedocs.io/en/latest/) to install Snooty. The module will be symlinked (via `-s`) to allow for testing changes without reinstalling the module.
+```shell
+flit install -s
+```
+
+## Running tests
+To run tests for a specific file:
+```shell
+. .venv/bin/activate
+pytest snooty/test_<file>.py
+```
 
 # Problem Areas
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -81,6 +81,13 @@ To run tests for a specific file:
 pytest snooty/test_<file>.py
 ```
 
+### Code Coverage
+Install [Coverage](https://coverage.readthedocs.io/en/v4.5.x/). After running tests via `make format test`, run:
+```shell
+coverage html
+```
+This will generate an HTML representation of code coverage throughout the repo that can be viewed in the browser.
+
 # Problem Areas
 
 * Transforming docutils nodes into our AST (parser.JSONVisitor) is

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -289,10 +289,14 @@ class JSONVisitor:
         elif node_name == "substitution_reference":
             # If this substitution was defined in snooty.toml, append its defined replacement as children nodes
             if node.astext() in self.project_config.substitution_nodes:
+                # Strip the node of its root and paragraph nodes
                 substitution_definition = cast(
                     Dict[str, SerializableType],
                     self.project_config.substitution_nodes[node.astext()],
                 )["children"]
+                substitution_definition = cast(List[Any], substitution_definition)[0][
+                    "children"
+                ]
                 self.state[-1].setdefault("children", [])
                 self.state[-1]["children"].extend(substitution_definition)
             else:
@@ -552,15 +556,13 @@ class _Project:
             "release": gizaparser.release.GizaReleaseSpecificationCategory(self.config),
         }
 
+        # For each repo-wide substitution, parse the string and save to our project config
         substitution_nodes: Dict[str, SerializableType] = {}
         for k, v in self.config.substitutions.items():
             node, diagnostics = parse_rst(self.parser, root, v)
             substitution_nodes[k] = node.ast
 
         self.config.substitution_nodes = substitution_nodes
-
-        # Re-parse using our updated config that now includes substitutions represented as nodes
-        self.parser = rstparser.Parser(self.config, JSONVisitor)
 
         username = pwd.getpwuid(os.getuid()).pw_name
         branch = subprocess.check_output(

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -372,7 +372,10 @@ class NoTransformRstParser(docutils.parsers.rst.Parser):
 
 class Visitor(Protocol):
     def __init__(
-        self, project_root: Path, docpath: PurePath, document: docutils.nodes.document
+        self,
+        project_config: ProjectConfig,
+        docpath: PurePath,
+        document: docutils.nodes.document,
     ) -> None:
         ...
 
@@ -485,7 +488,7 @@ class Parser(Generic[_V]):
 
         parser.parse(text, document)
 
-        visitor = self.visitor_class(self.project_config.source_path, path, document)
+        visitor = self.visitor_class(self.project_config, path, document)
         visitor.add_diagnostics(diagnostics)
         document.walkabout(visitor)
         return visitor, text

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -274,9 +274,7 @@ def test_toml_replacement() -> None:
         """<root>
         <paragraph>
         <substitution_reference>
-        <paragraph>
         <emphasis><text>Yet Another Markup Language</text></emphasis>
-        </paragraph>
         </substitution_reference>
         <text>ain't markup language.</text>
         </paragraph>

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -12,6 +12,9 @@ def test_project() -> None:
         "invalid": "\u200b",
     }
 
+    assert project_config.substitution_nodes == {}
+    assert project_config.substitutions == {"guides-short": "MongoDB Guides"}
+
     path = Path("test_data/empty_project")
     project_config, project_diagnostics = ProjectConfig.open(path)
     assert project_config.constants == {}

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -261,6 +261,7 @@ class ProjectConfig:
     source: str = field(default="source")
     constants: Dict[str, object] = field(default_factory=dict)
     substitutions: Dict[str, str] = field(default_factory=dict)
+    # This variable is populated after parse time with the nodes from `substitutions` strings
     substitution_nodes: Dict[str, SerializableType] = field(default_factory=dict)
 
     @property

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -261,7 +261,7 @@ class ProjectConfig:
     source: str = field(default="source")
     constants: Dict[str, object] = field(default_factory=dict)
     substitutions: Dict[str, str] = field(default_factory=dict)
-    # This variable is populated after parse time with the nodes from `substitutions` strings
+    # substitution_nodes contains a parsed representation of the substitutions member, and is populated on Project initialization.
     substitution_nodes: Dict[str, SerializableType] = field(default_factory=dict)
 
     @property

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -260,6 +260,8 @@ class ProjectConfig:
     name: str
     source: str = field(default="source")
     constants: Dict[str, object] = field(default_factory=dict)
+    substitutions: Dict[str, str] = field(default_factory=dict)
+    substitution_nodes: Dict[str, SerializableType] = field(default_factory=dict)
 
     @property
     def source_path(self) -> Path:

--- a/test_data/bad_project/snooty.toml
+++ b/test_data/bad_project/snooty.toml
@@ -4,3 +4,6 @@ name = "test_data"
 version = 3.4
 package_title = "{+version+}.tar.gz"
 invalid = "{+foo+}"
+
+[substitutions]
+guides-short = "MongoDB Guides"

--- a/test_data/test_project/snooty.toml
+++ b/test_data/test_project/snooty.toml
@@ -2,3 +2,6 @@ name = "test_data"
 
 [constants]
 name = "MongoDB"
+
+[substitutions]
+guides = "MongoDB Guides"


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-6442)] Parse substitutions defined in the `snooty.toml` under `[substitutions]` and include their nodes in the AST.