### PR TITLE
DOCSP-7399: Temporarily remove multiprocessing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.8'
         architecture: 'x64'
     - name: Run tests
       run: make test

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -35,6 +35,10 @@ from .types import (
     BuildIdentifierSet,
 )
 
+# XXX: Work around to get snooty working with Python 3.8 until we can fix
+# our implicit data flow issues.
+multiprocessing.set_start_method("fork")
+
 NO_CHILDREN = {"substitution_reference"}
 RST_EXTENSIONS = {".rst", ".txt"}
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
We will need to unify pending tasks and postprocessing to work with
Python 3.8's macOS new default multiprocessing spawn mode.