### PR TITLE
Bugfix: Add empty array if toctree node lacks children

### DIFF
--- a/snooty/semanticparser.py
+++ b/snooty/semanticparser.py
@@ -228,6 +228,9 @@ def find_toctree_nodes(
 
             # Recursively build the tree for each toctree node in this entries list
             for toctree_node in ast["entries"]:
+                if not children_exist(toctree_node):
+                    # If the node has no children, save `children` as an empty list
+                    toctree_node["children"] = []
                 if "slug" in toctree_node:
                     # Only recursively build the tree for internal links
                     slug = remove_leading_slash(toctree_node["slug"])

--- a/snooty/test_semantic_parser.py
+++ b/snooty/test_semantic_parser.py
@@ -63,16 +63,17 @@ def test_slug_title_mapping(backend: Backend) -> None:
 def test_toctree(backend: Backend) -> None:
     assert backend.metadata["toctree"] == {
         "children": [
-            {"slug": "page1", "title": "Print this heading"},
+            {"children": [], "slug": "page1", "title": "Print this heading"},
             {
                 "slug": "page2",
                 "title": "Heading is not at the top for some reason",
                 "children": [
                     {
+                        "children": [],
                         "title": "MongoDB Connector for Business Intelligence",
                         "url": "https://docs.mongodb.com/bi-connector/current/",
                     },
-                    {"slug": "page3", "title": ""},
+                    {"children": [], "slug": "page3", "title": ""},
                 ],
             },
         ],


### PR DESCRIPTION
Save toctree nodes that lack children with an empty array, in accordance with the [spec](https://gist.github.com/sophstad/01e4265bdb0118b367adf6800f6d4ac4). This improves compatibility with the TOC React component.