### PR TITLE
DOCSP-7186: Implement RPC method to get project name

### DIFF
--- a/RPC-methods.md
+++ b/RPC-methods.md
@@ -2,35 +2,67 @@
 
 `language_server.py` utilizes RPC methods that the snooty parser uses to communicate with the VS Code extension.
 
+## textDocument/get_page_ast
+
+Given a .txt file, return the abstract syntax tree (AST) of the page that is created from parsing that file.
+
+### Parameters
+
+| Parameter | Description |
+| :--- | :--- |
+| `filePath`: `str` | Path of the current file the user is focused on in VS Code. |
+
+### Return
+
+| Return Type | Description |
+| :--- | :--- |
+| `SerializableType`: `Dict` or `None` | The AST of the page created by the parser. |
+
+## textDocument/get_page_fileid
+
+Given a path to a file, return its `FileId`. This method is used to let the extension and the frontend know what the page is called.
+
+### Parameters
+
+| Parameter | Description |
+| :--- | :--- |
+| `filePath`: `str` | Path of the current file the user is focused on in VS Code. |
+
+### Return
+
+| Return Type | Description |
+| :--- | :--- |
+|`SerializableType`: `str` or `None` | The name of the file as represented by its stringified `FileId`. |
+
+## textDocument/get_project_name
+
+Uses the current project's `snooty.toml` file to return the name of the project.
+
+### Return
+
+| Return Type | Description |
+| :--- | :--- |
+| `SerializableType`: `str` or `None` | The `name` that can be found within the project's `snooty.toml` file. |
+
 ## textDocument/resolve
+
 Given an artifact's path relative to the project's source directory, return a corresponding source file path relative to the project's root.
 
 ### Parameters
 
-| Parameter           | Description                                              |
-| :------------------ | :------------------------------------------------------- |
-|`fileName`: `str`    | Name of the target or directive to be resolved.          |
-|`docPath`: `str`     | Path of the text document that `fileName` is found in.   |
-|`resolveType`: `str` | Identifies how the method should resolve the `fileName`. |
+| Parameter | Description |
+| :-- | :-- |
+| `fileName`: `str` | Name of the target or directive to be resolved. |
+| `docPath`: `str` | Path of the text document that `fileName` is found in. |
+| `resolveType`: `str` | Identifies how the method should resolve the `fileName`. |
 
 Resolve types that are currently supported:
-* `directive` - Given an `include`, `literalinclude`, or `figure` directive, the full path to the directive link is returned.
-* `doc` - Given a `doc` role target, the full path to the target with a `.txt` extension is returned.
+
+- `directive` - Given an `include`, `literalinclude`, or `figure` directive, the full path to the directive link is returned.
+- `doc` - Given a `doc` role target, the full path to the target with a `.txt` extension is returned.
 
 ### Return
-| Return Type | Description                                              |
-| :---------- | :------------------------------------------------------- |
-| `str`       | The full path of where the `fileName` should be located. |
 
-## textDocument/get_page_ast
-Given a .txt file, return the abstract syntax tree (AST) of the page that is created from parsing that file.
-
-### Parameters
-| Parameter           | Description                                              |
-| :------------------ | :------------------------------------------------------- |
-|`filePath`: `str`    | Path of the `.txt` file we want the AST of.          |
-
-### Return
-| Return Type | Description                                              |
-| :---------- | :------------------------------------------------------- |
-| `SerializableType`       | The AST of the page created by the parser. |
+| Return Type | Description |
+| :--- | :--- |
+| `SerializableType`: `str` or `None` | The full path of where the `fileName` should be located. |

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -15,6 +15,7 @@ from .gizaparser.published_branches import PublishedBranches
 from .types import FileId, SerializableType
 from . import types, util
 from .parser import Project
+from .util import PAT_FILE_EXTENSIONS
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 Uri = str
@@ -308,6 +309,24 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             return None
 
         return self.project.get_page_ast(Path(filePath))
+
+    def m_text_document__get_project_name(self) -> SerializableType:
+        """Get the project's name from its snooty.toml file"""
+        if not self.project:
+            logger.warn("Project uninitialized")
+            return None
+
+        return self.project.get_project_name()
+
+    def m_text_document__get_page_fileid(self, filePath: str) -> SerializableType:
+        """Given a path to a file, return its fileid as a string"""
+        if not self.project:
+            logger.warn("Project uninitialized")
+            return None
+
+        fileid = self.project.get_fileid(PurePath(filePath))
+        fileid = fileid.with_name(PAT_FILE_EXTENSIONS.sub("", fileid.name))
+        return fileid.as_posix()
 
     def m_text_document__did_open(self, textDocument: SerializableType) -> None:
         if not self.project:

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -15,7 +15,6 @@ from .gizaparser.published_branches import PublishedBranches
 from .types import FileId, SerializableType
 from . import types, util
 from .parser import Project
-from .util import PAT_FILE_EXTENSIONS
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 Uri = str
@@ -311,7 +310,9 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
         return self.project.get_page_ast(Path(filePath))
 
     def m_text_document__get_project_name(self) -> SerializableType:
-        """Get the project's name from its snooty.toml file"""
+        """Get the project's name from its ProjectConfig"""
+        # This method may later be refactored to obtain other ProjectConfig data
+        # (https://github.com/mongodb/snooty-parser/pull/44#discussion_r336749209)
         if not self.project:
             logger.warn("Project uninitialized")
             return None
@@ -325,8 +326,7 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             return None
 
         fileid = self.project.get_fileid(PurePath(filePath))
-        fileid = fileid.with_name(PAT_FILE_EXTENSIONS.sub("", fileid.name))
-        return fileid.as_posix()
+        return fileid.without_known_suffix
 
     def m_text_document__did_open(self, textDocument: SerializableType) -> None:
         if not self.project:

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -2,7 +2,6 @@ import getpass
 import logging
 import sys
 import pymongo
-import re
 import watchdog.events
 import watchdog.observers
 from pathlib import Path, PurePath
@@ -12,9 +11,9 @@ from . import language_server
 from .gizaparser.published_branches import PublishedBranches
 from .parser import Project, RST_EXTENSIONS
 from .types import Page, Diagnostic, FileId, SerializableType
+from .util import PAT_FILE_EXTENSIONS
 
 PATTERNS = ["*" + ext for ext in RST_EXTENSIONS] + ["*.yaml"]
-PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 logger = logging.getLogger(__name__)
 
 

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -11,7 +11,6 @@ from . import language_server
 from .gizaparser.published_branches import PublishedBranches
 from .parser import Project, RST_EXTENSIONS
 from .types import Page, Diagnostic, FileId, SerializableType
-from .util import PAT_FILE_EXTENSIONS
 
 PATTERNS = ["*" + ext for ext in RST_EXTENSIONS] + ["*.yaml"]
 logger = logging.getLogger(__name__)
@@ -96,9 +95,7 @@ class MongoBackend(Backend):
             asset.get_checksum() for asset in page.static_assets if asset.can_upload()
         )
 
-        # Manually strip file extensions so that filenames that contain periods are not truncated
-        page_id = page_id.with_name(PAT_FILE_EXTENSIONS.sub("", page_id.name))
-        fully_qualified_pageid = "/".join(prefix + [page_id.as_posix()])
+        fully_qualified_pageid = "/".join(prefix + [page_id.without_known_suffix])
 
         self.client["snooty"]["documents"].replace_one(
             {"_id": fully_qualified_pageid},

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -690,6 +690,9 @@ class _Project:
         page_ast["children"] = self._populate_include_nodes(page_ast["children"])
         return cast(SerializableType, page_ast)
 
+    def get_project_name(self) -> str:
+        return self.config.name
+
     def update(self, path: Path, optional_text: Optional[str] = None) -> None:
         diagnostics: Dict[PurePath, List[Diagnostic]] = {path: []}
         prefix = get_giza_category(path)
@@ -936,6 +939,9 @@ class Project:
         """Return complete AST of page with updated text"""
         with self._lock:
             return self._project.get_page_ast(path)
+
+    def get_project_name(self) -> str:
+        return self._project.get_project_name()
 
     def update(self, path: Path, optional_text: Optional[str] = None) -> None:
         """Re-parse a file, optionally using the provided text rather than reading the file."""

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -154,3 +154,55 @@ def test_text_doc_get_page_ast() -> None:
             <text>Compose MongoDB deployment</text></heading>
             </section></directive></directive></root>""",
         )
+
+
+def test_text_doc_get_project_name() -> None:
+    """Tests to see if m_text_document__get_project_name() returns the correct name found
+    in the project's snooty.toml"""
+
+    # Set up language server for test_project
+    with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:
+        server.m_initialize(None, CWD_URL + "/test_data/test_project")
+        assert server.project is not None
+
+        expected_name = "test_data"  # Found in test_project's snooty.toml
+        assert server.m_text_document__get_project_name() == expected_name
+
+    # Set up language server for merge_conflict project
+    with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:
+        server.m_initialize(None, CWD_URL + "/test_data/merge_conflict")
+        assert server.project is not None
+
+        expected_name = "merge_conflict"  # Found in test_project's snooty.toml
+        assert server.m_text_document__get_project_name() == expected_name
+
+
+def test_text_doc_get_page_fileid() -> None:
+    """Tests to see if m_text_document__get_page_fileid gets the correct fileid for
+    a file given its path."""
+
+    with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:
+        server.m_initialize(
+            None, CWD_URL + "/test_data/test_project_embedding_includes"
+        )
+
+        assert server.project is not None
+
+        # Set up file path for index.txt
+        source_path = server.project.config.source_path
+        test_file = "index.txt"
+        test_file_path = str(source_path.joinpath(test_file))
+        expected_fileid = "index"
+
+        assert (
+            server.m_text_document__get_page_fileid(test_file_path) == expected_fileid
+        )
+
+        # Test it on an include file this time
+        test_file = "includes/include_child.rst"
+        test_file_path = str(source_path.joinpath(test_file))
+        expected_fileid = "includes/include_child"
+
+        assert (
+            server.m_text_document__get_page_fileid(test_file_path) == expected_fileid
+        )

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -24,6 +24,7 @@ from . import intersphinx
 
 PAT_VARIABLE = re.compile(r"{\+([\w-]+)\+}")
 PAT_GIT_MARKER = re.compile(r"^<<<<<<< .*?^=======\n.*?^>>>>>>>", re.M | re.S)
+PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 SerializableType = Union[None, bool, str, int, float, Dict[str, Any], List[Any]]
 EmbeddedRstParser = Callable[[str, int, bool], List[SerializableType]]
 
@@ -39,7 +40,11 @@ class ProjectConfigError(SnootyError):
 class FileId(PurePosixPath):
     """An unambiguous file path relative to the local project's root."""
 
-    pass
+    @property
+    def without_known_suffix(self) -> str:
+        """Returns the fileid without any of its known file extensions (txt, rst, yaml)"""
+        fileid = self.with_name(PAT_FILE_EXTENSIONS.sub("", self.name))
+        return fileid.as_posix()
 
 
 @dataclass

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -5,6 +5,7 @@ import docutils.parsers.rst.directives
 import watchdog.events
 import watchdog.observers
 import watchdog.observers.api
+import re
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import (
@@ -24,6 +25,7 @@ from .types import FileId, SerializableType
 
 logger = logging.getLogger(__name__)
 _K = TypeVar("_K", bound=Hashable)
+PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 
 
 def reroot_path(

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -5,7 +5,6 @@ import docutils.parsers.rst.directives
 import watchdog.events
 import watchdog.observers
 import watchdog.observers.api
-import re
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import (
@@ -25,7 +24,6 @@ from .types import FileId, SerializableType
 
 logger = logging.getLogger(__name__)
 _K = TypeVar("_K", bound=Hashable)
-PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 
 
 def reroot_path(


### PR DESCRIPTION
[JIRA Ticket](https://jira.mongodb.org/browse/DOCSP-7186)

This PR handles changes to the parser needed to retrieve the project name and fileid for pages being previewed via the Snooty extension.

Note: This must be pushed alongside the PR for the [frontend](https://github.com/mongodb/snooty/pull/118) before creating the formal PR for the VS Code extension.