### PR TITLE
DOCSP-8084: Improve yaml output_file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Support for defining non-drawer TOC nodes via `toc_landing_pages` array in snooty.toml (DOCSP-7573).
+
+### Fixed
+
+- Inconsistent YAML output filenames leading to broken page previews (DOCSP-8084).
 
 ## [v0.1.15] - 2019-12-05
 

--- a/snooty/gizaparser/extracts.py
+++ b/snooty/gizaparser/extracts.py
@@ -61,7 +61,8 @@ class GizaExtractsCategory(GizaCategory[Extract]):
 
     def to_pages(
         self,
-        page_factory: Callable[[], Tuple[Page, EmbeddedRstParser]],
+        source_path: Path,
+        page_factory: Callable[[str], Tuple[Page, EmbeddedRstParser]],
         extracts: Sequence[Extract],
     ) -> List[Page]:
         pages: List[Page] = []
@@ -70,9 +71,8 @@ class GizaExtractsCategory(GizaCategory[Extract]):
             if extract.ref.startswith("_"):
                 continue
 
-            page, rst_parser = page_factory()
+            page, rst_parser = page_factory(f"{extract.ref}.rst")
             page.category = "extracts"
-            page.output_filename = extract.ref
             page.ast = extract_to_page(page, extract, rst_parser)
             pages.append(page)
 

--- a/snooty/gizaparser/nodes.py
+++ b/snooty/gizaparser/nodes.py
@@ -182,7 +182,8 @@ class GizaCategory(Generic[_I]):
 
     def to_pages(
         self,
-        page_factory: Callable[[], Tuple[Page, EmbeddedRstParser]],
+        source_path: Path,
+        page_factory: Callable[[str], Tuple[Page, EmbeddedRstParser]],
         data: Sequence[_I],
     ) -> List[Page]:
         """Abstract method to generate pages from a given set of Giza nodes."""

--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -126,10 +126,13 @@ class GizaStepsCategory(GizaCategory[Step]):
 
     def to_pages(
         self,
-        page_factory: Callable[[], Tuple[Page, EmbeddedRstParser]],
+        source_path: Path,
+        page_factory: Callable[[str], Tuple[Page, EmbeddedRstParser]],
         steps: Sequence[Step],
     ) -> List[Page]:
-        page, rst_parser = page_factory()
+        output_filename = source_path.with_suffix(".rst").name
+        output_filename = output_filename[len("steps-") :]
+        page, rst_parser = page_factory(output_filename)
         page.category = "steps"
         page.ast = {
             "type": "directive",

--- a/snooty/gizaparser/test_extracts.py
+++ b/snooty/gizaparser/test_extracts.py
@@ -1,5 +1,5 @@
 from pathlib import Path, PurePath
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 from .extracts import GizaExtractsCategory
 from ..types import Diagnostic, Page, EmbeddedRstParser, ProjectConfig
 from ..parser import make_embedded_rst_parser
@@ -35,19 +35,19 @@ def test_extract() -> None:
     assert len(category) == 2
     file_id, giza_node = next(category.reify_all_files(all_diagnostics))
 
-    def create_page() -> Tuple[Page, EmbeddedRstParser]:
-        page = Page(path, "", {})
+    def create_page(filename: Optional[str]) -> Tuple[Page, EmbeddedRstParser]:
+        page = Page.create(path, filename, "", {})
         return (
             page,
             make_embedded_rst_parser(project_config, page, all_diagnostics[path]),
         )
 
-    pages = category.to_pages(create_page, giza_node.data)
+    pages = category.to_pages(path, create_page, giza_node.data)
     assert [str(page.fake_full_path()) for page in pages] == [
-        "test_data/extracts/installation-directory-rhel",
-        "test_data/extracts/broken-inherit",
-        "test_data/extracts/another-file",
-        "test_data/extracts/missing-substitution",
+        "test_data/extracts/installation-directory-rhel.rst",
+        "test_data/extracts/broken-inherit.rst",
+        "test_data/extracts/another-file.rst",
+        "test_data/extracts/missing-substitution.rst",
     ]
 
     assert ast_to_testing_string(pages[0].ast) == "".join(

--- a/snooty/gizaparser/test_release.py
+++ b/snooty/gizaparser/test_release.py
@@ -1,5 +1,5 @@
 from pathlib import Path, PurePath
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 from .release import GizaReleaseSpecificationCategory
 from ..types import Diagnostic, Page, EmbeddedRstParser, ProjectConfig
 from ..parser import make_embedded_rst_parser
@@ -34,17 +34,17 @@ def test_release_specification() -> None:
     assert len(category) == 2
     file_id, giza_node = next(category.reify_all_files(all_diagnostics))
 
-    def create_page() -> Tuple[Page, EmbeddedRstParser]:
-        page = Page(path, "", {})
+    def create_page(filename: Optional[str]) -> Tuple[Page, EmbeddedRstParser]:
+        page = Page.create(path, filename, "", {})
         return (
             page,
             make_embedded_rst_parser(project_config, page, all_diagnostics[path]),
         )
 
-    pages = category.to_pages(create_page, giza_node.data)
+    pages = category.to_pages(path, create_page, giza_node.data)
     assert [str(page.fake_full_path()) for page in pages] == [
-        "test_data/release/untar-release-osx-x86_64",
-        "test_data/release/install-ent-windows-default",
+        "test_data/release/untar-release-osx-x86_64.rst",
+        "test_data/release/install-ent-windows-default.rst",
     ]
 
     assert all((not diagnostics for diagnostics in all_diagnostics.values()))

--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -1,5 +1,5 @@
 from pathlib import Path, PurePath
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 from .steps import GizaStepsCategory
 from ..types import Diagnostic, Page, EmbeddedRstParser, ProjectConfig
 from ..parser import make_embedded_rst_parser
@@ -34,15 +34,17 @@ def test_step() -> None:
     assert len(category) == 2
     file_id, giza_node = next(category.reify_all_files(all_diagnostics))
 
-    def create_page() -> Tuple[Page, EmbeddedRstParser]:
-        page = Page(path, "", {})
+    def create_page(filename: Optional[str]) -> Tuple[Page, EmbeddedRstParser]:
+        page = Page.create(path, filename, "", {})
         return (
             page,
             make_embedded_rst_parser(project_config, page, all_diagnostics[path]),
         )
 
-    pages = category.to_pages(create_page, giza_node.data)
-    assert len(pages) == 1
+    pages = category.to_pages(path, create_page, giza_node.data)
+    assert [str(page.fake_full_path()) for page in pages] == [
+        "test_data/steps/test.rst"
+    ]
     print(repr(ast_to_testing_string(pages[0].ast)))
     assert ast_to_testing_string(pages[0].ast) == "".join(
         (

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -376,8 +376,15 @@ content_type = "block"
 help = """Used to denote subscript text."""
 type = "text"
 
-[role.sup]
+[role.superscript]
 help = """Used to denote superscript text."""
+type = "text"
+
+[role.sup]
+inherit = "superscript"
+
+[role.samp]
+help = """Literal text where you may use curly braces to denote a "variable". For example, "samp:`print(1+{x})`"."""
 type = "text"
 
 [role.guilabel]

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -16,6 +16,7 @@ from .types import (
 )
 from .parser import Project
 from .util import ast_dive
+from .util_test import check_ast_testing_string
 
 
 @dataclass
@@ -179,3 +180,33 @@ def test_not_a_project() -> None:
     backend = Backend()
     project = Project(Path("test_data/not_a_project"), backend)
     project.build()
+
+
+def test_get_ast() -> None:
+    backend = Backend()
+    project = Project(Path("test_data/get-preview"), backend)
+    project.build()
+    ast = project.get_page_ast(
+        Path("test_data/get-preview/source/index.txt").absolute()
+    )
+    check_ast_testing_string(
+        ast,
+        """<root>
+        <section>
+        <heading id="index"><text>Index</text></heading>
+        <paragraph><text>Test.</text></paragraph>
+        <directive name="include"><text>/includes/steps/test.rst</text>
+            <directive name="step"><section><heading id="identify-the-privileges-granted-by-a-role">
+            <text>Identify the privileges granted by a role.</text></heading>
+            <paragraph><text>this is a test step.</text></paragraph></section></directive>
+        </directive>
+        <directive name="include"><text>/includes/extracts/test.rst</text>
+            <paragraph><text>test extract</text></paragraph>
+        </directive>
+        <directive name="include">
+            <text>/includes/release/pin-version-intro.rst</text>
+            <paragraph><text>To install a specific release, you must specify each component package
+individually along with the version number, as in the
+following example:</text></paragraph>
+        </directive></section></root>""",
+    )

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -55,9 +55,5 @@ def test_static_asset() -> None:
 
 
 def test_page() -> None:
-    page = Page(Path("foo.rst"), "", {})
+    page = Page.create(Path("foo.rst"), None, "", {})
     assert page.fake_full_path() == PurePath("foo.rst")
-
-    page = Page(Path("steps-foo.yaml"), "", {})
-    page.category = "steps"
-    assert page.fake_full_path() == PurePath("steps/foo.yaml")

--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -41,6 +41,7 @@ def test_get_files() -> None:
         Path("test_data/merge_conflict/snooty.toml"),
         Path("test_data/test_semantic_parser/snooty.toml"),
         Path("test_data/test_project_embedding_includes/snooty.toml"),
+        Path("test_data/get-preview/snooty.toml"),
     }
 
 

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -286,12 +286,25 @@ class PendingTask:
 @dataclass
 class Page:
     source_path: Path
+    output_filename: str
     source: str
     ast: SerializableType
     static_assets: Set[StaticAsset] = field(default_factory=set)
     pending_tasks: List[PendingTask] = field(default_factory=list)
     category: Optional[str] = None
-    output_filename: Optional[str] = None
+
+    @classmethod
+    def create(
+        self,
+        source_path: Path,
+        output_filename: Optional[str],
+        source: str,
+        ast: SerializableType,
+    ) -> "Page":
+        if output_filename is None:
+            output_filename = source_path.name
+
+        return Page(source_path, output_filename, source, ast)
 
     def fake_full_path(self) -> PurePath:
         """Return a fictitious path (hopefully) uniquely identifying this output artifact."""
@@ -299,12 +312,7 @@ class Page:
             # Giza wrote out yaml file artifacts under a directory. e.g. steps-foo.yaml becomes
             # steps/foo.rst
             return self.source_path.parent.joinpath(
-                PurePath(self.category),
-                (
-                    self.output_filename
-                    if self.output_filename
-                    else self.source_path.name.replace(f"{self.category}-", "", 1)
-                ),
+                PurePath(self.category), self.output_filename
             )
         return self.source_path
 

--- a/test_data/get-preview/snooty.toml
+++ b/test_data/get-preview/snooty.toml
@@ -1,0 +1,1 @@
+name = "get-preview"

--- a/test_data/get-preview/source/includes/extracts-test.yaml
+++ b/test_data/get-preview/source/includes/extracts-test.yaml
@@ -1,0 +1,3 @@
+ref: test
+content: |
+  test extract

--- a/test_data/get-preview/source/includes/release-pinning.yaml
+++ b/test_data/get-preview/source/includes/release-pinning.yaml
@@ -1,0 +1,6 @@
+ref: pin-version-intro
+pre: |
+   To install a specific release, you must specify each component package
+   individually along with the version number, as in the
+   following example:
+...

--- a/test_data/get-preview/source/includes/steps-test.yaml
+++ b/test_data/get-preview/source/includes/steps-test.yaml
@@ -1,0 +1,5 @@
+title: Identify the privileges granted by a role.
+ref: identify-privileges
+pre: |
+  this is a test step.
+...

--- a/test_data/get-preview/source/index.txt
+++ b/test_data/get-preview/source/index.txt
@@ -1,0 +1,11 @@
+=====
+Index
+=====
+
+Test.
+
+.. include:: /includes/steps/test.rst
+
+.. include:: /includes/extracts/test.rst
+
+.. include:: /includes/release/pin-version-intro.rst


### PR DESCRIPTION
* `Page.output_filename` becomes non-Optional, and a `Page.create()` class method is added.
* All output filename hacking is removed.
* `GizaCategory.to_pages()` takes an additional source path parameter, and the page creation factory takes in an output filename, allowing each GizaCategory to specify its desired output filename.