### PR TITLE
Add support for align & width option to list-table directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -40,6 +40,8 @@ example = """.. list-table::
 """
 content_type = "list_table"
 argument_type = "string"
+options.align = "alignment"
+options.width = "string"
 options.widths = "string"
 options.class = "string"
 options.header-rows = "nonnegative_integer"


### PR DESCRIPTION
Add support for two options to `list-table` directive:
- `align`
- `width`

Support is defined in the [documentation](https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table).