### PR TITLE
DOCSP-8389: Fix catch-22 in reporting config issues

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -22,10 +22,11 @@ from typing import Any, Dict, List, Optional, Union
 from docopt import docopt
 
 from . import language_server
-from .parser import Project, RST_EXTENSIONS
+from .parser import Project
+from .util import SOURCE_FILE_EXTENSIONS
 from .types import Page, Diagnostic, FileId, SerializableType, BuildIdentifierSet
 
-PATTERNS = ["*" + ext for ext in RST_EXTENSIONS] + ["*.yaml"]
+PATTERNS = ["*" + ext for ext in SOURCE_FILE_EXTENSIONS]
 logger = logging.getLogger(__name__)
 SNOOTY_ENV = os.getenv("SNOOTY_ENV", "development")
 PACKAGE_ROOT = Path(sys.modules["snooty"].__file__).resolve().parent
@@ -49,7 +50,7 @@ class ObserveHandler(watchdog.events.PatternMatchingEventHandler):
         # Ignore non-text files; the Project handles changed static assets.
         # Eventually this logic should probably be moved into the Project's
         # filesystem monitor.
-        if PurePath(event.src_path).suffix not in {".txt", ".rst", ".yaml"}:
+        if PurePath(event.src_path).suffix not in SOURCE_FILE_EXTENSIONS:
             return
 
         if event.event_type in (

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -20,13 +20,13 @@ from . import gizaparser, rstparser, util
 from .gizaparser.nodes import GizaCategory
 from .gizaparser.published_branches import PublishedBranches
 from .postprocess import DevhubPostprocessor, Postprocessor
+from .util import RST_EXTENSIONS
 from .types import (
     Diagnostic,
     SerializableType,
     EmbeddedRstParser,
     Page,
     StaticAsset,
-    ProjectConfigError,
     ProjectConfig,
     PendingTask,
     FileId,
@@ -41,7 +41,6 @@ from .types import (
 multiprocessing.set_start_method("fork")
 
 NO_CHILDREN = {"substitution_reference"}
-RST_EXTENSIONS = {".rst", ".txt"}
 logger = logging.getLogger(__name__)
 
 
@@ -671,7 +670,6 @@ class _Project:
             backend.on_diagnostics(
                 FileId(self.config.config_path.relative_to(root)), config_diagnostics
             )
-            raise ProjectConfigError()
 
         self.parser = rstparser.Parser(self.config, JSONVisitor)
         self.backend = backend
@@ -759,7 +757,7 @@ class _Project:
         return None, []
 
     def get_fileid(self, path: PurePath) -> FileId:
-        return FileId(path.relative_to(self.config.source_path))
+        return FileId(os.path.relpath(path, self.config.source_path))
 
     def get_full_path(self, fileid: FileId) -> Path:
         return self.config.source_path.joinpath(fileid)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1,4 +1,4 @@
-import re
+import os.path
 import logging
 from collections import defaultdict
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Iterable, Sequence
@@ -11,10 +11,9 @@ from .types import (
     SerializableType,
     TargetDatabase,
 )
-from .util import get_child_of_type
+from .util import get_child_of_type, SOURCE_FILE_EXTENSIONS
 
 logger = logging.getLogger(__name__)
-PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 
 
 # XXX: The following two functions should probably be combined at some point
@@ -438,11 +437,15 @@ def get_paths(node: Dict[str, Any], path: List[str], all_paths: List[Any]) -> No
 
 def clean_slug(slug: str) -> str:
     """Strip file extension and leading/trailing slashes (/) from string"""
-    slug_cleaned = slug.strip("/")
+    slug = slug.strip("/")
 
     # TODO: remove file extensions in initial parse layer
     # https://jira.mongodb.org/browse/DOCSP-7595
-    return PAT_FILE_EXTENSIONS.sub("", slug_cleaned)
+    root, ext = os.path.splitext(slug)
+    if ext in SOURCE_FILE_EXTENSIONS:
+        return root
+
+    return slug
 
 
 def children_exist(ast: Dict[str, Any]) -> bool:

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -223,3 +223,16 @@ def test_text_doc_get_page_fileid() -> None:
         assert (
             server.m_text_document__get_page_fileid(test_file_path) == expected_fileid
         )
+
+
+def test_reporting_config_error() -> None:
+    with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:
+        server.m_initialize(None, CWD_URL + "/test_data/bad_project")
+        doc = {
+            "uri": f"file://{CWD_URL}/test_data/bad_project/snooty.toml",
+            "languageId": "",
+            "version": 0,
+            "text": "",
+        }
+        server.m_text_document__did_open(doc)
+        server.m_text_document__did_close({"uri": doc["uri"]})

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -10,7 +10,6 @@ from .types import (
     Page,
     Diagnostic,
     ProjectConfig,
-    ProjectConfigError,
     SerializableType,
     BuildIdentifierSet,
 )
@@ -170,16 +169,12 @@ def test_merge_conflict() -> None:
 
 def test_bad_project() -> None:
     backend = Backend()
-    try:
-        Project(Path("test_data/bad_project"), backend, build_identifiers)
-    except ProjectConfigError:
-        fileid = FileId("snooty.toml")
-        assert list(backend.diagnostics.keys()) == [fileid]
-        diagnostics = backend.diagnostics[fileid]
-        assert len(diagnostics) == 1
-        assert "source constant" in diagnostics[0].message
-    else:
-        assert False
+    Project(Path("test_data/bad_project"), backend, build_identifiers)
+    fileid = FileId("snooty.toml")
+    assert list(backend.diagnostics.keys()) == [fileid]
+    diagnostics = backend.diagnostics[fileid]
+    assert len(diagnostics) == 1
+    assert "source constant" in diagnostics[0].message
 
 
 def test_not_a_project() -> None:

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -44,10 +44,6 @@ class SnootyError(Exception):
     pass
 
 
-class ProjectConfigError(SnootyError):
-    pass
-
-
 class FileId(PurePosixPath):
     """An unambiguous file path relative to the local project's root."""
 

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -28,6 +28,8 @@ from .types import FileId, SerializableType
 
 logger = logging.getLogger(__name__)
 _K = TypeVar("_K", bound=Hashable)
+SOURCE_FILE_EXTENSIONS = {".txt", ".rst", ".yaml"}
+RST_EXTENSIONS = {".txt", ".rst"}
 
 
 def reroot_path(


### PR DESCRIPTION
I would like to have tests to ensure the URI returned is correct, but alas I couldn't figure out how to do that without increasing scope.

Basically, we store up diagnostics in the backend and let the language server decide when it's ready to pull them.