### PR TITLE
DOP-948 update: Don't write patch_id to DB

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -232,7 +232,6 @@ def _generate_build_identifiers(args: Dict[str, Optional[str]]) -> BuildIdentifi
     identifiers = {}
 
     identifiers["commit_hash"] = args["--commit"]
-    identifiers["patch_id"] = args["--patch"]
 
     return identifiers
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -14,7 +14,7 @@ ROOT_PATH = Path("test_data")
 @pytest.fixture(scope="module")
 def backend() -> Backend:
     backend = Backend()
-    build_identifiers: BuildIdentifierSet = {"commit_hash": "123456", "patch_id": None}
+    build_identifiers: BuildIdentifierSet = {"commit_hash": "123456"}
     with Project(
         Path("test_data/test_postprocessor"), backend, build_identifiers
     ) as project:

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -18,7 +18,7 @@ from .util import ast_dive
 from .util_test import check_ast_testing_string
 from . import n
 
-build_identifiers: BuildIdentifierSet = {"commit_hash": "123456", "patch_id": None}
+build_identifiers: BuildIdentifierSet = {"commit_hash": "123456"}
 
 
 @dataclass


### PR DESCRIPTION
In order to have a successful rollout of patch-based builds, we'd like to have a period where the parser accepts the `--patch` flag, but does not actually write the `patch_id` field to the database. This PR accomplishes that and undoes some of the work of #138. Once the autobuilder Makefiles are properly implemented, we will attach `patch_id` to builds again.