### PR TITLE
DOP-938: Add image-alt to twitter directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -506,6 +506,7 @@ example = """.. twitter::
    :creator: @Lauren_Schaefer
    :title: Wordswordswords
    :image: </path/to/image>
+   :image-alt: Image description
 
    This is the description of the tweet in up to 200 characters.
 """
@@ -514,6 +515,7 @@ options.site = "string"
 options.creator = "string"
 options.title = "string"
 options.image = ["path", "uri"]
+options.image-alt = "string"
 
 [directive.og]
 help="""Options

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -100,6 +100,7 @@ def test_queryable_fields(backend: Backend) -> None:
         "creator": "@Lauren_Schaefer",
         "title": "Wordswordswords",
         "image": "/images/atf-images/generic/pink.png",
+        "image-alt": "Description of the image",
         "checksum": "71bf03ab0c5b8d46f0c03b77db6bd18a77d984d216c62c3519dfb45c162cd86b",
         "children": [
             "<paragraph><text>Description of max 200 characters</text></paragraph>"

--- a/test_data/test_devhub/source/index.txt
+++ b/test_data/test_devhub/source/index.txt
@@ -13,6 +13,7 @@
    :creator: @Lauren_Schaefer
    :title: Wordswordswords
    :image: /images/atf-images/generic/pink.png
+   :image-alt: Description of the image
 
    Description of max 200 characters
 


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-938)] Support for `image-alt` option.