### PR TITLE
DOP-1207: standardize on doc-format links for role.atlas

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1103,7 +1103,7 @@ type = {link = "https://godoc.org/github.com/mongodb/mongo-go-driver/%s"}
 
 [role.atlas]
 help = """Link to the synchronous Atlas documentation."""
-type = {link = "https://docs.atlas.mongodb.com/%s"}
+type = {link = "https://docs.atlas.mongodb.com%s"}
 
 [role."v2.2"]
 type = {link = "https://docs.mongodb.com/v2.2%s"}


### PR DESCRIPTION
We're standardizing on :doc:-style links for atlas. [DOP-1208](jira.mongodb.com/browse/DOP-1208) will sort out the content side for repos that are using the "wrong" format.

I have, uncharacteristically, run the tests.