### PR TITLE
DOCSP-6885: Fix footnote bug

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -303,11 +303,19 @@ class JSONVisitor:
                 doc["name"] = node["refname"]
             return
         elif node_name == "footnote":
-            name = node["names"][0]
-            doc["name"] = name
+            # Autonumbered footnotes do not have a name
+            try:
+                name = node["names"][0]
+                doc["name"] = name
+            except IndexError:
+                pass
             doc["id"] = node["ids"][0]
         elif node_name == "footnote_reference":
-            doc["refname"] = node["refname"]
+            # Autonumbered footnotes do not have a refname
+            try:
+                doc["refname"] = node["refname"]
+            except KeyError:
+                pass
             doc["id"] = node["ids"][0]
 
         doc["children"] = []

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -743,6 +743,27 @@ def test_footnote() -> None:
         </root>""",
     )
 
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. [#]
+    This is an autonumbered footnote.
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <footnote id="id1">
+        <paragraph>
+        <text>This is an autonumbered footnote.</text>
+        </paragraph>
+        </footnote>
+        </root>""",
+    )
+
 
 def test_footnote_reference() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))
@@ -764,6 +785,26 @@ This is a footnote [#test-footnote]_ in use.
         <paragraph>
         <text>This is a footnote</text>
         <footnote_reference id="id1" refname="test-footnote" />
+        <text> in use.</text>
+        </paragraph>
+        </root>""",
+    )
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+This is an autonumbered footnote [#]_ in use.
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <paragraph>
+        <text>This is an autonumbered footnote</text>
+        <footnote_reference id="id1" />
         <text> in use.</text>
         </paragraph>
         </root>""",


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-6885)] The MongoDB Manual successfully parses now.