### PR TITLE
Add spec extlink for ecosystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `spec` role.
+
 ## [v0.4.2] - 2020-04-03
 
 ### Added

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -898,6 +898,9 @@ type = {link = "http://www.mongodb.com/download-center/%s?jmp=docs"}
 [role.wtdocs]
 type = {link = "http://source.wiredtiger.com/mongodb-3.4%s"}
 
+[role.spec]
+type = {link = "https://github.com/mongodb/specifications/blob/master/source%s"}
+
 [role."js-sdk"]
 type = {link = "https://docs.mongodb.com/stitch-sdks/js/4/%s"}
 


### PR DESCRIPTION
This adds the `spec` substitution from ecosystem extlinks.