### PR TITLE
DOCSP-7573: Add drawer flag to toctree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support for defining non-drawer TOC nodes via `toc_landing_pages` array in snooty.toml (DOCSP-7573).
+
 ## [v0.1.15] - 2019-12-05
 
 ### Added

--- a/snooty/test_semantic_parser.py
+++ b/snooty/test_semantic_parser.py
@@ -68,6 +68,7 @@ def test_toctree(backend: Backend) -> None:
         "children": [
             {
                 "children": [],
+                "options": {"drawer": True},
                 "slug": "page1",
                 "title": [
                     {
@@ -78,6 +79,7 @@ def test_toctree(backend: Backend) -> None:
                 ],
             },
             {
+                "options": {"drawer": False},
                 "slug": "page2",
                 "title": [
                     {
@@ -92,7 +94,12 @@ def test_toctree(backend: Backend) -> None:
                         "title": "MongoDB Connector for Business Intelligence",
                         "url": "https://docs.mongodb.com/bi-connector/current/",
                     },
-                    {"children": [], "slug": "page3", "title": None},
+                    {
+                        "children": [],
+                        "options": {"drawer": False},
+                        "slug": "page3",
+                        "title": None,
+                    },
                 ],
             },
         ],

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -331,6 +331,7 @@ class ProjectConfig:
     substitutions: Dict[str, str] = field(default_factory=dict)
     # substitution_nodes contains a parsed representation of the substitutions member, and is populated on Project initialization.
     substitution_nodes: Dict[str, SerializableType] = field(default_factory=dict)
+    toc_landing_pages: List[str] = field(default_factory=list)
 
     @property
     def source_path(self) -> Path:

--- a/test_data/test_semantic_parser/snooty.toml
+++ b/test_data/test_semantic_parser/snooty.toml
@@ -1,4 +1,5 @@
 name = "test_data"
+toc_landing_pages = ["/page2", "page3"]
 
 [constants]
 name = "MongoDB"


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-7573)] Add support for new `toc_landing_pages` variable in `snooty.toml`, which defines which pages will _not_ be rendered as drawers in the toctree. This information as stored as a `drawer` flag in an `options` object within each toctree node.

For conversion from legacy toolchain, move slugs listed under `config/sphinx_local.yaml`'s `nav_excluded` section to an array represented by `toc_landing_pages` in snooty.toml.
## Old (`config/sphinx_local.yaml`)
```yaml
nav_excluded:
  - /drivers
  - /drivers/c
  - /drivers/cpp
  - /drivers/csharp
  - /drivers/go
  - /drivers/erlang
  - /drivers/node-js
  - /drivers/perl
  - /drivers/php
  - /drivers/python
  - /drivers/ruby
  - /drivers/scala
  - /tools
```

## New (`snooty.toml`)
```toml
toc_landing_pages = [
  "/drivers",
  "/drivers/c",
  "/drivers/cpp",
  "/drivers/csharp",
  "/drivers/go",
  "/drivers/erlang",
  "/drivers/node-js",
  "/drivers/perl",
  "/drivers/php",
  "/drivers/python",
  "/drivers/ruby",
  "/drivers/scala",
  "/tools"
]
```