### PR TITLE
DOCSP-6657: Add local targets to the TargetDatabase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## Show this help message
 	. .venv/bin/activate && \
 		python3 -m pip install --upgrade pip && \
 		python3 -m pip install flit && \
-		flit install --deps=develop
+		flit install -s --deps=develop
 	touch $@
 
 lint: .venv/.EXISTS ## Run all linting

--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -56,7 +56,7 @@ def test_step() -> None:
             "following command to import the\n</text><reference ",
             'refuri="https://www.mongodb.org/static/pgp/server-3.4.asc">',
             "<text>MongoDB public GPG Key</text>",
-            "</reference><target ids=\"['mongodb-public-gpg-key']\" ",
+            """</reference><target domain="std" name="label" target="mongodb-public-gpg-key" """,
             'refuri="https://www.mongodb.org/static/pgp/server-3.4.asc">',
             "</target></paragraph></section></directive>",
             '<directive name="step">',

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -276,7 +276,14 @@ class JSONVisitor:
                 self.validate_doc_role(node)
         elif node_name == "target":
             doc["type"] = "target"
-            doc["ids"] = node["ids"]
+            doc["domain"] = "std"
+            doc["name"] = "label"
+
+            # It's unclear why this is a list; I can't find any examples of it being
+            # a list in our corpus.
+            assert len(node["ids"]) == 1
+            doc["target"] = node["ids"][0]
+
             if "refuri" in node:
                 doc["refuri"] = node["refuri"]
         elif node_name == "definition_list":
@@ -367,9 +374,9 @@ class JSONVisitor:
     ) -> None:
         """Handle populating a target_directive AST node."""
         options = node["options"] or {}
-        name = node["name"]
+        doc["type"] = "target"
         doc["domain"] = node["domain"]
-        doc["name"] = name
+        doc["name"] = node["name"]
         doc["target"] = node["target"]
         doc["options"] = options
         doc["children"] = []
@@ -881,11 +888,11 @@ class _Project:
         self, nodes: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
         """
-        Add include nodes to page AST's children. 
+        Add include nodes to page AST's children.
 
         To render images on the Snooty extension's Snooty Preview,
-        we must use the full path of the image on the user's local machine. Note that this does change the 
-        figure's value within the parser's dict. However, this should not change the value when using the parser 
+        we must use the full path of the image on the user's local machine. Note that this does change the
+        figure's value within the parser's dict. However, this should not change the value when using the parser
         outside of Snooty Preview, since this function is currently only called by the language server.
         """
 

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -64,6 +64,19 @@ DOMAIN_RESOLUTION_SEQUENCE = ("mongodb", "std", "")
 RoleHandler = Callable[..., Any]
 
 
+def strip_parameters(target: str) -> str:
+    """Remove trailing ALGOL-style parameters from a target name;
+       e.g. foo(bar, baz) -> foo."""
+    if not target.endswith(")"):
+        return target
+
+    starting_index = target.rfind("(")
+    if starting_index == -1:
+        return target
+
+    return target[0:starting_index]
+
+
 @checked
 @dataclass
 class LegacyTabDefinition(nodes.Node):
@@ -218,10 +231,13 @@ class ExplicitTitleRoleHandler:
 
 
 class RefRoleHandler:
-    def __init__(self, domain: str, name: str, prefix: Optional[str]) -> None:
+    def __init__(
+        self, domain: str, name: str, prefix: Optional[str], callable: bool
+    ) -> None:
         self.domain = domain
         self.name = name
         self.prefix = prefix
+        self.callable = callable
 
     def __call__(
         self,
@@ -249,6 +265,9 @@ class RefRoleHandler:
         # Add the giza prefix/tag, if necessary
         if self.prefix and not target.startswith(self.prefix):
             target = f"{self.prefix}.{target}"
+
+        if self.callable:
+            target = strip_parameters(target)
 
         node = ref_role(self.domain, self.name, lineno, label, target)
         if flag:
@@ -312,22 +331,26 @@ def parse_linenos(term: str, max_val: int) -> List[Tuple[int, int]]:
 class BaseDocutilsDirective(docutils.parsers.rst.Directive):
     directive_spec: specparser.Directive
     required_arguments = 0
-    creates_target = False
 
     def run(self) -> List[docutils.nodes.Node]:
         source, line = self.state_machine.get_source_and_line(self.lineno)
 
-        constructor = target_directive if self.creates_target else directive
+        rstobject_spec = self.directive_spec.rstobject
+        constructor = target_directive if rstobject_spec else directive
         node = constructor(self.directive_spec.domain or "", self.name)
         node.document = self.state.document
         node.source, node.line = source, line
         node["options"] = self.options
         self.add_name(node)
 
-        if self.creates_target is True:
-            node["target"] = self.arguments[0]
-        elif isinstance(self.creates_target, str):
-            node["target"] = f"{self.creates_target}.{self.arguments[0]}"
+        if rstobject_spec is not None:
+            if rstobject_spec.prefix:
+                node["target"] = f"{rstobject_spec.prefix}.{self.arguments[0]}"
+            else:
+                node["target"] = self.arguments[0]
+
+            if rstobject_spec.callable:
+                node["target"] = strip_parameters(node["target"])
         else:
             self.parse_argument(node, source, line)
 
@@ -730,6 +753,24 @@ SPECIAL_DIRECTIVE_HANDLERS: Dict[str, Type[docutils.parsers.rst.Directive]] = {
 }
 
 
+def make_docutils_directive_handler(
+    directive: specparser.Directive,
+    base_class: Type[docutils.parsers.rst.Directive],
+    name: str,
+    options: Dict[str, object],
+) -> Type[docutils.parsers.rst.Directive]:
+    class DocutilsDirective(base_class):  # type: ignore
+        directive_spec = directive
+        has_content = bool(directive.content_type)
+        optional_arguments = 1 if directive.argument_type else 0
+        final_argument_whitespace = True
+        option_spec = options
+
+    new_name = "".join(e for e in name.title() if e.isalnum() or e == "_") + "Directive"
+    DocutilsDirective.__name__ = DocutilsDirective.__qualname__ = new_name
+    return DocutilsDirective
+
+
 def register_spec_with_docutils(spec: specparser.Spec) -> None:
     """Register all of the definitions in the spec with docutils, overwriting the previous
        call to this function. This function should only be called once in the
@@ -774,18 +815,9 @@ def register_spec_with_docutils(spec: specparser.Spec) -> None:
         elif name in SPECIAL_DIRECTIVE_HANDLERS:
             base_class = SPECIAL_DIRECTIVE_HANDLERS[name]
 
-        class DocutilsDirective(base_class):  # type: ignore
-            directive_spec = directive
-            has_content = bool(directive.content_type)
-            optional_arguments = 1 if directive.argument_type else 0
-            final_argument_whitespace = True
-            option_spec = options
-            creates_target = directive.creates_target
-
-        new_name = (
-            "".join(e for e in name.title() if e.isalnum() or e == "_") + "Directive"
+        DocutilsDirective = make_docutils_directive_handler(
+            directive, base_class, name, options
         )
-        DocutilsDirective.__name__ = DocutilsDirective.__qualname__ = new_name
         registry.add_directive(name, DocutilsDirective)
 
     # Docutils builtins
@@ -803,7 +835,10 @@ def register_spec_with_docutils(spec: specparser.Spec) -> None:
             handler = LinkRoleHandler(role_spec.type.link)
         elif isinstance(role_spec.type, specparser.RefRoleType):
             handler = RefRoleHandler(
-                role_spec.type.domain or domain, role_spec.type.name, role_spec.type.tag
+                role_spec.type.domain or domain,
+                role_spec.type.name,
+                role_spec.type.tag,
+                role_spec.rstobject.callable if role_spec.rstobject else False,
             )
         elif role_spec.type == specparser.PrimitiveRoleType.explicit_title:
             handler = ExplicitTitleRoleHandler(domain)

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -218,8 +218,9 @@ class ExplicitTitleRoleHandler:
 
 
 class RefRoleHandler:
-    def __init__(self, domain: str) -> None:
+    def __init__(self, domain: str, name: str) -> None:
         self.domain = domain
+        self.name = name
 
     def __call__(
         self,
@@ -244,7 +245,7 @@ class RefRoleHandler:
             flag = target[0]
             target = target[1:]
 
-        node = ref_role(self.domain, typ, lineno, label, target)
+        node = ref_role(self.domain, self.name, lineno, label, target)
         if flag:
             node["flag"] = flag
 
@@ -794,7 +795,9 @@ def register_spec_with_docutils(spec: specparser.Spec) -> None:
         elif isinstance(role_spec.type, specparser.LinkRoleType):
             handler = LinkRoleHandler(role_spec.type.link)
         elif isinstance(role_spec.type, specparser.RefRoleType):
-            handler = RefRoleHandler(domain)
+            handler = RefRoleHandler(
+                role_spec.type.domain or domain, role_spec.type.name
+            )
         elif role_spec.type == specparser.PrimitiveRoleType.explicit_title:
             handler = ExplicitTitleRoleHandler(domain)
 

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -121,13 +121,7 @@ class Directive:
     deprecated: bool = field(default=False)
     options: Dict[str, ArgumentType] = field(default_factory=MissingDict)
     name: str = field(default="")
-
-    #: A tri-state flag indicating whether this directive creates a directive node
-    #: or a target node. If this flag is a string, it indicates a prefix to which to add
-    #: to the target field of the output AST node; e.g. if creates_target="bin", then
-    #: the target "mongod" would be come "bin.mongod". This is for compatibility with the
-    #: legacy Sphinx stack.
-    creates_target: Union[str, bool] = field(default=False)
+    rstobject: "Optional[RstObject]" = field(default=None)
 
 
 @checked
@@ -142,6 +136,7 @@ class Role:
     domain: Optional[str]
     deprecated: bool = field(default=False)
     name: str = field(default="")
+    rstobject: "Optional[RstObject]" = field(default=None)
 
 
 # A target consists of the following parts:
@@ -177,7 +172,7 @@ class RstObject:
             deprecated=self.deprecated,
             options={},
             name=self.name,
-            creates_target=self.prefix if self.prefix else True,
+            rstobject=self,
         )
 
     def create_role(self) -> Role:
@@ -189,6 +184,7 @@ class RstObject:
             domain=self.domain,
             deprecated=self.deprecated,
             name=self.name,
+            rstobject=self,
         )
 
 

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -121,7 +121,13 @@ class Directive:
     deprecated: bool = field(default=False)
     options: Dict[str, ArgumentType] = field(default_factory=MissingDict)
     name: str = field(default="")
-    is_target: bool = field(default=False)
+
+    #: A tri-state flag indicating whether this directive creates a directive node
+    #: or a target node. If this flag is a string, it indicates a prefix to which to add
+    #: to the target field of the output AST node; e.g. if creates_target="bin", then
+    #: the target "mongod" would be come "bin.mongod". This is for compatibility with the
+    #: legacy Sphinx stack.
+    creates_target: Union[str, bool] = field(default=False)
 
 
 @checked
@@ -171,7 +177,7 @@ class RstObject:
             deprecated=self.deprecated,
             options={},
             name=self.name,
-            is_target=True,
+            creates_target=self.prefix if self.prefix else True,
         )
 
     def create_role(self) -> Role:

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -80,7 +80,7 @@ def test_language_server() -> None:
 
 
 def test_text_doc_resolve() -> None:
-    """Tests to see if m_text_document__resolve() returns the proper path combined with 
+    """Tests to see if m_text_document__resolve() returns the proper path combined with
     appropriate extension"""
     with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:
         server.m_initialize(None, CWD_URL + "/test_data/test_project")
@@ -134,7 +134,7 @@ def test_text_doc_get_page_ast() -> None:
         # Change image path to be full path
         index_ast_string = (
             """<root>
-            <target ids="['guides']"></target>
+            <target domain="std" name="label" target=\"guides\"></target>
             <section alt="Sample images">
             <heading id="id1"><text>Guides</text></heading>
             <directive name="figure" checksum="10e351828f156afcafc7744c30d7b2564c6efba1ca7c55cac59560c67581f947">

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -134,7 +134,7 @@ def test_text_doc_get_page_ast() -> None:
         # Change image path to be full path
         index_ast_string = (
             """<root>
-            <target domain="std" name="label" target=\"guides\"></target>
+            <target domain="std" name="label" target="guides"></target>
             <section alt="Sample images">
             <heading id="id1"><text>Guides</text></heading>
             <directive name="figure" checksum="10e351828f156afcafc7744c30d7b2564c6efba1ca7c55cac59560c67581f947">

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -420,7 +420,7 @@ def test_roles() -> None:
     check_ast_testing_string(
         page.ast,
         """<root>
-            <target domain="mongodb" name="binary" target="mongod"></target>
+            <target domain="mongodb" name="binary" target="bin.mongod"></target>
             <list>
             <listItem>
             <paragraph>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from . import rstparser
-from .util_test import check_ast_testing_string
+from .util_test import check_ast_testing_string, ast_to_testing_string
 from .types import Diagnostic, ProjectConfig
 from .parser import parse_rst, JSONVisitor
 
@@ -420,7 +420,7 @@ def test_roles() -> None:
     check_ast_testing_string(
         page.ast,
         """<root>
-            <target_directive domain="mongodb" name="binary" target="mongod"></target_directive>
+            <target domain="mongodb" name="binary" target="mongod"></target>
             <list>
             <listItem>
             <paragraph>
@@ -571,12 +571,13 @@ def test_rstobject() -> None:
     )
     page.finish(diagnostics)
     assert diagnostics == []
+    print(ast_to_testing_string(page.ast))
     check_ast_testing_string(
         page.ast,
         """<root>
-            <target_directive name="option" target="--slowms &lt;integer&gt;">
+            <target name="option" target="--slowms &lt;integer&gt;">
             <paragraph><text>test</text></paragraph>
-            </target_directive>
+            </target>
             </root>""",
     )
 

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1042,3 +1042,43 @@ def test_toctree() -> None:
         <directive name="toctree" titlesonly="True" entries="[{'title': 'Title here', 'slug': '/test1'}, {'slug': '/test2/faq'}, {'title': 'URL with title', 'url': 'https://docs.atlas.mongodb.com'}]" />
         </root>""",
     )
+
+
+def test_callable_target() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. method:: db.collection.ensureIndex(keys, options)
+
+   Creates an index on the specified field if the index does not already exist.
+
+* :method:`db.collection.ensureIndex(keys, options)`
+* :method:`db.collection.ensureIndex()`
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """
+<root>
+    <target domain="mongodb" name="method" target="db.collection.ensureIndex">
+    <paragraph>
+    <text>Creates an index on the specified field if the index does not already exist.</text>
+    </paragraph>
+    </target>
+    <list>
+    <listItem><paragraph>
+        <ref_role domain="mongodb" name="method" target="db.collection.ensureIndex"/>
+    </paragraph></listItem>
+    <listItem><paragraph>
+        <ref_role domain="mongodb" name="method" target="db.collection.ensureIndex"/>
+    </paragraph></listItem>
+    </list>
+</root>""",
+    )

--- a/snooty/test_semantic_parser.py
+++ b/snooty/test_semantic_parser.py
@@ -3,6 +3,7 @@ from typing import Dict, List, cast, Any
 from .types import FileId, SerializableType
 from .parser import Project
 from .test_project import Backend
+from .util_test import ast_to_testing_string, check_ast_testing_string
 import pytest
 
 
@@ -44,7 +45,9 @@ def test_expand_includes(backend: Backend) -> None:
         {
             "type": "target",
             "position": {"start": {"line": 1}},
-            "ids": ["connection-limits"],
+            "domain": "std",
+            "name": "label",
+            "target": "connection-limits",
             "children": [],
         },
         {
@@ -94,18 +97,40 @@ def test_expand_includes(backend: Backend) -> None:
 def test_validate_ref_targets(backend: Backend) -> None:
     page_id = FileId("refrole.txt")
     ast = cast(Dict[str, List[SerializableType]], backend.pages[page_id].ast)
+
+    # Assert that targets found in intersphinx inventories are correctly resolved
     paragraph = cast(Dict[str, Any], ast["children"][0])
     ref_role = paragraph["children"][0]
-    assert ref_role["type"] == "ref_role"
-    assert "url" in ref_role
-    assert (
-        ref_role["url"]
-        == "https://docs.mongodb.com/manual/reference/configuration-options/#net.port"
+    print(ast_to_testing_string(ref_role))
+    check_ast_testing_string(
+        ref_role,
+        """<ref_role
+        domain="mongodb"
+        name="setting"
+        target="net.port"
+        url="https://docs.mongodb.com/manual/reference/configuration-options/#net.port"></ref_role>""",
     )
 
+    # Assert that local targets are correctly resolved
+    paragraph = cast(Dict[str, Any], ast["children"][3])
+    ref_role = paragraph["children"][1]
+    print(ast_to_testing_string(ref_role))
+    check_ast_testing_string(
+        ref_role,
+        """<ref_role
+        domain="mongodb"
+        name="method"
+        target="amethod"
+        fileid="index.txt"></ref_role>""",
+    )
+
+    # Check that undeclared targets raise an error
     diagnostics = backend.diagnostics[page_id]
-    assert len(diagnostics) == 2
-    assert all(["Target" in diagnostic.message for diagnostic in diagnostics])
+    assert len(diagnostics) == 1
+    assert (
+        "Target" in diagnostics[0].message
+        and "global-writes-collections" in diagnostics[0].message
+    )
 
 
 def test_toctree(backend: Backend) -> None:

--- a/snooty/test_semantic_parser.py
+++ b/snooty/test_semantic_parser.py
@@ -121,7 +121,20 @@ def test_validate_ref_targets(backend: Backend) -> None:
         domain="mongodb"
         name="method"
         target="amethod"
-        fileid="index.txt"></ref_role>""",
+        fileid="index"></ref_role>""",
+    )
+
+    # Assert that local targets with a prefix correctly resolved
+    paragraph = cast(Dict[str, Any], ast["children"][4])
+    ref_role = paragraph["children"][1]
+    print(ast_to_testing_string(ref_role))
+    check_ast_testing_string(
+        ref_role,
+        """<ref_role
+        domain="mongodb"
+        name="binary"
+        target="bin.mongod"
+        url="https://docs.mongodb.com/manual/reference/program/mongod/#bin.mongod"></ref_role>""",
     )
 
     # Check that undeclared targets raise an error

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -184,7 +184,7 @@ class TargetDatabase:
     """A database of targets known to this project."""
 
     intersphinx_inventories: Dict[str, intersphinx.Inventory]
-    local_definitions: Dict[str, Tuple[FileId, str]]
+    local_definitions: Dict[str, FileId]
 
     def __contains__(self, key: str) -> bool:
         key = normalize_target(key)
@@ -201,7 +201,7 @@ class TargetDatabase:
         key = normalize_target(key)
         # Check to see if the target is defined locally
         try:
-            return ("fileid", self.local_definitions[key][0].without_known_suffix)
+            return ("fileid", self.local_definitions[key].without_known_suffix)
         except KeyError:
             pass
 
@@ -218,7 +218,7 @@ class TargetDatabase:
         self, domain: str, name: str, target: str, pageid: FileId
     ) -> None:
         target = normalize_target(target)
-        self.local_definitions[f"{domain}:{name}:{target}"] = (pageid, "")
+        self.local_definitions[f"{domain}:{name}:{target}"] = pageid
 
     def reset(self, config: "ProjectConfig") -> None:
         """Reset this database to a "blank" state with intersphinx inventories defined by

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -33,6 +33,12 @@ EmbeddedRstParser = Callable[[str, int, bool], List[SerializableType]]
 logger = logging.getLogger(__name__)
 
 
+def normalize_target(target: str) -> str:
+    """Normalize targets to allow easy matching against the target
+       database: normalize whitespace and convert to lowercase."""
+    return re.sub(r"\s+", " ", target).lower()
+
+
 class SnootyError(Exception):
     pass
 
@@ -181,6 +187,7 @@ class TargetDatabase:
     local_definitions: Dict[str, Tuple[FileId, str]]
 
     def __contains__(self, key: str) -> bool:
+        key = normalize_target(key)
         if key in self.local_definitions:
             return True
 
@@ -191,6 +198,7 @@ class TargetDatabase:
         return False
 
     def get_url(self, key: str) -> Tuple[str, str]:
+        key = normalize_target(key)
         # Check to see if the target is defined locally
         try:
             return ("fileid", self.local_definitions[key][0].without_known_suffix)
@@ -209,6 +217,7 @@ class TargetDatabase:
     def define_local_target(
         self, domain: str, name: str, target: str, pageid: FileId
     ) -> None:
+        target = normalize_target(target)
         self.local_definitions[f"{domain}:{name}:{target}"] = (pageid, "")
 
     def reset(self, config: "ProjectConfig") -> None:

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -193,7 +193,7 @@ class TargetDatabase:
     def get_url(self, key: str) -> Tuple[str, str]:
         # Check to see if the target is defined locally
         try:
-            return ("fileid", self.local_definitions[key][0].as_posix())
+            return ("fileid", self.local_definitions[key][0].without_known_suffix)
         except KeyError:
             pass
 

--- a/test_data/test_semantic_parser/source/index.txt
+++ b/test_data/test_semantic_parser/source/index.txt
@@ -9,8 +9,18 @@ Connection Limits and Cluster Tier
 .. meta::
    :keywords: connect
 
+
+.. _global-writes-zones:
+
+Global Writes Zones
+-------------------
+
+.. method:: amethod
+
+   Testing
+
 .. toctree::
-   :titlesonly: 
+   :titlesonly:
 
    /page1
    /page2

--- a/test_data/test_semantic_parser/source/refrole.txt
+++ b/test_data/test_semantic_parser/source/refrole.txt
@@ -13,3 +13,5 @@ requirements for sharding collections for |global-write|, see
 :ref:`global-writes-collections`.
 
 And this is a link to :method:`amethod`.
+
+And this is a link to :binary:`mongod`.

--- a/test_data/test_semantic_parser/source/refrole.txt
+++ b/test_data/test_semantic_parser/source/refrole.txt
@@ -1,13 +1,15 @@
 :setting:`net.port` on AWS.
 
-|service| |global-write-clusters| require developers to define 
+|service| |global-write-clusters| require developers to define
 single or multi-region :guilabel:`Zones`, where each zone supports
 write and read operations from geographically local shards. You can also
-configure zones to support global low-latency secondary reads. For more 
+configure zones to support global low-latency secondary reads. For more
 information on |global-write| zones, see :ref:`global-writes-zones`.
 
-|service| does not auto-configure or auto-shard collections. 
-Sharded collections must meet specific compatibility requirements to 
-utilize |global-write|. For more information on guidance and 
-requirements for sharding collections for |global-write|, see 
+|service| does not auto-configure or auto-shard collections.
+Sharded collections must meet specific compatibility requirements to
+utilize |global-write|. For more information on guidance and
+requirements for sharding collections for |global-write|, see
 :ref:`global-writes-collections`.
+
+And this is a link to :method:`amethod`.


### PR DESCRIPTION
There's one big strawman AST structure change: `target` and `target_directive` are unified. So:
`<target ids=[...] uriref="...">`
becomes
`<target domain="..." name="..." target="..." uriref="...">`
and `target_directive` becomes regular `target`.
Let me know what you think of this idea.

There's also a caveat in that the following things won't work right:
* `option` (requires special parsing voodoo)