### PR TITLE
Write patch ID to DB

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -233,6 +233,7 @@ def _generate_build_identifiers(args: Dict[str, Optional[str]]) -> BuildIdentifi
     identifiers = {}
 
     identifiers["commit_hash"] = args["--commit"]
+    identifiers["patch_id"] = args["--patch"]
 
     return identifiers
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -15,7 +15,7 @@ ROOT_PATH = Path("test_data")
 @pytest.fixture(scope="module")
 def backend() -> Backend:
     backend = Backend()
-    build_identifiers: BuildIdentifierSet = {"commit_hash": "123456"}
+    build_identifiers: BuildIdentifierSet = {"commit_hash": "123456", "patch_id": "678"}
     with Project(
         Path("test_data/test_postprocessor"), backend, build_identifiers
     ) as project:

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -12,7 +12,7 @@ from .util import ast_dive
 from .util_test import check_ast_testing_string
 from . import n
 
-build_identifiers: BuildIdentifierSet = {"commit_hash": "123456"}
+build_identifiers: BuildIdentifierSet = {"commit_hash": "123456", "patch_id": "789"}
 
 
 @dataclass


### PR DESCRIPTION
Implement what was undone in #145. Write patch ID (may be `None`) to the database.