### PR TITLE
DOCSP-6447: Parse card-group directive

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -431,11 +431,7 @@ class JSONVisitor:
                     msg = f'"{name}" could not open "{argument_text}": No such file exists'
                     self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
         elif name == "cardgroup-card":
-            image_argument = None
-            try:
-                image_argument = options["image"]
-            except (IndexError, KeyError):
-                pass
+            image_argument = options.get("image", None)
 
             if image_argument is None:
                 self.diagnostics.append(

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -423,21 +423,27 @@ class JSONVisitor:
                 else:
                     msg = f'"{name}" could not open "{argument_text}": No such file exists'
                     self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
-        elif name == "card":
+        elif name == "cardgroup-card":
             image_argument = None
             try:
                 image_argument = options["image"]
             except (IndexError, KeyError):
                 pass
-            if image_argument is not None:
-                try:
-                    static_asset = self.add_static_asset(
-                        Path(image_argument), upload=True
+
+            if image_argument is None:
+                self.diagnostics.append(
+                    Diagnostic.error(
+                        f'"{name}" expected an image argument', util.get_line(node)
                     )
-                    self.pending.append(PendingFigure(doc, static_asset))
-                except OSError as err:
-                    msg = f'"{name}" could not open "{image_argument}": {os.strerror(err.errno)}'
-                    self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
+                )
+                return True
+
+            try:
+                static_asset = self.add_static_asset(Path(image_argument), upload=True)
+                self.pending.append(PendingFigure(doc, static_asset))
+            except OSError as err:
+                msg = f'"{name}" could not open "{image_argument}": {os.strerror(err.errno)}'
+                self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
 
         if options:
             doc["options"] = options

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -423,6 +423,21 @@ class JSONVisitor:
                 else:
                     msg = f'"{name}" could not open "{argument_text}": No such file exists'
                     self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
+        elif name == "card":
+            image_argument = None
+            try:
+                image_argument = options["image"]
+            except (IndexError, KeyError):
+                pass
+            if image_argument is not None:
+                try:
+                    static_asset = self.add_static_asset(
+                        Path(image_argument), upload=True
+                    )
+                    self.pending.append(PendingFigure(doc, static_asset))
+                except OSError as err:
+                    msg = f'"{name}" could not open "{image_argument}": {os.strerror(err.errno)}'
+                    self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
 
         if options:
             doc["options"] = options

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -302,7 +302,8 @@ class CardGroupDirective(BaseDocutilsDirective):
         """Synthesize a new-style tab node out of a legacy (YAML) tab definition."""
         line = self.lineno + child.line
 
-        node = directive("card")
+        # Give the node a unique name, as "card" is used by landing page cards in docs-tutorials.
+        node = directive("cardgroup-card")
         node.document = self.state.document
         node.source = source
         node.line = line

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -271,8 +271,8 @@ class CardGroupDirective(BaseDocutilsDirective):
     optional_arguments = 0
     has_content = True
     option_spec = {
-        "type": lambda type: docutils.parsers.rst.directives.choice(
-            type, ("large", "small", None)
+        "type": lambda ty: docutils.parsers.rst.directives.choice(
+            ty, ("large", "small", None)
         )
     }
 

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -615,3 +615,41 @@ def test_cond() -> None:
         </directive>
         </root>""",
     )
+
+
+def test_cardgroup() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. card-group::
+    :type: small
+
+    cards:
+
+    - id: test-one
+      headline: Test One
+      image: /compass-explain-plan-with-index-raw-json.png
+      link: https://docs.mongodb.com/guides/server/delete
+
+    - id: test-two
+      headline: Test Two
+      image: /compass-explain-plan-with-index-raw-json.png
+      link: https://docs.mongodb.com/guides/server/update
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <directive name="card-group" type="small">
+        <directive name="cardgroup-card" cardid="test-one" headline="Test One" image="/compass-explain-plan-with-index-raw-json.png" link="https://docs.mongodb.com/guides/server/delete" checksum="e8d907020488a0b0ba070ae3eeb86aae2713a61cc5bb28346c023cb505cced3c" />
+        <directive name="cardgroup-card" cardid="test-two" headline="Test Two" image="/compass-explain-plan-with-index-raw-json.png" link="https://docs.mongodb.com/guides/server/update" checksum="e8d907020488a0b0ba070ae3eeb86aae2713a61cc5bb28346c023cb505cced3c" />
+        </directive>
+        </root>""",
+    )


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-6447)] Parse card group and upload associated images to `snooty.assets` collection.