### PR TITLE
Bugfix: Empty semantic parser dictionary

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -141,9 +141,11 @@ class MongoBackend(Backend):
         self, prefix: List[str], field: Dict[str, SerializableType]
     ) -> None:
         property_name = "/".join(prefix)
-        self.client["snooty"]["metadata"].update_one(
-            {"_id": property_name}, {"$set": field}, upsert=True
-        )
+        # Write to Atlas if field is not an empty dictionary
+        if field:
+            self.client["snooty"]["metadata"].update_one(
+                {"_id": property_name}, {"$set": field}, upsert=True
+            )
 
     def on_delete(self, page_id: FileId) -> None:
         pass


### PR DESCRIPTION
Fixes bug where PyMongo throws an error when using `$set` with an empty field:
```sh
pymongo.errors.WriteError: '$set' is empty. You must specify a field like so: {$set: {<field>: ...}}
```