### PR TITLE
Bugfix: Fix linenos flag

### DIFF
--- a/snooty/gizaparser/release.py
+++ b/snooty/gizaparser/release.py
@@ -31,6 +31,7 @@ class ReleaseSpecification(Inheritable):
                     True if self.copyable is None else self.copyable,
                     None,
                     self.code,
+                    False,
                 )
             )
         return children

--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -47,6 +47,7 @@ class Action(HeadingMixin):
                     True if self.copyable is None else self.copyable,
                     None,
                     self.code,
+                    False,
                 )
             )
 

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -104,12 +104,13 @@ class InlineNode(Node):
 
 @dataclass
 class Code(Node):
-    __slots__ = ("lang", "copyable", "emphasize_lines", "value")
+    __slots__ = ("lang", "copyable", "emphasize_lines", "value", "linenos")
     type = "code"
     lang: Optional[str]
     copyable: bool
     emphasize_lines: Optional[Sequence[Tuple[int, int]]]
     value: str
+    linenos: bool
 
 
 @dataclass

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -248,6 +248,7 @@ class JSONVisitor:
                 node["copyable"],
                 node["emphasize_lines"] if "emphasize_lines" in node else None,
                 node.astext(),
+                node["linenos"],
             )
             top_of_state = self.state[-1]
             assert isinstance(top_of_state, n.Parent)
@@ -491,7 +492,14 @@ class JSONVisitor:
                 if "language" in options
                 else asset_path.suffix.lstrip(".")
             )
-            code = n.Code((line,), lang, "copyable" in options, [], "")
+            code = n.Code(
+                (line,),
+                lang,
+                "copyable" not in options or options["copyable"] == "true",
+                [],
+                "",
+                "linenos" in options,
+            )
 
             try:
                 static_asset = self.add_static_asset(asset_path, False)

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -666,6 +666,7 @@ class BaseCodeDirective(docutils.parsers.rst.Directive):
     def run(self) -> List[docutils.nodes.Node]:
         source, line = self.state_machine.get_source_and_line(self.lineno)
         copyable = "copyable" not in self.options or self.options["copyable"] == "true"
+        linenos = "linenos" in self.options
 
         try:
             n_lines = len(self.content)
@@ -683,6 +684,7 @@ class BaseCodeDirective(docutils.parsers.rst.Directive):
             node["lang"] = self.arguments[0]
         node["copyable"] = copyable
         node["emphasize_lines"] = emphasize_lines
+        node["linenos"] = linenos
         node.document = self.state.document
         node.source, node.line = source, line
         return [node]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -87,6 +87,7 @@ def test_codeblock() -> None:
 .. code-block:: sh
    :copyable: false
    :emphasize-lines: 1, 2-3
+   :linenos:
 
    foo
    bar
@@ -97,7 +98,7 @@ def test_codeblock() -> None:
     check_ast_testing_string(
         page.ast,
         """<root>
-        <code lang="sh" emphasize_lines="[(1, 1), (2, 3)]">foo\nbar\nbaz</code>
+        <code lang="sh" emphasize_lines="[(1, 1), (2, 3)]" linenos="True">foo\nbar\nbaz</code>
         </root>""",
     )
 
@@ -147,6 +148,7 @@ def test_literalinclude() -> None:
    :dedent:
    :start-after: Start Example 3
    :end-before: End Example 3
+   :linenos:
 """,
     )
     page.finish(diagnostics)
@@ -154,7 +156,7 @@ def test_literalinclude() -> None:
     check_ast_testing_string(
         page.ast,
         """<root>
-<code lang="py">db.inventory.insert_many([
+<code lang="py" copyable="True" linenos="True">db.inventory.insert_many([
     {"item": "journal",
      "qty": 25,
      "tags": ["blank", "red"],


### PR DESCRIPTION
- Persist `:linenso:` flag
- Fix incorrect handling of `copyable` flag when used with `literalinclude` directives