### PR TITLE
Tweak :doc: role

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -232,7 +232,7 @@ class Postprocessor:
             return
         key = f"{node.domain}:{node.name}"
 
-        if key == ":doc":
+        if key == "std:doc":
             if not node.children:
                 # If title is not explicitly given, search slug-title mapping for the page's title
                 self._attach_doc_title(filename, node)
@@ -417,6 +417,9 @@ class Postprocessor:
 
         # Save the first heading we encounter to the slug title mapping
         if slug not in self.slug_title_mapping and isinstance(node, n.Heading):
+            self.targets.define_local_target(
+                "std", "doc", (slug,), filename, node.children
+            )
             self.slug_title_mapping[slug] = node.children
 
     def build_slug_fileid_mapping(self) -> None:

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -674,7 +674,7 @@ type = {link = "https://en.wikipedia.org/wiki/%s"}
 help = """Link to a URL in the current project."""
 type = "explicit_title"
 
-[role.doc]
+[role."std:doc"]
 help = """Link to a page in the current project."""
 type = "explicit_title"
 

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -79,7 +79,8 @@ def test_queryable_fields(backend: Backend) -> None:
         related[0], "<literal><text>list of related articles</text></literal>"
     )
     check_ast_testing_string(
-        related[1], """<ref_role name="doc" fileid="/path/to/article"></ref_role>"""
+        related[1],
+        """<ref_role domain="std" name="doc" fileid="/path/to/article"></ref_role>""",
     )
     check_ast_testing_string(
         related[2], """<literal><text>:doc:`/path/to/other/article`</text></literal>"""

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -161,7 +161,7 @@ def test_text_doc_get_page_ast() -> None:
             <directive name="include"><text>/includes/steps/migrate-compose-pr.rst</text>
             <directive name="step"><section><heading id="mongodb-atlas-account"><text>MongoDB Atlas account</text>
             </heading><paragraph><text>If you don't have an Atlas account, </text>
-            <ref_role name="doc" fileid="/cloud/atlas"><text>create one</text></ref_role>
+            <ref_role domain="std" name="doc" fileid="/cloud/atlas"><text>create one</text></ref_role>
             <text> now.</text></paragraph></section></directive>
             <directive name="step"><section><heading id="compose-mongodb-deployment">
             <text>Compose MongoDB deployment</text></heading>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -466,36 +466,36 @@ def test_doc_role() -> None:
         <list>
         <listItem>
         <paragraph>
-        <ref_role name="doc" fileid="/index">
+        <ref_role domain="std" name="doc" fileid="/index">
         <text>Testing this</text>
         </ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <ref_role name="doc" fileid="./../source/index">
+        <ref_role domain="std" name="doc" fileid="./../source/index">
         <text>Testing that</text>
         </ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <ref_role name="doc" fileid="index"></ref_role>
+        <ref_role domain="std" name="doc" fileid="index"></ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <ref_role name="doc" fileid="/index"></ref_role>
+        <ref_role domain="std" name="doc" fileid="/index"></ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <ref_role name="doc" fileid="./../source/index"></ref_role>
+        <ref_role domain="std" name="doc" fileid="./../source/index"></ref_role>
         </paragraph>
         </listItem>
         <listItem>
         <paragraph>
-        <ref_role name="doc" fileid="/index/"></ref_role>
+        <ref_role domain="std" name="doc" fileid="/index/"></ref_role>
         </paragraph>
         </listItem>
         </list>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -418,7 +418,7 @@ def test_doc_titles(backend: Backend) -> None:
     assert isinstance(paragraph, n.Paragraph)
     check_ast_testing_string(
         paragraph,
-        """<paragraph><text>This doc role (</text><ref_role name="doc" fileid="../page1"><text>Print this heading</text></ref_role><text>) should read "Print this heading".</text></paragraph>""",
+        """<paragraph><text>This doc role (</text><ref_role domain="std" name="doc" fileid="../page1"><text>Print this heading</text></ref_role><text>) should read "Print this heading".</text></paragraph>""",
     )
 
     # Test no heading in page
@@ -426,7 +426,7 @@ def test_doc_titles(backend: Backend) -> None:
     assert isinstance(paragraph, n.Paragraph)
     check_ast_testing_string(
         paragraph,
-        """<paragraph><text>This doc role (</text><ref_role name="doc" fileid="/page3"></ref_role><text>) has no heading.</text></paragraph>""",
+        """<paragraph><text>This doc role (</text><ref_role domain="std" name="doc" fileid="/page3"></ref_role><text>) has no heading.</text></paragraph>""",
     )
 
     # Test doc with title specified inline
@@ -434,7 +434,7 @@ def test_doc_titles(backend: Backend) -> None:
     assert isinstance(paragraph, n.Paragraph)
     check_ast_testing_string(
         paragraph,
-        """<paragraph><text>This doc role (</text><ref_role name="doc" fileid="/page2"><text>A Title</text></ref_role><text>) says "A Title" inline.</text></paragraph>""",
+        """<paragraph><text>This doc role (</text><ref_role domain="std" name="doc" fileid="/page2"><text>A Title</text></ref_role><text>) says "A Title" inline.</text></paragraph>""",
     )
 
 


### PR DESCRIPTION
* Place `doc` in the `std` domain
* For each page top-level heading, create a target