### PR TITLE
DOCSP-6904: Fix truncated extracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Parsing of extract filenames that include periods (DOCSP-6904)
+
 ## [v0.1.13] - 2019-09-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Parsing of extract filenames that include periods (DOCSP-6904)
+### Fixed
+
+- Parsing of extract filenames that include periods (DOCSP-6904).
 
 ## [v0.1.13] - 2019-09-23
 

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -84,7 +84,12 @@ class MongoBackend(Backend):
             asset.get_checksum() for asset in page.static_assets if asset.can_upload()
         )
 
-        fully_qualified_pageid = "/".join(prefix + [page_id.with_suffix("").as_posix()])
+        if "extracts" in page_id.as_posix():
+            fully_qualified_pageid = "/".join(prefix + [page_id.as_posix()])
+        else:
+            fully_qualified_pageid = "/".join(
+                prefix + [page_id.with_suffix("").as_posix()]
+            )
         self.client["snooty"]["documents"].replace_one(
             {"_id": fully_qualified_pageid},
             {

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -2,6 +2,7 @@ import getpass
 import logging
 import sys
 import pymongo
+import re
 import watchdog.events
 import watchdog.observers
 from pathlib import Path, PurePath
@@ -84,12 +85,11 @@ class MongoBackend(Backend):
             asset.get_checksum() for asset in page.static_assets if asset.can_upload()
         )
 
-        if "extracts" in page_id.as_posix():
-            fully_qualified_pageid = "/".join(prefix + [page_id.as_posix()])
-        else:
-            fully_qualified_pageid = "/".join(
-                prefix + [page_id.with_suffix("").as_posix()]
-            )
+        page_id = page_id.with_name(
+            re.sub(r"\.((txt)|(rst)|(yaml))$", "", page_id.name)
+        )
+        fully_qualified_pageid = "/".join(prefix + [page_id.as_posix()])
+
         self.client["snooty"]["documents"].replace_one(
             {"_id": fully_qualified_pageid},
             {

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -13,6 +13,7 @@ from .parser import Project, RST_EXTENSIONS
 from .types import Page, Diagnostic, FileId
 
 PATTERNS = ["*" + ext for ext in RST_EXTENSIONS] + ["*.yaml"]
+PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 logger = logging.getLogger(__name__)
 
 
@@ -85,9 +86,8 @@ class MongoBackend(Backend):
             asset.get_checksum() for asset in page.static_assets if asset.can_upload()
         )
 
-        page_id = page_id.with_name(
-            re.sub(r"\.((txt)|(rst)|(yaml))$", "", page_id.name)
-        )
+        # Manually strip file extensions so that filenames that contain periods are not truncated
+        page_id = page_id.with_name(PAT_FILE_EXTENSIONS.sub("", page_id.name))
         fully_qualified_pageid = "/".join(prefix + [page_id.as_posix()])
 
         self.client["snooty"]["documents"].replace_one(


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-6904)] The removal of suffixes from includes was causing filenames to be truncated if they contained a period (`.`). Now, don't remove suffix if the file is an extract.