### PR TITLE
Bugfix: Use substitution more than once on a page

### DIFF
--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -280,6 +280,14 @@ def test_substitutions(backend: Backend) -> None:
         """<substitution_reference name="global-write-clusters"><text>Global </text><emphasis><text>Clusters</text></emphasis></substitution_reference>""",
     )
 
+    # Verify that same substitution can be used multiple times on the same page
+    paragraph = cast(Dict[str, Any], ast["children"][4])
+    substitution_reference = paragraph["children"][0]
+    check_ast_testing_string(
+        substitution_reference,
+        """<substitution_reference name="service"><text>Atlas</text></substitution_reference>""",
+    )
+
     # Test substitution of empty string
     paragraph = cast(Dict[str, Any], ast["children"][3])
     substitution_reference = paragraph["children"][1]


### PR DESCRIPTION
Fixes a bug introduced by #108. To check for circular substitutions, a set was created to identify substitution reference nodes that had already been encountered. However, the check for duplicates was performed _every time_ a `substitution_replacement` node was encountered. Therefore, when a substitution was used more than once on a page, it was mistakenly identified as a circular substitution.

Now, only perform this check when looking at children of a `substitution_definition` node. Adds test to verify this behavior works (test currently fails on `master` branch).