### PR TITLE
DOCSP-6805: Doc links with dotted filenames are validated properly

### DIFF
--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -279,11 +279,10 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             return fileName
 
         if resolveType == "doc":
-            target = PurePath(fileName).with_suffix(".txt")
-            fileid, target_path = util.reroot_path(
-                target, PurePath(docPath), self.project.config.source_path
+            resolved_target_path = util.add_doc_target_ext(
+                fileName, PurePath(docPath), self.project.config.source_path
             )
-            return str(target_path)
+            return str(resolved_target_path)
         elif resolveType == "directive":
             return str(self.project.config.source_path) + fileName
         else:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -432,15 +432,12 @@ class JSONVisitor:
 
     def validate_doc_role(self, node: docutils.nodes.Node) -> None:
         """Validate target for doc role"""
-        target = PurePath(node["target"]).with_suffix(".txt")
-        fileid, target_path = util.reroot_path(
-            target, self.docpath, self.project_config.source_path
+        resolved_target_path = util.add_doc_target_ext(
+            node["target"], self.docpath, self.project_config.source_path
         )
 
-        if not target_path.is_file():
-            msg = (
-                f'"{node["name"]}" could not open "{target_path}": No such file exists'
-            )
+        if not resolved_target_path.is_file():
+            msg = f'"{node["name"]}" could not open "{resolved_target_path}": No such file exists'
             self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
 
     def add_static_asset(self, path: Path, upload: bool) -> StaticAsset:

--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -40,6 +40,33 @@ def test_get_files() -> None:
     }
 
 
+def test_add_doc_target_ext() -> None:
+    # Set up target filenames
+    root = Path("root")
+    docpath = PurePath("path/to/doc/")
+    targets = [
+        "dottedfilename",
+        "dotted.filename",
+        "dotted.file.name",
+        "d.o.t.t.e.d.f.i.l.e.n.a.m.e",
+    ]
+
+    # What we want the resulting target paths to be
+    path_to_file = root.joinpath(docpath.parent)
+    resolved_targets = [
+        path_to_file.joinpath(Path("dottedfilename.txt")).resolve(),
+        path_to_file.joinpath(Path("dotted.filename.txt")).resolve(),
+        path_to_file.joinpath(Path("dotted.file.name.txt")).resolve(),
+        path_to_file.joinpath(Path("d.o.t.t.e.d.f.i.l.e.n.a.m.e.txt")).resolve(),
+    ]
+
+    # Compare resulting target paths from add_doc_target_ext()
+    test_results = [
+        util.add_doc_target_ext(target, docpath, root) for target in targets
+    ]
+    assert test_results == resolved_targets
+
+
 @pytest.mark.skipif(
     sys.platform != "darwin",
     reason="file watching has very different behavior on different systems; it's hard to test",

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -79,6 +79,18 @@ def ast_dive(ast: Any) -> Iterator[Dict[str, SerializableType]]:
         yield from ast_dive(child)
 
 
+def add_doc_target_ext(target: str, docpath: PurePath, project_root: Path) -> Path:
+    """Given the target file of a doc role, add the appropriate extension and return full file path"""
+    # Add .txt to end of doc role target path
+    target_path = PurePath(target)
+    # Adding the current suffix first takes into account dotted targets
+    new_suffix = target_path.suffix + ".txt"
+    target_path = target_path.with_suffix(new_suffix)
+
+    fileid, resolved_target_path = reroot_path(target_path, docpath, project_root)
+    return resolved_target_path
+
+
 class FileWatcher:
     """A monitor for file changes."""
 


### PR DESCRIPTION
[Jira ticket](https://jira.mongodb.org/browse/DOCSP-6805)

I refactored the process of converting the doc target name into its own util function `add_doc_target_ext()` to keep the logic consistent between the parser's doc target validation and the language server