### PR TITLE
DOP-954: Attach :doc: titles in postprocessor

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -278,7 +278,9 @@ class JSONVisitor:
 
             if role_name == "doc":
                 self.validate_doc_role(node)
-                role = n.RefRole((line,), [], node["domain"], role_name, target, flag, target, None)
+                role = n.RefRole(
+                    (line,), [], node["domain"], role_name, "", flag, target, None
+                )
                 self.state.append(role)
                 return
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -275,11 +275,15 @@ class JSONVisitor:
             role_name = node["name"]
             target = node["target"] if "target" in node else ""
             flag = node["flag"] if "flag" in node else ""
-            role = n.Role((line,), [], node["domain"], role_name, target, flag)
-            self.state.append(role)
 
             if role_name == "doc":
                 self.validate_doc_role(node)
+                role = n.RefRole((line,), [], node["domain"], role_name, target, flag, target, None)
+                self.state.append(role)
+                return
+
+            role = n.Role((line,), [], node["domain"], role_name, target, flag)
+            self.state.append(role)
             return
         elif isinstance(node, docutils.nodes.target):
             assert (

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -219,14 +219,16 @@ class Postprocessor:
         new_suffix = target_path.suffix + ".txt"
         target_path = target_path.with_suffix(new_suffix)
 
-        relative, _ = util.reroot_path(target_path, filename, self.project_config.source_path)
+        relative, _ = util.reroot_path(
+            target_path, filename, self.project_config.source_path
+        )
         slug = clean_slug(relative.as_posix())
         title = self.slug_title_mapping.get(slug)
 
         if not title:
             line = node.span[0]
             self.diagnostics[filename].append(
-                Diagnostic.error(f'Page title not found: {target_path}', line)
+                Diagnostic.error(f"Page title not found: {target_path}", line)
             )
             return
 
@@ -236,7 +238,6 @@ class Postprocessor:
         for text_node in page_title_nodes:
             deep_copy_position(node, text_node)
         node.children = page_title_nodes
-
 
     def handle_refs(self, filename: FileId, node: n.Node) -> None:
         """When a node of type ref_role is encountered, ensure that it references a valid target.

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -79,7 +79,7 @@ def test_queryable_fields(backend: Backend) -> None:
         related[0], "<literal><text>list of related articles</text></literal>"
     )
     check_ast_testing_string(
-        related[1], """<role name="doc" target="/path/to/article"></role>"""
+        related[1], """<ref_role name="doc" fileid="/path/to/article"></ref_role>"""
     )
     check_ast_testing_string(
         related[2], """<literal><text>:doc:`/path/to/other/article`</text></literal>"""

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -149,7 +149,7 @@ def test_text_doc_get_page_ast() -> None:
             <directive name="include"><text>/includes/steps/migrate-compose-pr.rst</text>
             <directive name="step"><section><heading id="mongodb-atlas-account"><text>MongoDB Atlas account</text>
             </heading><paragraph><text>If you don't have an Atlas account, </text>
-            <role name="doc" target="/cloud/atlas"><text>create one</text></role>
+            <ref_role name="doc" fileid="/cloud/atlas"><text>create one</text></ref_role>
             <text> now.</text></paragraph></section></directive>
             <directive name="step"><section><heading id="compose-mongodb-deployment">
             <text>Compose MongoDB deployment</text></heading>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -463,36 +463,36 @@ def test_doc_role() -> None:
         <list>
         <listItem>
         <paragraph>
-        <role name="doc" target="/index">
+        <ref_role name="doc" fileid="/index">
         <text>Testing this</text>
-        </role>
+        </ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <role name="doc" target="./../source/index">
+        <ref_role name="doc" fileid="./../source/index">
         <text>Testing that</text>
-        </role>
+        </ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <role name="doc" target="index"></role>
+        <ref_role name="doc" fileid="index"></ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <role name="doc" target="/index"></role>
+        <ref_role name="doc" fileid="/index"></ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <role name="doc" target="./../source/index"></role>
+        <ref_role name="doc" fileid="./../source/index"></ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <role name="doc" target="/index/"></role>
+        <ref_role name="doc" fileid="/index/"></ref_role>
         </paragraph>
         </listItem>
         </list>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -411,6 +411,35 @@ def test_program_option(backend: Backend) -> None:
     )
 
 
+def test_doc_titles(backend: Backend) -> None:
+    doc_id = FileId("folder/doc.txt")
+    ast = backend.pages[doc_id].ast
+
+    # Test relative path
+    paragraph = ast.children[0]
+    assert isinstance(paragraph, n.Paragraph)
+    check_ast_testing_string(
+        paragraph,
+        """<paragraph><text>This doc role (</text><ref_role name="doc" target="../page1" fileid="../page1"><text>Print this heading</text></ref_role><text>) should read "Print this heading".</text></paragraph>""",
+    )
+
+    # Test no heading in page
+    paragraph = ast.children[1]
+    assert isinstance(paragraph, n.Paragraph)
+    check_ast_testing_string(
+        paragraph,
+        """<paragraph><text>This doc role (</text><ref_role name="doc" target="/page3" fileid="/page3"></ref_role><text>) has no heading.</text></paragraph>""",
+    )
+
+    # Test doc with title specified inline
+    paragraph = ast.children[2]
+    assert isinstance(paragraph, n.Paragraph)
+    check_ast_testing_string(
+        paragraph,
+        """<paragraph><text>This doc role (</text><ref_role name="doc" target="/page2" fileid="/page2"><text>A Title</text></ref_role><text>) says "A Title" inline.</text></paragraph>""",
+    )
+
+
 def test_substitutions(backend: Backend) -> None:
     # Test substitutions as defined in snooty.toml
     page_id = FileId("page3.txt")

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -420,7 +420,7 @@ def test_doc_titles(backend: Backend) -> None:
     assert isinstance(paragraph, n.Paragraph)
     check_ast_testing_string(
         paragraph,
-        """<paragraph><text>This doc role (</text><ref_role name="doc" target="../page1" fileid="../page1"><text>Print this heading</text></ref_role><text>) should read "Print this heading".</text></paragraph>""",
+        """<paragraph><text>This doc role (</text><ref_role name="doc" fileid="../page1"><text>Print this heading</text></ref_role><text>) should read "Print this heading".</text></paragraph>""",
     )
 
     # Test no heading in page
@@ -428,7 +428,7 @@ def test_doc_titles(backend: Backend) -> None:
     assert isinstance(paragraph, n.Paragraph)
     check_ast_testing_string(
         paragraph,
-        """<paragraph><text>This doc role (</text><ref_role name="doc" target="/page3" fileid="/page3"></ref_role><text>) has no heading.</text></paragraph>""",
+        """<paragraph><text>This doc role (</text><ref_role name="doc" fileid="/page3"></ref_role><text>) has no heading.</text></paragraph>""",
     )
 
     # Test doc with title specified inline
@@ -436,7 +436,7 @@ def test_doc_titles(backend: Backend) -> None:
     assert isinstance(paragraph, n.Paragraph)
     check_ast_testing_string(
         paragraph,
-        """<paragraph><text>This doc role (</text><ref_role name="doc" target="/page2" fileid="/page2"><text>A Title</text></ref_role><text>) says "A Title" inline.</text></paragraph>""",
+        """<paragraph><text>This doc role (</text><ref_role name="doc" fileid="/page2"><text>A Title</text></ref_role><text>) says "A Title" inline.</text></paragraph>""",
     )
 
 

--- a/test_data/test_postprocessor/source/folder/doc.txt
+++ b/test_data/test_postprocessor/source/folder/doc.txt
@@ -1,0 +1,5 @@
+This doc role (:doc:`../page1`) should read "Print this heading".
+
+This doc role (:doc:`/page3`) has no heading.
+
+This doc role (:doc:`A Title </page2>`) says "A Title" inline.


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-954)]
- Convert `:doc:` to `ref_role` in `JSONVisitor` class
  - RefRoles with `name=doc` do not contain targets. We use targets on the front-end to navigate to a particular id (e.g. `/fileid#target`), so omitting this navigates to the root doc, as is expected behavior with `:doc:` roles. Let me know if this doesn't make sense!
  - Doc refroles contain `fileid` properties to navigate to the correct page
