### PR TITLE
points node-api and node-docs roles to the 3.3 docs

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -521,11 +521,11 @@ type = {link = "https://metacpan.org/pod/MongoDB::%s"}
 
 [role.node-docs]
 help = """Link to a page in the Node.js driver's documentation."""
-type = "link http://mongodb.github.io/node-mongodb-native/3.3/%s"
+type = {link = "http://mongodb.github.io/node-mongodb-native/3.4/%s"}
 
 [role.node-api]
 help = """Link to a page in the Node.js driver's API reference."""
-type = "link http://mongodb.github.io/node-mongodb-native/3.3/api/%s"
+type = {link = "http://mongodb.github.io/node-mongodb-native/3.4/api/%s"}
 
 [role.ruby-api]
 help = """Link to a page in the Ruby driver's API reference."""

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -521,11 +521,11 @@ type = {link = "https://metacpan.org/pod/MongoDB::%s"}
 
 [role.node-docs]
 help = """Link to a page in the Node.js driver's documentation."""
-type = {link = "http://mongodb.github.io/node-mongodb-native/3.0/%s"}
+type = "link http://mongodb.github.io/node-mongodb-native/3.3/%s"
 
 [role.node-api]
 help = """Link to a page in the Node.js driver's API reference."""
-type = {link = "http://mongodb.github.io/node-mongodb-native/3.0/api/%s"}
+type = "link http://mongodb.github.io/node-mongodb-native/3.3/api/%s"
 
 [role.ruby-api]
 help = """Link to a page in the Ruby driver's API reference."""


### PR DESCRIPTION
We're documenting some methods that don't exist in the 3.0 driver, so we'd like to point the node-api/node-docs roles to 3.3. Tweaking it myself seems like it would create less work for y'all.

