### PR TITLE
Fix project title tests

### DIFF
--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -246,7 +246,7 @@ def test_toctree(backend: Backend) -> None:
                 ],
             },
         ],
-        "title": "untitled",
+        "title": "MongoDB title",
         "slug": "/",
     }
 

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -134,6 +134,7 @@ def test() -> None:
             project._project.get_parsed_branches()
         )
         assert len(published_branch_diagnostics) == 0
+        assert project.config.title == "MongoDB title"
         assert published_branches and published_branches.serialize() == {
             "git": {"branches": {"manual": "master", "published": ["master", "v1.0"]}},
             "version": {

--- a/test_data/test_postprocessor/snooty.toml
+++ b/test_data/test_postprocessor/snooty.toml
@@ -1,9 +1,6 @@
 name = "test_name"
 toc_landing_pages = ["/page2", "page3"]
 intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
-
-[constants]
-name = "MongoDB name"
 title = "MongoDB title"
 
 [substitutions]

--- a/test_data/test_project/snooty.toml
+++ b/test_data/test_project/snooty.toml
@@ -1,7 +1,4 @@
 name = "test_data"
-
-[constants]
-name = "MongoDB name"
 title = "MongoDB title"
 
 [substitutions]


### PR DESCRIPTION
Update tests from https://github.com/mongodb/snooty-parser/pull/90. A project's `title` field as defined in `snooty.toml` does not belong in the `constants` table, so ensure we are properly testing it outside of this table.