### PR TITLE
DOP-1073: no longer render RefRole prefix if no title is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Populate literal include nodes (DOP-876).
 
+### Fixed
+
+- RefRole nodes no longer render with the prefix if no title is found (DOP-1073).
+
 ## [v0.4.9] - 2020-06-05
 
 ### Added

--- a/snooty/cache.py
+++ b/snooty/cache.py
@@ -1,0 +1,42 @@
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Set, Tuple, Dict, DefaultDict, Optional, Iterator, TypeVar, Generic
+
+_T = TypeVar("_T")
+
+
+@dataclass
+class Cache(Generic[_T]):
+    """A versioned cache that associates a (_T, int) pair with an arbitrary object and
+       an integer version. Whenever the key is re-assigned, the version is incremented."""
+
+    _cache: Dict[Tuple[_T, int], object] = field(default_factory=dict)
+    _keys_of_each_fileid: DefaultDict[_T, Set[int]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+    _versions: DefaultDict[Tuple[_T, int], int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+
+    def __setitem__(self, key: Tuple[_T, int], value: object) -> None:
+        if key in self._cache:
+            self._cache[key] = value
+        else:
+            self._cache[key] = value
+
+        self._versions[key] += 1
+        self._keys_of_each_fileid[key[0]].add(key[1])
+
+    def __delitem__(self, fileid: _T) -> None:
+        keys = self._keys_of_each_fileid[fileid]
+        del self._keys_of_each_fileid[fileid]
+        for key in keys:
+            del self._cache[(fileid, key)]
+
+    def __getitem__(self, key: Tuple[_T, int]) -> Optional[object]:
+        return self._cache.get(key, None)
+
+    def get_versions(self, fileid: _T) -> Iterator[int]:
+        for key, version in self._versions.items():
+            if key[0] == fileid:
+                yield version

--- a/snooty/eventparser.py
+++ b/snooty/eventparser.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Dict, Set, Tuple, Iterable, Union
-from .types import FileId, Page
+from .types import FileId
+from .page import Page
 from . import n
 
 

--- a/snooty/gizaparser/extracts.py
+++ b/snooty/gizaparser/extracts.py
@@ -4,7 +4,8 @@ from typing import Callable, List, Tuple, Sequence, Optional
 from ..flutter import checked
 from .nodes import Inheritable, GizaCategory, HeadingMixin
 from .parse import parse
-from ..types import EmbeddedRstParser, Page
+from ..types import EmbeddedRstParser
+from ..page import Page
 from ..diagnostics import Diagnostic, MissingRef
 from .. import n
 

--- a/snooty/gizaparser/nodes.py
+++ b/snooty/gizaparser/nodes.py
@@ -24,7 +24,7 @@ from typing import (
     Set,
 )
 from ..flutter import checked
-from ..types import Page, EmbeddedRstParser, ProjectConfig
+from ..types import EmbeddedRstParser, ProjectConfig
 from ..diagnostics import (
     Diagnostic,
     UnknownSubstitution,
@@ -32,6 +32,7 @@ from ..diagnostics import (
     CannotOpenFile,
     RefAlreadyExists,
 )
+from ..page import Page
 from .. import n
 
 _T = TypeVar("_T", str, object)

--- a/snooty/gizaparser/release.py
+++ b/snooty/gizaparser/release.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, List, Tuple, Sequence
 from ..flutter import checked
-from ..types import EmbeddedRstParser, Page
+from ..types import EmbeddedRstParser
+from ..page import Page
 from ..diagnostics import Diagnostic, MissingRef
 from .. import n
 from .parse import parse

--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -5,7 +5,8 @@ from ..flutter import checked
 from .. import n
 from .parse import parse
 from .nodes import Inheritable, GizaCategory, HeadingMixin
-from ..types import EmbeddedRstParser, Page
+from ..types import EmbeddedRstParser
+from ..page import Page
 from ..diagnostics import Diagnostic
 
 

--- a/snooty/gizaparser/test_extracts.py
+++ b/snooty/gizaparser/test_extracts.py
@@ -1,7 +1,8 @@
 from pathlib import Path, PurePath
 from typing import Dict, Tuple, List, Optional
 from .extracts import GizaExtractsCategory
-from ..types import Page, ProjectConfig
+from ..types import ProjectConfig
+from ..page import Page
 from ..diagnostics import Diagnostic
 from ..parser import EmbeddedRstParser
 from ..util_test import ast_to_testing_string

--- a/snooty/gizaparser/test_release.py
+++ b/snooty/gizaparser/test_release.py
@@ -1,7 +1,8 @@
 from pathlib import Path, PurePath
 from typing import Dict, Tuple, List, Optional
 from .release import GizaReleaseSpecificationCategory
-from ..types import Page, ProjectConfig
+from ..types import ProjectConfig
+from ..page import Page
 from ..diagnostics import Diagnostic
 from ..parser import EmbeddedRstParser
 from ..util_test import check_ast_testing_string

--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -1,7 +1,8 @@
 from pathlib import Path, PurePath
 from typing import Dict, Tuple, List, Optional
 from .steps import GizaStepsCategory
-from ..types import Page, ProjectConfig
+from ..types import ProjectConfig
+from ..page import Page
 from ..diagnostics import Diagnostic
 from ..parser import EmbeddedRstParser
 from ..util_test import ast_to_testing_string, check_ast_testing_string

--- a/snooty/intersphinx.py
+++ b/snooty/intersphinx.py
@@ -29,7 +29,11 @@ class TargetDefinition(NamedTuple):
     priority: int
     uri_base: str
     uri: str
-    display_name: str
+    display_name: Optional[str]
+
+    @property
+    def domain_and_role(self) -> str:
+        return f"{self.role[0]}:{self.role[1]}"
 
 
 @dataclass
@@ -73,9 +77,7 @@ class Inventory:
                         ":".join(target.role),
                         str(target.priority),
                         target.uri_base,
-                        "-"
-                        if target.name == target.display_name
-                        else target.display_name,
+                        "-" if target.display_name is None else target.display_name,
                     )
                 )
             )
@@ -106,7 +108,7 @@ class Inventory:
                 logger.info(f"Invalid intersphinx line: {line}")
                 continue
 
-            name, domain_and_role, raw_priority, uri, dispname = match.groups()
+            name, domain_and_role, raw_priority, uri, raw_dispname = match.groups()
 
             # This is hard-coded in Sphinx as well. Support this name for compatibility.
             if domain_and_role == "std:cmdoption":
@@ -127,8 +129,7 @@ class Inventory:
             domain, role = domain_and_role.split(":", 1)
 
             # "If {dispname} is identical to {name}, it is stored as -"
-            if dispname == "-":
-                dispname = name
+            dispname = None if raw_dispname == "-" else raw_dispname
 
             target_definition = TargetDefinition(
                 name, (domain, role), priority, uri_base, uri, dispname

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -25,7 +25,8 @@ from typing import (
 )
 from .flutter import checked, check_type
 from .types import BuildIdentifierSet, FileId, SerializableType
-from . import types, util, n
+from . import util, n
+from .page import Page
 from .parser import Project
 from .diagnostics import Diagnostic
 
@@ -176,7 +177,7 @@ class Backend:
         prefix: List[str],
         build_identifiers: BuildIdentifierSet,
         page_id: FileId,
-        page: types.Page,
+        page: Page,
     ) -> None:
         pass
 

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -31,7 +31,8 @@ from docopt import docopt
 from . import language_server
 from .parser import Project
 from .util import SOURCE_FILE_EXTENSIONS
-from .types import Page, FileId, SerializableType, BuildIdentifierSet
+from .types import FileId, SerializableType, BuildIdentifierSet
+from .page import Page
 from .diagnostics import Diagnostic
 
 PARANOID_MODE = os.environ.get("SNOOTY_PARANOID", "0") == "1"

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+from pathlib import Path, PurePath
+from .diagnostics import Diagnostic
+from .types import StaticAsset
+from .target_database import ProjectInterface, EmptyProjectInterface
+from . import n
+
+
+class PendingTask:
+    """A thunk which will be executed in the main process after the full tree is
+       constructed. This should primarily be used to execute tasks which may need
+       to mutate state from the main process (e.g. caches or dependency graphs)."""
+
+    def __init__(self, node: n.Node) -> None:
+        self.node = node
+
+    def __call__(
+        self, diagnostics: List[Diagnostic], project: ProjectInterface
+    ) -> None:
+        """Perform an action in the main process once the tree has been built."""
+        pass
+
+
+@dataclass
+class Page:
+    source_path: Path
+    output_filename: str
+    source: str
+    ast: n.Parent[n.Node]
+    static_assets: Set[StaticAsset] = field(default_factory=set)
+    pending_tasks: List[PendingTask] = field(default_factory=list)
+    category: Optional[str] = None
+    query_fields: Dict[str, n.SerializableType] = field(default_factory=dict)
+
+    @classmethod
+    def create(
+        self,
+        source_path: Path,
+        output_filename: Optional[str],
+        source: str,
+        ast: Optional[n.Parent[n.Node]] = None,
+    ) -> "Page":
+        if output_filename is None:
+            output_filename = source_path.name
+
+        if ast is None:
+            ast = n.Root((0,), [], {})
+
+        return Page(source_path, output_filename, source, ast)
+
+    def fake_full_path(self) -> PurePath:
+        """Return a fictitious path (hopefully) uniquely identifying this output artifact."""
+        if self.category:
+            # Giza wrote out yaml file artifacts under a directory. e.g. steps-foo.yaml becomes
+            # steps/foo.rst
+            return self.source_path.parent.joinpath(
+                PurePath(self.category), self.output_filename
+            )
+        return self.source_path
+
+    def finish(
+        self, diagnostics: List[Diagnostic], project: Optional[ProjectInterface] = None
+    ) -> None:
+        """Finish all pending tasks for this page. This should be run in the main process."""
+        for task in self.pending_tasks:
+            task(
+                diagnostics, project if project is not None else EmptyProjectInterface()
+            )
+
+        self.pending_tasks.clear()

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -20,20 +20,18 @@ import watchdog.events
 import networkx
 
 from . import n, gizaparser, rstparser, util
+from .cache import Cache
 from .gizaparser.nodes import GizaCategory
 from .gizaparser.published_branches import PublishedBranches, parse_published_branches
 from .postprocess import DevhubPostprocessor, Postprocessor
 from .util import RST_EXTENSIONS
+from .page import Page, PendingTask
+from .target_database import ProjectInterface, TargetDatabase
 from .types import (
     SerializableType,
-    Page,
     StaticAsset,
     ProjectConfig,
-    PendingTask,
     FileId,
-    ProjectInterface,
-    Cache,
-    TargetDatabase,
     BuildIdentifierSet,
 )
 from .diagnostics import (
@@ -858,7 +856,7 @@ class _Project:
         self.pages: Dict[FileId, Page] = {}
 
         self.asset_dg: "networkx.DiGraph[FileId]" = networkx.DiGraph()
-        self.expensive_operation_cache = Cache()
+        self.expensive_operation_cache: Cache[FileId] = Cache()
 
         published_branches, published_branches_diagnostics = self.get_parsed_branches()
         if published_branches:

--- a/snooty/performance_report.py
+++ b/snooty/performance_report.py
@@ -3,7 +3,8 @@ import logging
 from pathlib import Path
 from typing import Dict, List
 from .parser import Project
-from .types import Page, FileId, SerializableType, BuildIdentifierSet
+from .types import FileId, SerializableType, BuildIdentifierSet
+from .page import Page
 from .diagnostics import Diagnostic
 from .util import PerformanceLogger
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -15,7 +15,7 @@ from typing import (
     MutableSequence,
 )
 from .eventparser import EventParser
-from .types import FileId, Page, ProjectConfig, SerializableType, TargetDatabase
+from .types import FileId, ProjectConfig, SerializableType
 from .diagnostics import (
     Diagnostic,
     MissingOption,
@@ -26,6 +26,8 @@ from .diagnostics import (
     UnnamedPage,
 )
 from . import n, util
+from .page import Page
+from .target_database import TargetDatabase
 from .util import SOURCE_FILE_EXTENSIONS
 
 logger = logging.getLogger(__name__)

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -3,8 +3,10 @@
 
 import dataclasses
 import toml
+import sys
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 import docutils.nodes
 import docutils.parsers.rst
 import docutils.parsers.rst.directives
@@ -25,6 +27,10 @@ from typing import (
 )
 from typing_extensions import Protocol
 
+
+PACKAGE_ROOT = Path(sys.modules["snooty"].__file__).resolve().parent
+if PACKAGE_ROOT.is_file():
+    PACKAGE_ROOT = PACKAGE_ROOT.parent
 
 #: Types of formatting that can be applied to a role.
 FormattingType = Enum("FormattingType", ("strong", "monospace", "emphasis"))
@@ -247,6 +253,17 @@ class Spec:
 
         return root
 
+    def strip_prefix_from_name(self, rstobject_id: str, title: str) -> str:
+        rstobject = self.rstobject.get(rstobject_id, None)
+        if rstobject is None:
+            return title
+
+        candidate = f"{rstobject.prefix}."
+        if title.startswith(candidate):
+            return title[len(candidate) :]
+
+        return title
+
     def get_validator(self, option_spec: ArgumentType) -> Callable[[str], object]:
         """Return a validation function for a given argument type. This function will take in a
            string, and either throw an exception or return an output value."""
@@ -323,3 +340,7 @@ class Spec:
 
         for key, inheritable in inheritable_index.items():
             resolve_value(key, inheritable)
+
+
+GLOBAL_SPEC_PATH = PACKAGE_ROOT.joinpath("rstspec.toml")
+SPEC = Spec.loads(GLOBAL_SPEC_PATH.read_text(encoding="utf-8"))

--- a/snooty/target_database.py
+++ b/snooty/target_database.py
@@ -1,0 +1,177 @@
+import enum
+import logging
+import urllib
+from collections import defaultdict
+from dataclasses import dataclass, field
+from docutils.nodes import make_id
+from typing import Dict, DefaultDict, NamedTuple, Sequence, List, Protocol, Optional
+from .types import normalize_target, FileId, ProjectConfig
+from .cache import Cache
+from . import n, intersphinx, specparser
+
+logger = logging.getLogger(__name__)
+
+#: Indicates the target protocol of a target: either a file local to the
+#: current project, or a URL (from an intersphinx inventory).
+TargetType = enum.Enum("TargetType", ("fileid", "url"))
+
+
+@dataclass
+class TargetDatabase:
+    """A database of targets known to this project."""
+
+    class Result(NamedTuple):
+        type: TargetType
+        result: str
+        canonical_target_name: str
+        title: Sequence[n.InlineNode]
+
+    class LocalDefinition(NamedTuple):
+        canonical_name: str
+        fileid: FileId
+        title: Sequence[n.InlineNode]
+
+    intersphinx_inventories: Dict[str, intersphinx.Inventory] = field(
+        default_factory=dict
+    )
+    local_definitions: DefaultDict[str, List[LocalDefinition]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+
+    def __contains__(self, key: str) -> bool:
+        key = normalize_target(key)
+        if key in self.local_definitions:
+            return True
+
+        for inventory in self.intersphinx_inventories.values():
+            if key in inventory:
+                return True
+
+        return False
+
+    def __getitem__(self, key: str) -> Sequence["TargetDatabase.Result"]:
+        key = normalize_target(key)
+        results: List[TargetDatabase.Result] = []
+
+        # Check to see if the target is defined locally
+        try:
+            results.extend(
+                TargetDatabase.Result(
+                    TargetType.fileid,
+                    fileid.without_known_suffix,
+                    canonical_target_name,
+                    title,
+                )
+                for canonical_target_name, fileid, title in self.local_definitions[key]
+            )
+        except KeyError:
+            pass
+
+        # Get URL from intersphinx inventories
+        for inventory in self.intersphinx_inventories.values():
+            if key in inventory:
+                base_url = inventory.base_url
+                entry = inventory[key]
+                url = urllib.parse.urljoin(base_url, entry.uri)
+
+                display_name = entry.display_name
+                if display_name is None:
+                    display_name = entry.name
+
+                    display_name = specparser.SPEC.strip_prefix_from_name(
+                        entry.domain_and_role, display_name
+                    )
+
+                title: List[n.InlineNode] = [n.Text((-1,), display_name)]
+                results.append(
+                    TargetDatabase.Result(TargetType.url, url, entry.name, title)
+                )
+
+        return results
+
+    def define_local_target(
+        self,
+        domain: str,
+        name: str,
+        targets: Sequence[str],
+        pageid: FileId,
+        title: Sequence[n.InlineNode],
+    ) -> None:
+        # If multiple target names are given, prefer placing the one with the most periods
+        # into referring RefRole nodes. This is an odd heuristic, but should work for now.
+        # e.g. if a RefRole links to "-v", we want it to get normalized to "mongod.-v" if that's
+        # what gets resolved.
+        canonical_target_name = max(targets, key=lambda x: x.count("."))
+
+        for target in targets:
+            target = normalize_target(target)
+            key = f"{domain}:{name}:{target}"
+            self.local_definitions[key].append(
+                TargetDatabase.LocalDefinition(canonical_target_name, pageid, title)
+            )
+
+    def reset(self, config: "ProjectConfig") -> None:
+        """Reset this database to a "blank" state with intersphinx inventories defined by
+           the given ProjectConfig instance."""
+        self.intersphinx_inventories.clear()
+        self.local_definitions.clear()
+
+        logger.debug("Loading %s intersphinx inventories", len(config.intersphinx))
+        for url in config.intersphinx:
+            self.intersphinx_inventories[url] = intersphinx.fetch_inventory(url)
+
+    def generate_inventory(self, base_url: str) -> intersphinx.Inventory:
+        targets: Dict[str, intersphinx.TargetDefinition] = {}
+        for key, definitions in self.local_definitions.items():
+            if not definitions:
+                continue
+
+            definition = definitions[0]
+            uri = definition.fileid.without_known_suffix + "/"
+            dispname: Optional[str] = "".join(
+                node.get_text() for node in definition.title
+            )
+            domain, role_name, name = key.split(":", 2)
+
+            if not dispname:
+                dispname = None
+
+            base_uri = uri
+            if (domain, role_name) != ("std", "doc"):
+                base_uri += "#$"
+                uri = uri + "#" + make_id(name)
+
+            targets[key] = intersphinx.TargetDefinition(
+                definition.canonical_name,
+                (domain, role_name),
+                -1,
+                base_uri,
+                uri,
+                dispname,
+            )
+        return intersphinx.Inventory(base_url, targets)
+
+    @classmethod
+    def load(cls, config: "ProjectConfig") -> "TargetDatabase":
+        """Create a TargetDatabase with the intersphinx inventories specified by the given
+           ProjectConfig."""
+        db = cls()
+        db.reset(config)
+        return db
+
+
+class ProjectInterface(Protocol):
+    expensive_operation_cache: Cache[FileId]
+    targets: TargetDatabase
+
+
+@dataclass
+class EmptyProjectInterface:
+    """An empty ProjectInterface implementation for testing."""
+
+    expensive_operation_cache: Cache[FileId]
+    targets: TargetDatabase
+
+    def __init__(self) -> None:
+        self.expensive_operation_cache = Cache()
+        self.targets = TargetDatabase()

--- a/snooty/test_intersphinx.py
+++ b/snooty/test_intersphinx.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from pytest import raises
 from .intersphinx import fetch_inventory, Inventory
 from .parser import Project
-from .types import TargetDatabase, FileId
+from .types import FileId
+from .target_database import TargetDatabase
 from .test_project import Backend
 
 TESTING_CACHE_DIR = Path(".intersphinx_cache")

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -140,7 +140,7 @@ def test_validate_ref_targets(backend: Backend) -> None:
         name="binary"
         target="bin.mongod"
         url="https://docs.mongodb.com/manual/reference/program/mongod/#bin.mongod">
-        <literal><text>bin.mongod</text></literal>
+        <literal><text>mongod</text></literal>
         </ref_role>""",
     )
 

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -5,7 +5,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, DefaultDict, List
-from .types import FileId, Page, ProjectConfig, SerializableType, BuildIdentifierSet
+from .types import FileId, ProjectConfig, SerializableType, BuildIdentifierSet
+from .page import Page
 from .diagnostics import Diagnostic, GitMergeConflictArtifactFound, ConstantNotDeclared
 from .parser import Project
 from .util import ast_dive

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -1,5 +1,6 @@
 from pathlib import Path, PurePath
-from .types import ProjectConfig, StaticAsset, Page, FileId
+from .types import ProjectConfig, StaticAsset, FileId
+from .page import Page
 
 
 def test_project() -> None:

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -1,24 +1,9 @@
-import enum
 import hashlib
 import logging
 import re
-from docutils.nodes import make_id
-from collections import defaultdict
 from dataclasses import dataclass, field
-from pathlib import Path, PurePath, PurePosixPath
-from typing import (
-    Dict,
-    DefaultDict,
-    NamedTuple,
-    Set,
-    List,
-    Iterator,
-    Sequence,
-    MutableSequence,
-    Tuple,
-    Optional,
-    Match,
-)
+from pathlib import Path, PurePosixPath
+from typing import Dict, List, MutableSequence, Tuple, Optional, Match
 from .diagnostics import (
     Diagnostic,
     UnmarshallingError,
@@ -26,10 +11,9 @@ from .diagnostics import (
     ConstantNotDeclared,
 )
 from typing_extensions import Protocol
-import urllib.parse
 import toml
 from .flutter import checked, check_type, LoadError
-from . import n, intersphinx
+from . import n
 from .n import SerializableType as ST
 
 SerializableType = ST
@@ -38,10 +22,6 @@ PAT_GIT_MARKER = re.compile(r"^<<<<<<< .*?^=======\n.*?^>>>>>>>", re.M | re.S)
 PAT_FILE_EXTENSIONS = re.compile(r"\.((txt)|(rst)|(yaml))$")
 BuildIdentifierSet = Dict[str, Optional[str]]
 logger = logging.getLogger(__name__)
-
-#: Indicates the target protocol of a target: either a file local to the
-#: current project, or a URL (from an intersphinx inventory).
-TargetType = enum.Enum("TargetType", ("fileid", "url"))
 
 
 class EmbeddedRstParser(Protocol):
@@ -115,257 +95,6 @@ class StaticAsset:
         if self._data is None:
             self._data = self.path.read_bytes()
             self._checksum = hashlib.blake2b(self._data, digest_size=32).hexdigest()
-
-
-@dataclass
-class TargetDatabase:
-    """A database of targets known to this project."""
-
-    class Result(NamedTuple):
-        type: TargetType
-        result: str
-        canonical_target_name: str
-        title: Sequence[n.InlineNode]
-
-    class LocalDefinition(NamedTuple):
-        canonical_name: str
-        fileid: FileId
-        title: Sequence[n.InlineNode]
-
-    intersphinx_inventories: Dict[str, intersphinx.Inventory] = field(
-        default_factory=dict
-    )
-    local_definitions: DefaultDict[str, List[LocalDefinition]] = field(
-        default_factory=lambda: defaultdict(list)
-    )
-
-    def __contains__(self, key: str) -> bool:
-        key = normalize_target(key)
-        if key in self.local_definitions:
-            return True
-
-        for inventory in self.intersphinx_inventories.values():
-            if key in inventory:
-                return True
-
-        return False
-
-    def __getitem__(self, key: str) -> Sequence["TargetDatabase.Result"]:
-        key = normalize_target(key)
-        results: List[TargetDatabase.Result] = []
-
-        # Check to see if the target is defined locally
-        try:
-            results.extend(
-                TargetDatabase.Result(
-                    TargetType.fileid,
-                    fileid.without_known_suffix,
-                    canonical_target_name,
-                    title,
-                )
-                for canonical_target_name, fileid, title in self.local_definitions[key]
-            )
-        except KeyError:
-            pass
-
-        # Get URL from intersphinx inventories
-        for inventory in self.intersphinx_inventories.values():
-            if key in inventory:
-                base_url = inventory.base_url
-                entry = inventory[key]
-                url = urllib.parse.urljoin(base_url, entry.uri)
-                title: List[n.InlineNode] = [n.Text((-1,), entry.display_name)]
-                results.append(
-                    TargetDatabase.Result(TargetType.url, url, entry.name, title)
-                )
-
-        return results
-
-    def define_local_target(
-        self,
-        domain: str,
-        name: str,
-        targets: Sequence[str],
-        pageid: FileId,
-        title: Sequence[n.InlineNode],
-    ) -> None:
-        # If multiple target names are given, prefer placing the one with the most periods
-        # into referring RefRole nodes. This is an odd heuristic, but should work for now.
-        # e.g. if a RefRole links to "-v", we want it to get normalized to "mongod.-v" if that's
-        # what gets resolved.
-        canonical_target_name = max(targets, key=lambda x: x.count("."))
-
-        for target in targets:
-            target = normalize_target(target)
-            key = f"{domain}:{name}:{target}"
-            self.local_definitions[key].append(
-                TargetDatabase.LocalDefinition(canonical_target_name, pageid, title)
-            )
-
-    def reset(self, config: "ProjectConfig") -> None:
-        """Reset this database to a "blank" state with intersphinx inventories defined by
-           the given ProjectConfig instance."""
-        self.intersphinx_inventories.clear()
-        self.local_definitions.clear()
-
-        logger.debug("Loading %s intersphinx inventories", len(config.intersphinx))
-        for url in config.intersphinx:
-            self.intersphinx_inventories[url] = intersphinx.fetch_inventory(url)
-
-    def generate_inventory(self, base_url: str) -> intersphinx.Inventory:
-        targets: Dict[str, intersphinx.TargetDefinition] = {}
-        for key, definitions in self.local_definitions.items():
-            if not definitions:
-                continue
-
-            definition = definitions[0]
-            uri = definition.fileid.without_known_suffix + "/"
-            dispname = "".join(node.get_text() for node in definition.title)
-            domain, role_name, name = key.split(":", 2)
-
-            if not dispname:
-                dispname = name
-
-            base_uri = uri
-            if (domain, role_name) != ("std", "doc"):
-                base_uri += "#$"
-                uri = uri + "#" + make_id(name)
-
-            targets[key] = intersphinx.TargetDefinition(
-                definition.canonical_name,
-                (domain, role_name),
-                -1,
-                base_uri,
-                uri,
-                dispname,
-            )
-        return intersphinx.Inventory(base_url, targets)
-
-    @classmethod
-    def load(cls, config: "ProjectConfig") -> "TargetDatabase":
-        """Create a TargetDatabase with the intersphinx inventories specified by the given
-           ProjectConfig."""
-        db = cls()
-        db.reset(config)
-        return db
-
-
-@dataclass
-class Cache:
-    """A versioned cache that associates a (FileId, int) pair with an arbitrary object and
-       an integer version. Whenever the key is re-assigned, the version is incremented."""
-
-    _cache: Dict[Tuple[FileId, int], object] = field(default_factory=dict)
-    _keys_of_each_fileid: DefaultDict[FileId, Set[int]] = field(
-        default_factory=lambda: defaultdict(set)
-    )
-    _versions: DefaultDict[Tuple[FileId, int], int] = field(
-        default_factory=lambda: defaultdict(int)
-    )
-
-    def __setitem__(self, key: Tuple[FileId, int], value: object) -> None:
-        if key in self._cache:
-            self._cache[key] = value
-        else:
-            self._cache[key] = value
-
-        self._versions[key] += 1
-        self._keys_of_each_fileid[key[0]].add(key[1])
-
-    def __delitem__(self, fileid: FileId) -> None:
-        keys = self._keys_of_each_fileid[fileid]
-        del self._keys_of_each_fileid[fileid]
-        for key in keys:
-            del self._cache[(fileid, key)]
-
-    def __getitem__(self, key: Tuple[FileId, int]) -> Optional[object]:
-        return self._cache.get(key, None)
-
-    def get_versions(self, fileid: FileId) -> Iterator[int]:
-        for key, version in self._versions.items():
-            if key[0] == fileid:
-                yield version
-
-
-class ProjectInterface(Protocol):
-    expensive_operation_cache: Cache
-    targets: TargetDatabase
-
-
-@dataclass
-class EmptyProjectInterface:
-    """An empty ProjectInterface implementation for testing."""
-
-    expensive_operation_cache: Cache
-    targets: TargetDatabase
-
-    def __init__(self) -> None:
-        self.expensive_operation_cache = Cache()
-        self.targets = TargetDatabase()
-
-
-class PendingTask:
-    """A thunk which will be executed in the main process after the full tree is
-       constructed. This should primarily be used to execute tasks which may need
-       to mutate state from the main process (e.g. caches or dependency graphs)."""
-
-    def __init__(self, node: n.Node) -> None:
-        self.node = node
-
-    def __call__(
-        self, diagnostics: List[Diagnostic], project: ProjectInterface
-    ) -> None:
-        """Perform an action in the main process once the tree has been built."""
-        pass
-
-
-@dataclass
-class Page:
-    source_path: Path
-    output_filename: str
-    source: str
-    ast: n.Parent[n.Node]
-    static_assets: Set[StaticAsset] = field(default_factory=set)
-    pending_tasks: List[PendingTask] = field(default_factory=list)
-    category: Optional[str] = None
-    query_fields: Dict[str, SerializableType] = field(default_factory=dict)
-
-    @classmethod
-    def create(
-        self,
-        source_path: Path,
-        output_filename: Optional[str],
-        source: str,
-        ast: Optional[n.Parent[n.Node]] = None,
-    ) -> "Page":
-        if output_filename is None:
-            output_filename = source_path.name
-
-        if ast is None:
-            ast = n.Root((0,), [], {})
-
-        return Page(source_path, output_filename, source, ast)
-
-    def fake_full_path(self) -> PurePath:
-        """Return a fictitious path (hopefully) uniquely identifying this output artifact."""
-        if self.category:
-            # Giza wrote out yaml file artifacts under a directory. e.g. steps-foo.yaml becomes
-            # steps/foo.rst
-            return self.source_path.parent.joinpath(
-                PurePath(self.category), self.output_filename
-            )
-        return self.source_path
-
-    def finish(
-        self, diagnostics: List[Diagnostic], project: Optional[ProjectInterface] = None
-    ) -> None:
-        """Finish all pending tasks for this page. This should be run in the main process."""
-        for task in self.pending_tasks:
-            task(
-                diagnostics, project if project is not None else EmptyProjectInterface()
-            )
-
-        self.pending_tasks.clear()
 
 
 @checked


### PR DESCRIPTION
Much refactoring was required to avoid circular import errors. This improves the overall code modularity, but makes this a bit bloated. Sorry!

Additionally, the spec is now a global, and is parsed upon specparser module import.

This is the resulting change in the output AST: https://github.com/mongodb/snooty-parser/pull/168/files#diff-915b6e0f0f3fa5b6662ec3cdccbee909R143

The specific example Jeff encountered is now output as:
```
{
    "type": "ref_role",
    "position": {
        "start": {
            "line": 107
        }
    },
    "children": [
        {
            "type": "literal",
            "position": {
                "start": {
                    "line": 107
                }
            },
            "children": [
                {
                    "type": "text",
                    "position": {
                        "start": {
                            "line": 107
                        }
                    },
                    "value": "$match"
                }
            ]
        }
    ],
    "domain": "mongodb",
    "name": "pipeline",
    "target": "pipe.$match",
    "flag": "",
    "url": "https://docs.mongodb.com/manual/reference/operator/aggregation/match/#pipe._S_match"
}
```