### PR TITLE
DOCSP-6620: Add footnote support

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -306,13 +306,9 @@ class JSONVisitor:
             name = node["names"][0]
             doc["name"] = name
             doc["id"] = node["ids"][0]
-            if "auto" in node:
-                doc["label"] = node["auto"]
         elif node_name == "footnote_reference":
             doc["refname"] = node["refname"]
             doc["id"] = node["ids"][0]
-            if "auto" in node:
-                doc["label"] = node["auto"]
 
         doc["children"] = []
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -302,6 +302,17 @@ class JSONVisitor:
             else:
                 doc["name"] = node["refname"]
             return
+        elif node_name == "footnote":
+            name = node["names"][0]
+            doc["name"] = name
+            doc["id"] = node["ids"][0]
+            if "auto" in node:
+                doc["label"] = node["auto"]
+        elif node_name == "footnote_reference":
+            doc["refname"] = node["refname"]
+            doc["id"] = node["ids"][0]
+            if "auto" in node:
+                doc["label"] = node["auto"]
 
         doc["children"] = []
 

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -615,3 +615,62 @@ def test_cond() -> None:
         </directive>
         </root>""",
     )
+
+
+def test_footnote() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. [#footnote-test]
+
+    This is an example of what a footnote looks like.
+
+    It may have multiple children.
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <footnote id="footnote-test" name="footnote-test" label="1">
+        <paragraph>
+        <text>This is an example of what a footnote looks like.</text>
+        </paragraph>
+        <paragraph>
+        <text>It may have multiple children.</text>
+        </paragraph>
+        </footnote>
+        </root>""",
+    )
+
+
+def test_footnote_reference() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+This is a footnote [#test-footnote]_ in use.
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <paragraph>
+        <text>This is a footnote</text>
+        <footnote_reference label="1" id="id1" refname="test-footnote" />
+        <text> in use.</text>
+        </paragraph>
+        </root>""",
+    )

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -638,7 +638,7 @@ def test_footnote() -> None:
     check_ast_testing_string(
         page.ast,
         """<root>
-        <footnote id="footnote-test" name="footnote-test" label="1">
+        <footnote id="footnote-test" name="footnote-test">
         <paragraph>
         <text>This is an example of what a footnote looks like.</text>
         </paragraph>
@@ -669,7 +669,7 @@ This is a footnote [#test-footnote]_ in use.
         """<root>
         <paragraph>
         <text>This is a footnote</text>
-        <footnote_reference label="1" id="id1" refname="test-footnote" />
+        <footnote_reference id="id1" refname="test-footnote" />
         <text> in use.</text>
         </paragraph>
         </root>""",


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-6620)] Handle `footnote` and `footnote_reference` directives by providing the relevant `id` and `refname` properties (as generated by Docutils) to the front-end. The front-end will be responsible for identifying `footnote_reference` nodes associated with a given `footnote`, as well as generating the numerical labels.