### PR TITLE
Add filename field to Snooty documents

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -102,6 +102,7 @@ class MongoBackend(Backend):
             {
                 "_id": fully_qualified_pageid,
                 "prefix": prefix,
+                "filename": page_id.as_posix(),
                 "ast": page.ast,
                 "source": page.source,
                 "static_assets": checksums,


### PR DESCRIPTION
Add `filename` (path from `source/` + extension) field to documents in the `documents` collection. This will allow the front-end to more easily identify pages by checking document extensions.