### PR TITLE
DOCSP-5819: Parse toctree directives

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -456,6 +456,16 @@ class JSONVisitor:
                 msg = f'"{name}" could not open "{image_argument}": {os.strerror(err.errno)}'
                 self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
         elif name == "toctree":
+            url_missing_title = any(
+                "url" in entry and entry["title"] == "" for entry in node["entries"]
+            )
+            if url_missing_title:
+                self.diagnostics.append(
+                    Diagnostic.error(
+                        f'"{name}" with URLs must include titles', util.get_line(node)
+                    )
+                )
+                return True
             doc["entries"] = node["entries"]
 
         if options:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -455,6 +455,8 @@ class JSONVisitor:
             except OSError as err:
                 msg = f'"{name}" could not open "{image_argument}": {os.strerror(err.errno)}'
                 self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
+        elif name == "toctree":
+            doc["entries"] = node["entries"]
 
         if options:
             doc["options"] = options

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -463,21 +463,7 @@ class JSONVisitor:
                 msg = f'"{name}" could not open "{image_argument}": {os.strerror(err.errno)}'
                 self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
         elif name == "toctree":
-
-            def url_missing_title(entry: Dict[str, str]) -> bool:
-                return "url" in entry and "title" not in entry
-
-            if any(url_missing_title(entry) for entry in node["entries"]):
-                self.diagnostics.append(
-                    Diagnostic.error(
-                        f'"{name}" with URLs must include titles', util.get_line(node)
-                    )
-                )
-
-            # Remove entries that are invalid (i.e. contain URLs without titles)
-            doc["entries"] = [
-                entry for entry in node["entries"] if not url_missing_title(entry)
-            ]
+            doc["entries"] = node["entries"]
 
         if options:
             doc["options"] = options

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -464,14 +464,10 @@ class JSONVisitor:
                 self.diagnostics.append(Diagnostic.error(msg, util.get_line(node)))
         elif name == "toctree":
 
-            def entry_is_invalid(entry: Dict[str, str]) -> bool:
+            def url_missing_title(entry: Dict[str, str]) -> bool:
                 return "url" in entry and "title" not in entry
 
-            url_missing_title = any(
-                entry_is_invalid(entry) for entry in node["entries"]
-            )
-
-            if url_missing_title:
+            if any(url_missing_title(entry) for entry in node["entries"]):
                 self.diagnostics.append(
                     Diagnostic.error(
                         f'"{name}" with URLs must include titles', util.get_line(node)
@@ -480,7 +476,7 @@ class JSONVisitor:
 
             # Remove entries that are invalid (i.e. contain URLs without titles)
             doc["entries"] = [
-                entry for entry in node["entries"] if not entry_is_invalid(entry)
+                entry for entry in node["entries"] if not url_missing_title(entry)
             ]
 
         if options:

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -520,15 +520,12 @@ class TocTreeDirective(docutils.parsers.rst.Directive):
         errors: List[docutils.nodes.Node] = []
         for child in self.content:
             entry, err = self.make_toc_entry(source, child)
+            errors.extend(err)
             if entry:
                 entries.append(entry)
-            if err:
-                errors.extend(err)
         node["entries"] = entries
 
-        result: List[docutils.nodes.Node] = [node]
-        result.extend(errors)
-        return result
+        return [node, *errors]
 
     def make_toc_entry(
         self, source: str, child: str
@@ -544,8 +541,8 @@ class TocTreeDirective(docutils.parsers.rst.Directive):
         elif child.startswith("<") and child.endswith(">"):
             # If entry is surrounded by <> tags, assume it is a URL and log an error.
             err = "toctree nodes with URLs must include titles"
-            error_node = self.state.document.reporter.error(str(err), line=self.lineno)
-            return (entry, [error_node])
+            error_node = self.state.document.reporter.error(err, line=self.lineno)
+            return entry, [error_node]
         else:
             target = child
 
@@ -554,7 +551,7 @@ class TocTreeDirective(docutils.parsers.rst.Directive):
             entry["url"] = target
         else:
             entry["slug"] = target
-        return (entry, [])
+        return entry, []
 
 
 class NoTransformRstParser(docutils.parsers.rst.Parser):

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -534,6 +534,7 @@ class TocTreeDirective(docutils.parsers.rst.Directive):
             label, target = match["label"], match["target"]
             entry["title"] = label
         else:
+            # Strip <> tags so that we can properly parse a lone URL and handle errors appropriately.
             target = child.replace("<", "").replace(">", "")
 
         parsed = urllib.parse.urlparse(target)

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -504,6 +504,9 @@ class TocTreeDirective(docutils.parsers.rst.Directive):
         "includehidden": util.option_flag,
         "maxdepth": int,
         "titlesonly": util.option_flag,
+        "reversed": util.option_flag,
+        "numbered": util.option_flag,
+        "glob": util.option_flag,
     }
 
     def run(self) -> List[docutils.nodes.Node]:

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -521,13 +521,14 @@ class TocTreeDirective(docutils.parsers.rst.Directive):
         return [node]
 
     def make_toc_entry(self, source: str, child: str) -> Dict[str, str]:
+        """Parse entry for either url or slug and optional title"""
         entry: Dict[str, str] = {}
         if "<" in child:
             title, path = child.split("<")
             path = path.strip(">")
             entry["title"] = title.strip()
         else:
-            path = child
+            path = child.strip()
 
         parsed = urllib.parse.urlparse(path)
         if parsed.scheme:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -864,10 +864,11 @@ def test_toctree() -> None:
     Title here </test1>
     /test2/faq
     URL with title <https://docs.atlas.mongodb.com>
+    <https://docs.mongodb.com/stitch>
 """,
     )
     page.finish(diagnostics)
-    assert len(diagnostics) == 0
+    assert len(diagnostics) == 1 and "toctree" in diagnostics[0].message
     check_ast_testing_string(
         page.ast,
         """<root>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -847,3 +847,30 @@ def test_cardgroup() -> None:
         </directive>
         </root>""",
     )
+
+
+def test_toctree() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. toctree::
+    :titlesonly:
+
+    Title here </test1>
+    /test2/faq
+    URL with title <https://docs.atlas.mongodb.com>
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <directive name="toctree" titlesonly="True" entries="[{'title': 'Title here', 'slug': '/test1'}, {'slug': '/test2/faq'}, {'title': 'URL with title', 'url': 'https://docs.atlas.mongodb.com'}]" />
+        </root>""",
+    )


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-5819)] Properly parse toctree directives to prepare them for semantic parsing.