### PR TITLE
DOCSP-8731: Support page groups

### DIFF
--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict
+from typing import cast, Any, Dict, List
 from .types import BuildIdentifierSet, FileId, SerializableType
 from .parser import Project
 from .test_project import Backend
@@ -25,3 +25,9 @@ def test_queryable_fields(backend: Backend) -> None:
     assert query_fields["tags"] == ["foo", "bar", "baz"]
     assert query_fields["languages"] == ["nodejs", "java"]
     assert query_fields["products"] == ["Realm", "MongoDB"]
+
+
+def test_page_groups(backend: Backend) -> None:
+    """Test that page groups are correctly filtered and cleaned."""
+    page_groups: Dict[str, List[str]] = cast(Any, backend.metadata["pageGroups"])
+    assert page_groups == {"Group 1": ["index", "index"]}

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -393,6 +393,7 @@ class ProjectConfig:
     # substitution_nodes contains a parsed representation of the substitutions member, and is populated on Project initialization.
     substitution_nodes: Dict[str, SerializableType] = field(default_factory=dict)
     toc_landing_pages: List[str] = field(default_factory=list)
+    page_groups: Dict[str, List[str]] = field(default_factory=dict)
 
     @property
     def source_path(self) -> Path:

--- a/test_data/test_devhub/snooty.toml
+++ b/test_data/test_devhub/snooty.toml
@@ -1,2 +1,5 @@
 name = "devhub-project"
 default_domain = "devhub"
+
+[page_groups]
+"Group 1" = ["/index", "index", "foo"]


### PR DESCRIPTION
This adds an optional `pageGroups` field to the build metadata containing cleaned and validated page group slugs.

Example `snooty.toml` syntax:
```toml
[page_groups]
"Group 1" = ["index", "foo", "/page4"]
```

Example output field in the metadata document:
```json
	"pageGroups" : {
		"A Test Group" : [
			"index",
			"platforms",
			"tutorial/getting-started-with-hadoop"
		]
	}
```

The careful reader will note that issues are logged rather than sent to the normal diagnostic mechanism: this is because our diagnostic mechanism doesn't currently handle snooty.toml issues properly (currently the vscode extension crashes), and I didn't want to make that problem any worse.