### PR TITLE
DOP-876: Edit CHANGELOG.md for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- Support for literal includes (DOP-876).
+- Populate literal include nodes (DOP-876).
 
 ## [v0.4.8] - 2020-05-27
 


### PR DESCRIPTION
CHANGELOG.md change for [DOP-876](https://jira.mongodb.org/browse/DOP-876), [PR 157](https://github.com/mongodb/snooty-parser/pull/157), was misleading. This fixes that.