### PR TITLE
DOCSP-6887: Update figure value to full local path when returning AST

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -797,13 +797,6 @@ class _Project:
         for page in pages:
             self._page_updated(page, diagnostic_list)
 
-        # Specify which transformations should be included in semantic postprocessing
-        fn_names: List[str] = ["toctree", "slug-title", "breadcrumbs", "toctree order"]
-        semantic_parse: Dict[str, SerializableType] = self.semantic_parser.run(
-            self.pages, fn_names
-        )
-        self.backend.on_update_metadata(self.prefix, semantic_parse)
-
     def delete(self, path: PurePath) -> None:
         file_id = os.path.basename(path)
         for giza_category in self.yaml_mapping.values():
@@ -870,7 +863,7 @@ class _Project:
     ) -> List[Dict[str, Any]]:
         """Add include nodes to page AST's children"""
 
-        def replace_include(node: Dict[str, Any]) -> Dict[str, Any]:
+        def replace_nodes(node: Dict[str, Any]) -> Dict[str, Any]:
             # Checks if key in node first to prevent .get() errors of SerializableType
             if node.get("name") == "include":
                 # Get the name of the file
@@ -893,15 +886,35 @@ class _Project:
                 include_node_children = include_file_page_ast["children"]
 
                 # Resolve includes within include node
-                replaced_include = list(map(replace_include, include_node_children))
+                replaced_include = list(map(replace_nodes, include_node_children))
                 node["children"] = replaced_include
+            # Replace instances of an image's name with its full path. This allows Snooty Preview to render an image by
+            # using the location of the image on the user's local machine
+            elif node.get("name") == "figure":
+                # Obtain subset of the image's path (name)
+                argument = node["argument"][0]
+                image_value = argument["value"]
+
+                # Prevents the image from having a redundant path if Snooty Preview already replaced
+                # its original value.
+                source_path_str = self.config.source_path.as_posix()
+                index_match = image_value.find(source_path_str)
+                if index_match != -1:
+                    repeated_offset = index_match + len(source_path_str)
+                    image_value = image_value[repeated_offset:]
+
+                # Replace subset of path with full path of image
+                if image_value[0] == "/":
+                    image_value = image_value[1:]
+                full_path = self.get_full_path(FileId(image_value))
+                argument["value"] = full_path.as_posix()
             # Check for include nodes among current node's children
             elif node.get("children"):
                 for child in node["children"]:
-                    replace_include(child)
+                    replace_nodes(child)
             return node
 
-        return list(map(replace_include, nodes))
+        return list(map(replace_nodes, nodes))
 
     def _page_updated(self, page: Page, diagnostics: List[Diagnostic]) -> None:
         """Update any state associated with a parsed page."""

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -131,17 +131,22 @@ def test_text_doc_get_page_ast() -> None:
         test_file_path = source_path.joinpath(test_file)
 
         language_server_ast: SerializableType = server.m_text_document__get_page_ast(
-            str(test_file_path)
+            test_file_path.as_posix()
         )
 
-        check_ast_testing_string(
-            language_server_ast,
+        # Image found in test file
+        image_path = Path("images/compass-create-database.png")
+        full_image_path = source_path.joinpath(image_path)
+        # Change image path to be full path
+        expected_ast_string = (
             """<root>
             <target ids="['guides']"></target>
             <section alt="Sample images">
             <heading id="id1"><text>Guides</text></heading>
             <directive name="figure" checksum="10e351828f156afcafc7744c30d7b2564c6efba1ca7c55cac59560c67581f947">
-            <text>/images/compass-create-database.png</text></directive></section>
+            <text>"""
+            + full_image_path.as_posix()
+            + """</text></directive></section>
             <directive name="include"><text>/includes/test_rst.rst</text>
             <directive name="include"><text>/includes/include_child.rst</text>
             <paragraph><text>This is an include in an include</text></paragraph></directive></directive>
@@ -152,8 +157,10 @@ def test_text_doc_get_page_ast() -> None:
             <text> now.</text></paragraph></section></directive>
             <directive name="step"><section><heading id="compose-mongodb-deployment">
             <text>Compose MongoDB deployment</text></heading>
-            </section></directive></directive></root>""",
+            </section></directive></directive></root>"""
         )
+
+        check_ast_testing_string(language_server_ast, expected_ast_string)
 
 
 def test_text_doc_get_project_name() -> None:


### PR DESCRIPTION
[JIRA Ticket](https://jira.mongodb.org/browse/DOCSP-6887)

This PR changes the way figure nodes are handled before returning the page AST to Snooty on VS Code. The AST will now return figure nodes with values including their full path of the image on the user's local machine.

This PR must be merged before the VS Code PR for [DOCSP-6887](https://github.com/mongodb/snooty-vscode/pull/8).