### PR TITLE
Refactor published branches update

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -147,16 +147,6 @@ class MongoBackend(Backend):
     def on_delete(self, page_id: FileId) -> None:
         pass
 
-    def on_published_branches(
-        self, prefix: List[str], published_branches: PublishedBranches
-    ) -> None:
-        page_id = "/".join(prefix)
-        self.client["snooty"]["metadata"].replace_one(
-            {"_id": page_id},
-            {"publishedBranches": published_branches.serialize()},
-            upsert=True,
-        )
-
 
 def usage(exit_code: int) -> None:
     """Exit and print usage information."""

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -686,7 +686,9 @@ class _Project:
 
         published_branches, published_branches_diagnostics = self.get_parsed_branches()
         if published_branches:
-            self.backend.on_published_branches(self.prefix, published_branches)
+            self.backend.on_update_metadata(
+                self.prefix, {"publishedBranches": published_branches.serialize()}
+            )
 
         if published_branches_diagnostics:
             backend.on_diagnostics(


### PR DESCRIPTION
Small refactor to remove a function that specially handles updating `publishedBranches` in the metadata collection. Uses the more generic `on_update_metadata()` instead.