### PR TITLE
DOP-1094: Add trailing newline to inventory to appease intermanual

### DIFF
--- a/snooty/intersphinx.py
+++ b/snooty/intersphinx.py
@@ -80,6 +80,9 @@ class Inventory:
                 )
             )
 
+        # giza/intermanual expects a terminating newline
+        lines.append("")
+
         buffer.append(zlib.compress(bytes("\n".join(lines), "utf-8"), 9))
 
         return b"".join(buffer)


### PR DESCRIPTION
Tested by feeding the inventory generated by ecosystem into cloud-docs, and confirming that it builds cleanly