### PR TITLE
DOCSP-8848: Add new devhub directives

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -457,7 +457,7 @@ class DevhubPostprocessor(Postprocessor):
 
     # TODO: Identify directives that should be exposed in the rstspec.toml to avoid hardcoding
     # These directives are represented as list nodes; they will return a list of strings
-    LIST_FIELDS = {"devhub:products", "devhub:tags", ":languages"}
+    LIST_FIELDS = {"devhub:products", "devhub:tags", "devhub:related", ":languages"}
     # These directives have their content represented as children; they will return a list of nodes
     BLOCK_FIELDS = {"devhub:meta-description"}
     # These directives have their content represented as an argument; they will return a string

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -459,7 +459,16 @@ class DevhubPostprocessor(Postprocessor):
     # These directives are represented as list nodes; they will return a list of strings
     LIST_FIELDS = {"devhub:products", "devhub:tags", ":languages"}
     # These directives have their content represented as children; they will return a list of nodes
-    BLOCK_FIELDS = {"devhub:introduction"}
+    BLOCK_FIELDS = {"devhub:meta-description"}
+    # These directives have their content represented as an argument; they will return a string
+    ARG_FIELDS = {
+        "pubdate",
+        "updated-date",
+        "devhub:level",
+        "devhub:type",
+        "devhub:atf-image",
+        "devhub:series",
+    }
 
     def run(
         self, pages: Dict[FileId, Page]
@@ -568,6 +577,9 @@ class DevhubPostprocessor(Postprocessor):
         if key == "devhub:author":
             options = cast(Dict[str, str], obj["options"])
             self.query_fields["author"] = options["name"]
+        elif key in self.ARG_FIELDS:
+            argument = cast(Any, obj["argument"])
+            self.query_fields[name] = argument[0]["value"]
         elif key in self.BLOCK_FIELDS:
             self.query_fields[name] = obj["children"]
         elif key in self.LIST_FIELDS:

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -430,6 +430,10 @@ example = """.. product::
 inherit = "_devhub-block"
 content_type = "list"
 
+[directive."devhub:callout"]
+help = "Call out a specific University course, blog post, event, etc."
+inherit = "_devhub-block"
+
 [directive."devhub:introduction"]
 help = "Capture the reader's attention, offer the reason for the article's existence, and explain how the content will address the problem. Use the target keyword in the first 100 words."
 inherit = "_devhub-block"
@@ -455,7 +459,10 @@ content_type = "list"
 [directive.pubdate]
 help = "Date the article was published"
 argument_type = "string"
-content_type = "block"
+
+[directive.updated-date]
+help = "Date the post was most recently updated"
+argument_type = "string"
 
 [directive.twitter]
 help = """Options


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOCSP-8848)] New directives:
- `devhub:updated-date`
- `devhub:callout`

Also exposes a few more fields from the AST based on conversations with Gregg.