### PR TITLE
Bugfix: Don't overwrite toctree titles

### DIFF
--- a/snooty/semanticparser.py
+++ b/snooty/semanticparser.py
@@ -216,7 +216,7 @@ def find_toctree_nodes(
         if node:
             node["slug"] = fileid.without_known_suffix
             # Look up title in slug-title mapping if it has not been specified
-            if "title" not in node or node.get("title") is None:
+            if node.get("title") is None:
                 node["title"] = slug_title_mapping.get(node["slug"], None)
         return
 

--- a/snooty/semanticparser.py
+++ b/snooty/semanticparser.py
@@ -215,7 +215,9 @@ def find_toctree_nodes(
     if not children_exist(ast):
         if node:
             node["slug"] = fileid.without_known_suffix
-            node["title"] = slug_title_mapping.get(node["slug"], [])
+            # Look up title in slug-title mapping if it has not been specified
+            if "title" not in node or node.get("title") is None:
+                node["title"] = slug_title_mapping.get(node["slug"], None)
         return
 
     if ast["type"] == "directive":

--- a/snooty/test_semantic_parser.py
+++ b/snooty/test_semantic_parser.py
@@ -92,7 +92,7 @@ def test_toctree(backend: Backend) -> None:
                         "title": "MongoDB Connector for Business Intelligence",
                         "url": "https://docs.mongodb.com/bi-connector/current/",
                     },
-                    {"children": [], "slug": "page3", "title": []},
+                    {"children": [], "slug": "page3", "title": None},
                 ],
             },
         ],


### PR DESCRIPTION
Fixes bug where user-specified toctree titles were being overwritten. Now, check to see if a title has been set. If not, attempt to lookup the page title to use. Otherwise, assign title to `None`.

Bug identified in https://github.com/mongodb/docs-node/pull/4.