### PR TITLE
Expose devhub author images

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -556,6 +556,7 @@ class DevhubPostprocessor(Postprocessor):
 
         # Save page title to query_fields, if it exists
         slug = clean_slug(filename.as_posix())
+        self.query_fields["slug"] = f"/{slug}" if slug != "index" else "/"
         title = self.slug_title_mapping.get(slug)
         if title is not None:
             self.query_fields["title"] = title

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -583,7 +583,7 @@ class DevhubPostprocessor(Postprocessor):
 
         if key == "devhub:author":
             options = cast(Dict[str, str], obj["options"])
-            self.query_fields["author"] = options["name"]
+            self.query_fields["author"] = options
         elif key == "devhub:related":
             # Save list of nodes (likely :doc: roles)
             self.query_fields[name] = []

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -35,6 +35,7 @@ def test_queryable_fields(backend: Backend) -> None:
     assert query_fields["type"] == "article, quickstart, how-to, video, live"
     assert query_fields["level"] == "beginner, intermediate, advanced"
     assert query_fields["series"] == "seriesName"
+    assert query_fields["slug"] == "/"
 
     related = cast(Any, query_fields["related"])
     check_ast_testing_string(

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -22,7 +22,10 @@ def test_queryable_fields(backend: Backend) -> None:
     page = backend.pages[page_id]
     query_fields: Dict[str, SerializableType] = page.query_fields
     assert query_fields is not None
-    assert query_fields["author"] == "Eliot Horowitz"
+    assert query_fields["author"] == {
+        "name": "Eliot Horowitz",
+        "image": "/path/to/eliots/bio/photo.jpg",
+    }
     assert query_fields["tags"] == ["foo", "bar", "baz"]
     assert query_fields["languages"] == ["nodejs", "java"]
     assert query_fields["products"] == ["Realm", "MongoDB"]


### PR DESCRIPTION
The devhub front-end should have easy access to author names and images, not just names.
- Save `author` as an object with `name` and `image` fields for easy access to both.
- Save page slug in query_fields object