### PR TITLE
DOCSP-6504: Fix parsing of versionadded, versionchanged, and deprecated directives

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -365,6 +365,38 @@ class CodeDirective(docutils.parsers.rst.Directive):
         return [node]
 
 
+class VersionDirective(docutils.parsers.rst.Directive):
+    required_arguments = 1
+    optional_arguments = 1
+    has_content = True
+    final_argument_whitespace = True
+    option_spec: Dict[str, object] = {}
+
+    def run(self) -> List[docutils.nodes.Node]:
+        source, line = self.state_machine.get_source_and_line(self.lineno)
+        node = directive(self.name)
+        node.document = self.state.document
+        node.source, node.line = source, line
+        node["options"] = self.options
+
+        if self.arguments is not None:
+            textnodes = []
+            for argument_text in self.arguments:
+                text, messages = self.state.inline_text(argument_text, self.lineno)
+                textnodes.extend(text)
+            argument = directive_argument("", "", *textnodes)
+            argument.document = self.state.document
+            argument.source, argument.line = source, line
+            node.append(argument)
+
+        if self.content:
+            self.state.nested_parse(
+                self.content, self.state_machine.line_offset, node, match_titles=True
+            )
+
+        return [node]
+
+
 class NoTransformRstParser(docutils.parsers.rst.Parser):
     def get_transforms(self) -> List[object]:
         return []
@@ -437,6 +469,11 @@ def register_spec_with_docutils(spec: specparser.Spec) -> None:
     docutils.parsers.rst.directives.register_directive("code-block", CodeDirective)
     docutils.parsers.rst.directives.register_directive("code", CodeDirective)
     docutils.parsers.rst.directives.register_directive("sourcecode", CodeDirective)
+    docutils.parsers.rst.directives.register_directive("deprecated", VersionDirective)
+    docutils.parsers.rst.directives.register_directive("versionadded", VersionDirective)
+    docutils.parsers.rst.directives.register_directive(
+        "versionchanged", VersionDirective
+    )
     docutils.parsers.rst.directives.register_directive("guide", LegacyGuideDirective)
     docutils.parsers.rst.directives.register_directive(
         "guide-index", LegacyGuideIndexDirective

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -366,6 +366,13 @@ class CodeDirective(docutils.parsers.rst.Directive):
 
 
 class VersionDirective(docutils.parsers.rst.Directive):
+    """Special handling for versionadded, versionchanged, and deprecated directives.
+
+    These directives include one required argument and an optional argument on the next line.
+    We need to ensure that these are both included in the `argument` field of the AST, and that
+    subsequent indented directives are included as children of the node.
+    """
+
     required_arguments = 1
     optional_arguments = 1
     has_content = True

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -615,3 +615,97 @@ def test_cond() -> None:
         </directive>
         </root>""",
     )
+
+
+def test_version() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. versionchanged:: 2.0
+    This is some modified content.
+
+    This is a child that should also be rendered here.
+
+This paragraph is not a child.
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <directive name="versionchanged">
+        <text>
+        2.0
+        </text>
+        <text>
+        This is some modified content.
+        </text>
+        <paragraph>
+        <text>This is a child that should also be rendered here.</text>
+        </paragraph>
+        </directive>
+        <paragraph>
+        <text>This paragraph is not a child.</text>
+        </paragraph>
+        </root>""",
+    )
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. deprecated:: 1.8
+
+A new paragraph.
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <directive name="deprecated">
+        <text>
+        1.8
+        </text>
+        </directive>
+        <paragraph>
+        <text>A new paragraph.</text>
+        </paragraph>
+        </root>""",
+    )
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. versionadded:: 2.1
+    A description that includes *emphasized* text.
+
+    A child paragraph.
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <directive name="versionadded">
+        <text>
+        2.1
+        </text>
+        <text>A description that includes </text>
+        <emphasis><text>emphasized</text></emphasis>
+        <text> text.</text>
+        <paragraph>
+        <text>A child paragraph.</text>
+        </paragraph>
+        </directive>
+        </root>""",
+    )


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-6504)] Both the numerical "version" argument (which appears on the same line as the directive) and the "explanation", which appears on the following line, are output as members of a node's `argument` array. Any subsequent indented directives are output as the node's children. I've already tested and verified that this output works on the front-end.