### PR TITLE
DOCSP-8727: Postprocess queryable nodes

### DIFF
--- a/snooty/eventparser.py
+++ b/snooty/eventparser.py
@@ -44,7 +44,7 @@ class EventParser(EventListeners):
     """Initialize an event-based parse on a python dictionary"""
 
     PAGE_START_EVENT = "page_start"
-    PAGE_LEAVE_EVENT = "page_leave"
+    PAGE_END_EVENT = "page_end"
     OBJECT_START_EVENT = "object_start"
     ARRAY_START_EVENT = "array_start"
     PAIR_EVENT = "pair"
@@ -58,7 +58,7 @@ class EventParser(EventListeners):
         for filename, page in d:
             self._on_page_enter_event(page, filename)
             self._iterate(cast(Dict[str, SerializableType], page.ast), filename)
-            self._on_page_leave_event(page, filename)
+            self._on_page_exit_event(page, filename)
 
     def _iterate(self, d: SerializableType, filename: FileId) -> None:
         if isinstance(d, dict):
@@ -83,7 +83,7 @@ class EventParser(EventListeners):
         """Called when an array is first encountered in tree"""
         self.fire(self.PAGE_START_EVENT, filename, page=page, *args, **kwargs)
 
-    def _on_page_leave_event(
+    def _on_page_exit_event(
         self,
         page: Page,
         filename: FileId,
@@ -91,7 +91,7 @@ class EventParser(EventListeners):
         **kwargs: SerializableType,
     ) -> None:
         """Called when an array is first encountered in tree"""
-        self.fire(self.PAGE_LEAVE_EVENT, filename, page=page, *args, **kwargs)
+        self.fire(self.PAGE_END_EVENT, filename, page=page, *args, **kwargs)
 
     def _on_object_enter_event(
         self,

--- a/snooty/eventparser.py
+++ b/snooty/eventparser.py
@@ -1,0 +1,135 @@
+from typing import Any, Callable, cast, Dict, List, Set, Tuple, Iterable, Union
+from .types import FileId, Page, SerializableType
+
+
+class EventListeners:
+    """Manage the listener functions associated with an event-based parse operation"""
+
+    def __init__(self) -> None:
+        self._universal_listeners: Set[Callable[..., Any]] = set()
+        self._event_listeners: Dict[str, Set[Callable[..., Any]]] = {}
+
+    def add_universal_listener(self, listener: Callable[..., Any]) -> None:
+        """Add a listener to be called on any event"""
+        self._universal_listeners.add(listener)
+
+    def add_event_listener(self, event: str, listener: Callable[..., Any]) -> None:
+        """Add a listener to be called when a particular type of event occurs"""
+        event = event.upper()
+        listeners: Set[Callable[..., Any]] = self._event_listeners.get(event, set())
+        listeners.add(listener)
+        self._event_listeners[event] = listeners
+
+    def get_event_listeners(self, event: str) -> Set[Callable[..., Any]]:
+        """Return all listeners of a particular type"""
+        event = event.upper()
+        return self._event_listeners.get(event, set())
+
+    def fire(
+        self,
+        event: str,
+        filename: FileId,
+        *args: Union[SerializableType, Page],
+        **kwargs: Union[SerializableType, Page],
+    ) -> None:
+        """Iterate through all universal listeners and all listeners of the specified type and call them"""
+        for listener in self.get_event_listeners(event):
+            listener(filename, *args, **kwargs)
+
+        for listener in self._universal_listeners:
+            listener(filename, *args, **kwargs)
+
+
+class EventParser(EventListeners):
+    """Initialize an event-based parse on a python dictionary"""
+
+    PAGE_START_EVENT = "page_start"
+    PAGE_LEAVE_EVENT = "page_leave"
+    OBJECT_START_EVENT = "object_start"
+    ARRAY_START_EVENT = "array_start"
+    PAIR_EVENT = "pair"
+    ELEMENT_EVENT = "element"
+
+    def __init__(self) -> None:
+        super(EventParser, self).__init__()
+
+    def consume(self, d: Iterable[Tuple[FileId, Page]]) -> None:
+        """Initializes a parse on the provided key-value map of pages"""
+        for filename, page in d:
+            self._on_page_enter_event(page, filename)
+            self._iterate(cast(Dict[str, SerializableType], page.ast), filename)
+            self._on_page_leave_event(page, filename)
+
+    def _iterate(self, d: SerializableType, filename: FileId) -> None:
+        if isinstance(d, dict):
+            self._on_object_enter_event(d, filename)
+            for k, v in d.items():
+                self._on_pair_event(k, v, filename)
+                self._iterate(v, filename)
+        elif isinstance(d, list):
+            self._on_array_enter_event(d, filename)
+            for child in d:
+                self._iterate(child, filename)
+        else:
+            self._on_element_event(d, filename)
+
+    def _on_page_enter_event(
+        self,
+        page: Page,
+        filename: FileId,
+        *args: SerializableType,
+        **kwargs: SerializableType,
+    ) -> None:
+        """Called when an array is first encountered in tree"""
+        self.fire(self.PAGE_START_EVENT, filename, page=page, *args, **kwargs)
+
+    def _on_page_leave_event(
+        self,
+        page: Page,
+        filename: FileId,
+        *args: SerializableType,
+        **kwargs: SerializableType,
+    ) -> None:
+        """Called when an array is first encountered in tree"""
+        self.fire(self.PAGE_LEAVE_EVENT, filename, page=page, *args, **kwargs)
+
+    def _on_object_enter_event(
+        self,
+        obj: Dict[str, SerializableType],
+        filename: FileId,
+        *args: SerializableType,
+        **kwargs: SerializableType,
+    ) -> None:
+        """Called when an object is first encountered in tree"""
+        self.fire(self.OBJECT_START_EVENT, filename, obj=obj, *args, **kwargs)
+
+    def _on_array_enter_event(
+        self,
+        arr: List[SerializableType],
+        filename: FileId,
+        *args: SerializableType,
+        **kwargs: SerializableType,
+    ) -> None:
+        """Called when an array is first encountered in tree"""
+        self.fire(self.ARRAY_START_EVENT, filename, arr=arr, *args, **kwargs)
+
+    def _on_pair_event(
+        self,
+        key: SerializableType,
+        value: SerializableType,
+        filename: FileId,
+        *args: SerializableType,
+        **kwargs: SerializableType,
+    ) -> None:
+        """Called when a key-value pair is encountered in tree"""
+        self.fire(self.PAIR_EVENT, filename, key=key, value=value, *args, **kwargs)
+
+    def _on_element_event(
+        self,
+        element: SerializableType,
+        filename: FileId,
+        *args: SerializableType,
+        **kwargs: SerializableType,
+    ) -> None:
+        """Called when an array element is encountered in tree"""
+        self.fire(self.ELEMENT_EVENT, filename, element=element, *args, **kwargs)

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -16,9 +16,10 @@ import watchdog.events
 import networkx
 
 from .flutter import check_type, LoadError
-from . import gizaparser, rstparser, postprocess, util
+from . import gizaparser, rstparser, util
 from .gizaparser.nodes import GizaCategory
 from .gizaparser.published_branches import PublishedBranches
+from .postprocess import DevhubPostprocessor, Postprocessor
 from .types import (
     Diagnostic,
     SerializableType,
@@ -675,8 +676,13 @@ class _Project:
         self.parser = rstparser.Parser(self.config, JSONVisitor)
         self.backend = backend
         self.filesystem_watcher = filesystem_watcher
-        self.postprocessor = postprocess.Postprocessor(self.config, self.targets)
         self.build_identifiers = build_identifiers
+
+        self.postprocessor = (
+            DevhubPostprocessor(self.config, self.targets)
+            if self.config.default_domain
+            else Postprocessor(self.config, self.targets)
+        )
 
         self.yaml_mapping: Dict[str, GizaCategory[Any]] = {
             "steps": gizaparser.steps.GizaStepsCategory(self.config),

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -520,6 +520,7 @@ class DevhubPostprocessor(Postprocessor):
         if obj.get("type") != "directive":
             return
 
+        # TODO: Identify directives that should be exposed in the rstspec.toml to avoid hardcoding
         # These directives are represented as list nodes; they will return a list of strings
         list_fields = ["products", "tags", "languages"]
         # These directives have their content represented as children; they will return a list of nodes

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -502,12 +502,12 @@ class DevhubPostprocessor(Postprocessor):
             return
 
         # These directives are represented as
-        list_fields = ["products", "tags", "authors", "languages"]
+        list_fields = ["products", "tags", "languages"]
         name = obj.get("name")
         assert isinstance(name, str)
         if name == "author":
             options = cast(Dict[str, str], obj["options"])
-            self.query_fields["author_name"] = options["name"]
+            self.query_fields["author"] = options["name"]
         elif name in list_fields:
             self.query_fields[name] = []
             children = cast(Any, obj["children"])

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -16,6 +16,25 @@ from .util import get_child_of_type
 PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 
 
+# XXX: The following two functions should probably be combined at some point
+def get_title_injection_candidate(
+    node: Dict[str, SerializableType]
+) -> Optional[Dict[str, SerializableType]]:
+    """Dive into a tree of nodes, and return the deepest non-inline node if and only if the tree is linear."""
+    while True:
+        children = node.get("children")
+        if children is not None:
+            assert isinstance(children, list)
+            if len(children) > 1:
+                return None
+            elif len(children) == 1:
+                node = children[0]
+            else:
+                return node
+        else:
+            return None
+
+
 def get_deepest(
     node: Dict[str, SerializableType]
 ) -> Optional[Dict[str, SerializableType]]:
@@ -134,7 +153,7 @@ class Postprocessor:
             try:
                 # Add title and link target to AST
                 field_name, target, title_nodes = self.targets[key]
-                injection_candidate = get_deepest(obj)
+                injection_candidate = get_title_injection_candidate(obj)
                 if not obj.get("children") or injection_candidate is not None:
                     for node in title_nodes:
                         deep_copy_position(obj, node)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1,17 +1,7 @@
 import re
 from collections import defaultdict
-from typing import (
-    Any,
-    Callable,
-    cast,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Iterable,
-    Sequence,
-)
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Iterable, Sequence
+from .eventparser import EventParser
 from .types import (
     Diagnostic,
     FileId,
@@ -24,12 +14,6 @@ from .util import get_child_of_type
 
 
 PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
-
-PAGE_START_EVENT = "page_start"
-OBJECT_START_EVENT = "object_start"
-ARRAY_START_EVENT = "array_start"
-PAIR_EVENT = "pair"
-ELEMENT_EVENT = "element"
 
 
 def get_deepest(
@@ -47,7 +31,7 @@ def get_deepest(
             else:
                 return node
         else:
-            return None
+            return node
 
 
 def deep_copy_position(source: SerializableType, dest: SerializableType) -> None:
@@ -94,17 +78,17 @@ class Postprocessor:
 
         self.run_event_parser(
             [
-                (OBJECT_START_EVENT, self.populate_include_nodes),
-                (OBJECT_START_EVENT, self.build_slug_title_mapping),
-                (OBJECT_START_EVENT, self.add_titles_to_label_targets),
-                (OBJECT_START_EVENT, self.handle_target),
+                (EventParser.OBJECT_START_EVENT, self.populate_include_nodes),
+                (EventParser.OBJECT_START_EVENT, self.build_slug_title_mapping),
+                (EventParser.OBJECT_START_EVENT, self.add_titles_to_label_targets),
+                (EventParser.OBJECT_START_EVENT, self.handle_target),
             ]
         )
 
         # Update metadata document with key-value pairs defined in event parser
         document.update({"slugToTitle": self.slug_title_mapping})
 
-        self.run_event_parser([(OBJECT_START_EVENT, self.handle_refs)])
+        self.run_event_parser([(EventParser.OBJECT_START_EVENT, self.handle_refs)])
 
         # Run postprocessing operations related to toctree and append to metadata document
         document.update(
@@ -444,112 +428,92 @@ def children_exist(ast: Dict[str, Any]) -> bool:
     return False
 
 
-class EventListeners:
-    """Manage the listener functions associated with an event-based parse operation"""
+class DevhubPostprocessor(Postprocessor):
+    """Postprocess operation to be run if a project's default_domain is equal to 'devhub'"""
 
-    def __init__(self) -> None:
-        self._universal_listeners: Set[Callable[..., Any]] = set()
-        self._event_listeners: Dict[str, Set[Callable[..., Any]]] = {}
+    def run(
+        self, pages: Dict[FileId, Page]
+    ) -> Tuple[Dict[str, SerializableType], Dict[FileId, List[Diagnostic]]]:
+        if not pages:
+            return {}, {}
 
-    def add_universal_listener(self, listener: Callable[..., Any]) -> None:
-        """Add a listener to be called on any event"""
-        self._universal_listeners.add(listener)
+        self.pages = pages
+        self.build_slug_fileid_mapping()
+        self.diagnostics: Dict[FileId, List[Diagnostic]] = defaultdict(list)
 
-    def add_event_listener(self, event: str, listener: Callable[..., Any]) -> None:
-        """Add a listener to be called when a particular type of event occurs"""
-        event = event.upper()
-        listeners: Set[Callable[..., Any]] = self._event_listeners.get(event, set())
-        listeners.add(listener)
-        self._event_listeners[event] = listeners
+        document: Dict[str, SerializableType] = {"title": self.project_config.title}
 
-    def get_event_listeners(self, event: str) -> Set[Callable[..., Any]]:
-        """Return all listeners of a particular type"""
-        event = event.upper()
-        return self._event_listeners.get(event, set())
+        self.run_event_parser(
+            [
+                (EventParser.OBJECT_START_EVENT, self.populate_include_nodes),
+                (EventParser.OBJECT_START_EVENT, self.build_slug_title_mapping),
+                (EventParser.OBJECT_START_EVENT, self.add_titles_to_label_targets),
+                (EventParser.OBJECT_START_EVENT, self.handle_target),
+            ]
+        )
 
-    def fire(
+        # Update metadata document with key-value pairs defined in event parser
+        document.update({"slugToTitle": self.slug_title_mapping})
+
+        self.run_event_parser(
+            [
+                (EventParser.OBJECT_START_EVENT, self.handle_refs),
+                (EventParser.OBJECT_START_EVENT, self.flatten_devhub_article),
+                (EventParser.PAGE_START_EVENT, self.reset_query_fields),
+                (EventParser.PAGE_LEAVE_EVENT, self.append_query_fields),
+            ]
+        )
+
+        return document, self.diagnostics
+
+    def reset_query_fields(
         self,
-        event: str,
         filename: FileId,
         *args: SerializableType,
-        **kwargs: SerializableType,
+        **kwargs: Optional[Dict[str, SerializableType]],
     ) -> None:
-        """Iterate through all universal listeners and all listeners of the specified type and call them"""
-        for listener in self.get_event_listeners(event):
-            listener(filename, *args, **kwargs)
+        """To be called at the start of each page: reset the query field dictionary"""
+        self.query_fields: Dict[str, Any] = {}
 
-        for listener in self._universal_listeners:
-            listener(filename, *args, **kwargs)
-
-
-class EventParser(EventListeners):
-    """Initialize an event-based parse on a python dictionary"""
-
-    def __init__(self) -> None:
-        super(EventParser, self).__init__()
-
-    def consume(self, d: Iterable[Tuple[FileId, Page]]) -> None:
-        """Initializes a parse on the provided key-value map of pages"""
-        for filename, page in d:
-            self._on_page_enter_event(filename)
-            self._iterate(cast(Dict[str, SerializableType], page.ast), filename)
-
-    def _iterate(self, d: SerializableType, filename: FileId) -> None:
-        if isinstance(d, dict):
-            self._on_object_enter_event(d, filename)
-            for k, v in d.items():
-                self._on_pair_event(k, v, filename)
-                self._iterate(v, filename)
-        elif isinstance(d, list):
-            self._on_array_enter_event(d, filename)
-            for child in d:
-                self._iterate(child, filename)
-        else:
-            self._on_element_event(d, filename)
-
-    def _on_page_enter_event(
-        self, filename: FileId, *args: SerializableType, **kwargs: SerializableType
-    ) -> None:
-        """Called when an array is first encountered in tree"""
-        self.fire(PAGE_START_EVENT, filename, *args, **kwargs)
-
-    def _on_object_enter_event(
+    def append_query_fields(
         self,
-        obj: Dict[str, SerializableType],
         filename: FileId,
         *args: SerializableType,
-        **kwargs: SerializableType,
+        **kwargs: Optional[Dict[str, SerializableType]],
     ) -> None:
-        """Called when an object is first encountered in tree"""
-        self.fire(OBJECT_START_EVENT, filename, obj=obj, *args, **kwargs)
+        """To be called at the end of each page: append the query field dictionary to the 
+        top level of the page's class instance.
+        """
+        page = kwargs.get("page")
+        assert isinstance(page, Page)
+        page.query_fields = self.query_fields
 
-    def _on_array_enter_event(
+    def flatten_devhub_article(
         self,
-        arr: List[SerializableType],
         filename: FileId,
         *args: SerializableType,
-        **kwargs: SerializableType,
+        **kwargs: Optional[Dict[str, SerializableType]],
     ) -> None:
-        """Called when an array is first encountered in tree"""
-        self.fire(ARRAY_START_EVENT, filename, arr=arr, *args, **kwargs)
+        """Extract fields from a page's AST and expose them as a queryable nested document in the page document."""
+        obj = kwargs.get("obj")
+        assert obj is not None
 
-    def _on_pair_event(
-        self,
-        key: SerializableType,
-        value: SerializableType,
-        filename: FileId,
-        *args: SerializableType,
-        **kwargs: SerializableType,
-    ) -> None:
-        """Called when a key-value pair is encountered in tree"""
-        self.fire(PAIR_EVENT, filename, key=key, value=value, *args, **kwargs)
+        if obj.get("type") != "directive":
+            return
 
-    def _on_element_event(
-        self,
-        element: SerializableType,
-        filename: FileId,
-        *args: SerializableType,
-        **kwargs: SerializableType,
-    ) -> None:
-        """Called when an array element is encountered in tree"""
-        self.fire(ELEMENT_EVENT, filename, element=element, *args, **kwargs)
+        # These directives are represented as
+        list_fields = ["products", "tags", "authors", "languages"]
+        name = obj.get("name")
+        assert isinstance(name, str)
+        if name == "author":
+            options = cast(Dict[str, str], obj["options"])
+            self.query_fields["author_name"] = options["name"]
+        elif name in list_fields:
+            self.query_fields[name] = []
+            children = cast(Any, obj["children"])
+            list_items = children[0]["children"]
+            assert isinstance(list_items, List)
+            for item in list_items:
+                text_candidate = get_deepest(item)
+                assert text_candidate is not None
+                self.query_fields[name].append(text_candidate["value"])

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -460,7 +460,7 @@ class DevhubPostprocessor(Postprocessor):
                 (EventParser.OBJECT_START_EVENT, self.handle_refs),
                 (EventParser.OBJECT_START_EVENT, self.flatten_devhub_article),
                 (EventParser.PAGE_START_EVENT, self.reset_query_fields),
-                (EventParser.PAGE_LEAVE_EVENT, self.append_query_fields),
+                (EventParser.PAGE_END_EVENT, self.append_query_fields),
             ]
         )
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -501,13 +501,18 @@ class DevhubPostprocessor(Postprocessor):
         if obj.get("type") != "directive":
             return
 
-        # These directives are represented as
+        # These directives are represented as list nodes; they will return a list of strings
         list_fields = ["products", "tags", "languages"]
+        # These directives have their content represented as children; they will return a list of nodes
+        block_fields = ["introduction"]
+
         name = obj.get("name")
         assert isinstance(name, str)
         if name == "author":
             options = cast(Dict[str, str], obj["options"])
             self.query_fields["author"] = options["name"]
+        elif name in block_fields:
+            self.query_fields[name] = obj["children"]
         elif name in list_fields:
             self.query_fields[name] = []
             children = cast(Any, obj["children"])

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from typing import Dict
+from .types import BuildIdentifierSet, FileId, SerializableType
+from .parser import Project
+from .test_project import Backend
+import pytest
+
+
+@pytest.fixture
+def backend() -> Backend:
+    backend = Backend()
+    build_identifiers: BuildIdentifierSet = {}
+    with Project(Path("test_data/test_devhub"), backend, build_identifiers) as project:
+        project.build()
+
+    return backend
+
+
+def test_queryable_fields(backend: Backend) -> None:
+    page_id = FileId("index.txt")
+    page = backend.pages[page_id]
+    query_fields: Dict[str, SerializableType] = page.query_fields
+    assert query_fields is not None
+    assert query_fields["author"] == "Eliot Horowitz"
+    assert query_fields["tags"] == ["foo", "bar", "baz"]
+    assert query_fields["languages"] == ["nodejs", "java"]
+    assert query_fields["products"] == ["Realm", "MongoDB"]

--- a/snooty/test_legacy_guides.py
+++ b/snooty/test_legacy_guides.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from . import rstparser
-from .util_test import ast_to_testing_string
+from .util_test import check_ast_testing_string
 from .types import ProjectConfig
 from .parser import parse_rst, JSONVisitor
 
@@ -66,5 +66,5 @@ def test_legacy_guides() -> None:
     )
 
     # Ensure that legacy syntax and new syntax create the same output
-    assert ast_to_testing_string(legacy_page.ast) == correct
-    assert ast_to_testing_string(new_page.ast) == correct
+    check_ast_testing_string(legacy_page.ast, correct)
+    check_ast_testing_string(new_page.ast, correct)

--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -41,6 +41,7 @@ def test_get_files() -> None:
         Path("test_data/merge_conflict/snooty.toml"),
         Path("test_data/test_project_embedding_includes/snooty.toml"),
         Path("test_data/get-preview/snooty.toml"),
+        Path("test_data/test_devhub/snooty.toml"),
     }
 
 

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -342,6 +342,7 @@ class Page:
     static_assets: Set[StaticAsset] = field(default_factory=set)
     pending_tasks: List[PendingTask] = field(default_factory=list)
     category: Optional[str] = None
+    query_fields: Dict[str, SerializableType] = field(default_factory=dict)
 
     @classmethod
     def create(

--- a/test_data/test_devhub/snooty.toml
+++ b/test_data/test_devhub/snooty.toml
@@ -1,0 +1,2 @@
+name = "devhub-project"
+default_domain = "devhub"

--- a/test_data/test_devhub/source/includes/authors/lastname-firstname.rst
+++ b/test_data/test_devhub/source/includes/authors/lastname-firstname.rst
@@ -1,0 +1,8 @@
+.. author:: 
+   :name: Eliot Horowitz
+   :image: /path/to/eliots/bio/photo.jpg
+   
+   Eliot Horowitz is the CTO and Co-Founder of MongoDB. He wrote the core
+   code base for MongoDB starting in 2007, and subsequently built the
+   engineering and product teams. Today, Eliot oversees those
+   teams, and continues to drive technology innovations at MongoDB.

--- a/test_data/test_devhub/source/index.txt
+++ b/test_data/test_devhub/source/index.txt
@@ -1,0 +1,134 @@
+:template: devhub-article
+
+.. ---------------------------------------------------------------
+.. META FIELDS FOR SEO / SOCIAL
+.. ---------------------------------------------------------------
+
+.. meta-description:: 
+
+   meta description (160 characters or fewer)
+
+.. twitter::
+   :site: @mongodb
+   :creator: @Lauren_Schaefer
+   :title: Wordswordswords
+   :image: </path/to/image>
+
+   Description of max 200 characters
+
+.. ---------------------------------------------------------------
+.. ARTICLE METADATA FIELDS (TO POPULATE FILTERS AND ARTICLE PAGE)
+.. ---------------------------------------------------------------
+
+.. include:: /includes/authors/lastname-firstname.rst
+
+.. pubdate:: January 31, 2019
+
+.. type:: article, quickstart, how-to, video, live
+
+.. level:: beginner, intermediate, advanced
+
+.. series:: seriesName
+
+.. tags:: 
+
+   * foo
+   * bar
+   * baz
+
+.. languages::
+
+   * nodejs
+   * java
+
+.. products::
+
+   * Realm
+   * MongoDB
+
+.. atf-image:: /img/heros/how-to-write-an-article.png
+
+.. related::
+
+   * ``list of related articles``
+   * ``:doc:`/path/to/article```
+   * ``:doc:`/path/to/other/article```
+
+.. ---------------------------------------------------------------
+.. ARTICLE CONTENT
+.. ---------------------------------------------------------------
+
+================
+h1 Article Title
+================
+
+.. introduction::
+
+   Capture the reader’s attention. An interesting fact or data point,
+   empathy, engaging.
+   
+   Offer the reason for the post’s existence. What’s the purpose of the
+   post?  What problem is the post going to address?
+
+   Explain how this content will address the problem 
+
+   Include target keyword in the first 100 words of content piece for SEO
+
+.. prerequisites::
+
+   H2 Prerequisites
+   ----------------
+
+   If your content has prerequisites, specify them in this section.
+   Indicating what type of content the content is can let us do more on
+   the front end with clever rendering bits.
+
+.. content::
+
+   H2 This is an H2 Header
+   -----------------------
+
+   Content under the first H2
+
+   h3 This is an H3 header
+   ~~~~~~~~~~~~~~~~~~~~~~~
+
+   .. youtube:: H3P0lW94L2Q
+
+   another h3
+   ~~~~~~~~~~
+
+   .. twitch:: <some sort of identifier>
+
+   Second H2
+   ---------
+
+   Content for second h2.
+
+   .. code-block:: javascript
+
+      // this is where you would put some lovely code!
+
+   h3 Step 1: Do stuff
+   ~~~~~~~~~~~~~~~~~~~
+
+   Talk about how to do that stuff.
+
+   h3 Step 2: Do other stuff
+   ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   Talk about why you're doing the other stuff
+
+   h4 Maybe We Need An h4
+   ``````````````````````
+
+   With content
+
+   h4 Another h4
+   `````````````
+
+   Second H4's content
+
+.. summary::
+
+   Conclude or summarize your article.


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-8727)]
- Move event parser classes into new file (`eventparser.py`)
  - Add new `PAGE_EXIT_EVENT`
- Add new `DevhubPostprocessor` class, to be used when `default_domain = "devhub"` in snooty.toml
- In `DevhubPostprocessor`, expose specified directives via a new field in the `Page` class: `query_fields`
  - `query_fields` is a top-level field on each page document and contains a nested document
- Fields exposed (listed as `field: data type`):
  - `author`: string
  - `tags`: list of strings
  - `languages`: list of strings
  - `products`: list of strings
- Will be queryable via Stitch

### Failing tests
- `test_legacy_guides.py`
- Usual flakiness in `test_postprocess:test_expand_includes()`