### PR TITLE
Bugfix: correctly target directives outside devhub domain

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -462,8 +462,8 @@ class DevhubPostprocessor(Postprocessor):
     BLOCK_FIELDS = {"devhub:meta-description"}
     # These directives have their content represented as an argument; they will return a string
     ARG_FIELDS = {
-        "pubdate",
-        "updated-date",
+        ":pubdate",
+        ":updated-date",
         "devhub:level",
         "devhub:type",
         "devhub:atf-image",

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -457,7 +457,7 @@ class DevhubPostprocessor(Postprocessor):
 
     # TODO: Identify directives that should be exposed in the rstspec.toml to avoid hardcoding
     # These directives are represented as list nodes; they will return a list of strings
-    LIST_FIELDS = {"devhub:products", "devhub:tags", "devhub:related", ":languages"}
+    LIST_FIELDS = {"devhub:products", "devhub:tags", ":languages"}
     # These directives have their content represented as children; they will return a list of nodes
     BLOCK_FIELDS = {"devhub:meta-description"}
     # These directives have their content represented as an argument; they will return a string
@@ -577,6 +577,15 @@ class DevhubPostprocessor(Postprocessor):
         if key == "devhub:author":
             options = cast(Dict[str, str], obj["options"])
             self.query_fields["author"] = options["name"]
+        elif key == "devhub:related":
+            # Save list of nodes (likely :doc: roles)
+            self.query_fields[name] = []
+            children = cast(Any, obj["children"])
+            list_items = children[0]["children"]
+            assert isinstance(list_items, List)
+            for item in list_items:
+                paragraph = item["children"][0]
+                self.query_fields[name].append(paragraph["children"][0])
         elif key in self.ARG_FIELDS:
             argument = cast(Any, obj["argument"])
             self.query_fields[name] = argument[0]["value"]

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -3,6 +3,7 @@ from typing import cast, Any, Dict, List
 from .types import BuildIdentifierSet, FileId, SerializableType
 from .parser import Project
 from .test_project import Backend
+from .util_test import check_ast_testing_string
 import pytest
 
 
@@ -25,6 +26,29 @@ def test_queryable_fields(backend: Backend) -> None:
     assert query_fields["tags"] == ["foo", "bar", "baz"]
     assert query_fields["languages"] == ["nodejs", "java"]
     assert query_fields["products"] == ["Realm", "MongoDB"]
+    assert query_fields["pubdate"] == "January 31, 2019"
+    assert query_fields["updated-date"] == "February 2, 2019"
+    assert query_fields["atf-image"] == "/img/heros/how-to-write-an-article.png"
+    assert query_fields["type"] == "article, quickstart, how-to, video, live"
+    assert query_fields["level"] == "beginner, intermediate, advanced"
+    assert query_fields["series"] == "seriesName"
+
+    related = cast(Any, query_fields["related"])
+    check_ast_testing_string(
+        related[0], "<literal><text>list of related articles</text></literal>"
+    )
+    check_ast_testing_string(
+        related[1], """<role name="doc" target="/path/to/article"></role>"""
+    )
+    check_ast_testing_string(
+        related[2], """<literal><text>:doc:`/path/to/other/article`</text></literal>"""
+    )
+
+    meta_description = cast(Any, query_fields["meta-description"])
+    check_ast_testing_string(
+        meta_description[0],
+        "<paragraph><text>meta description (160 characters or fewer)</text></paragraph>",
+    )
 
 
 def test_page_groups(backend: Backend) -> None:

--- a/test_data/test_devhub/source/index.txt
+++ b/test_data/test_devhub/source/index.txt
@@ -24,6 +24,8 @@
 
 .. pubdate:: January 31, 2019
 
+.. updated-date:: February 2, 2019
+
 .. type:: article, quickstart, how-to, video, live
 
 .. level:: beginner, intermediate, advanced
@@ -51,7 +53,7 @@
 .. related::
 
    * ``list of related articles``
-   * ``:doc:`/path/to/article```
+   * :doc:`/path/to/article`
    * ``:doc:`/path/to/other/article```
 
 .. ---------------------------------------------------------------


### PR DESCRIPTION
Add preceding colon to directives outside the devhub domain so that they will be properly identified by the postprocess layer.