### PR TITLE
DOP-1269: Allow for additional list-table width delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The :list-table: directive no longer generates incorrect warnings
+
 ## [v0.5.3] - 2020-07-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- The :list-table: directive no longer generates incorrect warnings
+- The list-table directive no longer generates incorrect warnings
 
 ## [v0.5.3] - 2020-07-29
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -447,7 +447,7 @@ class JSONVisitor:
             # Calculate the expected number of columns for this list-table structure.
             expected_num_columns = 0
             if "widths" in options:
-                expected_num_columns = len(re.split("[,* *]+", options["widths"]))
+                expected_num_columns = len(re.split("[,\s][\s]?", options["widths"]))
             bullet_list = node.children[0]
             for list_item in bullet_list.children:
                 if expected_num_columns == 0:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -448,7 +448,6 @@ class JSONVisitor:
             expected_num_columns = 0
             if "widths" in options:
                 widths = re.split(r"[,\s][\s]?", options["widths"])
-                self.validate_list_table_widths(node, widths)
                 expected_num_columns = len(widths)
             bullet_list = node.children[0]
             for list_item in bullet_list.children:
@@ -681,15 +680,6 @@ class JSONVisitor:
                     resolved_target_path, os.strerror(errno.ENOENT), util.get_line(node)
                 )
             )
-
-    def validate_list_table_widths(
-        self, node: docutils.nodes.Node, option_list: List[str]
-    ) -> None:
-        """Validate output from comma and/or space-delimited width option"""
-        for option in option_list:
-            if not re.match(r"\d+", option):
-                msg = f"Invalid option list: {option_list}"
-                self.diagnostics.append(InvalidTableStructure(msg, util.get_line(node)))
 
     def validate_list_table(
         self, node: docutils.nodes.Node, expected_num_columns: int

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import errno
 import pwd
+import re
 import subprocess
 import threading
 from copy import deepcopy
@@ -446,7 +447,7 @@ class JSONVisitor:
             # Calculate the expected number of columns for this list-table structure.
             expected_num_columns = 0
             if "widths" in options:
-                expected_num_columns = len(options["widths"].split(" "))
+                expected_num_columns = len(re.split("[,* *]+", options["widths"]))
             bullet_list = node.children[0]
             for list_item in bullet_list.children:
                 if expected_num_columns == 0:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -447,7 +447,7 @@ class JSONVisitor:
             # Calculate the expected number of columns for this list-table structure.
             expected_num_columns = 0
             if "widths" in options:
-                expected_num_columns = len(re.split("[,\s][\s]?", options["widths"]))
+                expected_num_columns = len(re.split(r"[,\s][\s]?", options["widths"]))
             bullet_list = node.children[0]
             for list_item in bullet_list.children:
                 if expected_num_columns == 0:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1269,7 +1269,7 @@ def test_list_table() -> None:
     page.finish(diagnostics)
     assert len(diagnostics) == 0
 
-    # Incorrectly delimited width option should fail
+    # Incorrectly delimited width option should not fail
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -1288,7 +1288,7 @@ def test_list_table() -> None:
 """,
     )
     page.finish(diagnostics)
-    assert len(diagnostics) == 1
+    assert len(diagnostics) == 0
 
     # Nesting
     page, diagnostics = parse_rst(

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1269,6 +1269,27 @@ def test_list_table() -> None:
     page.finish(diagnostics)
     assert len(diagnostics) == 0
 
+    # Incorrectly delimited width option should fail
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. list-table::
+   :header-rows: 1
+   :widths: 38,,72
+
+   * - Stage
+     - Description
+     - Description 2
+
+   * - :pipeline:`$geoNear`
+     - .. include:: /includes/extracts/geoNear-stage-toc-description.rst
+     - .. include:: /includes/extracts/geoNear-stage-index-requirement.rst
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+
     # Nesting
     page, diagnostics = parse_rst(
         parser,

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1150,6 +1150,7 @@ def test_list_table() -> None:
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
+    # Correct list-table
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -1169,6 +1170,7 @@ def test_list_table() -> None:
     page.finish(diagnostics)
     assert len(diagnostics) == 0
 
+    # Excess rows
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -1188,6 +1190,7 @@ def test_list_table() -> None:
     page.finish(diagnostics)
     assert len(diagnostics) == 1
 
+    # No width option variant
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -1206,6 +1209,67 @@ def test_list_table() -> None:
     page.finish(diagnostics)
     assert len(diagnostics) == 0
 
+    # Comma-separated width option should not fail
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. list-table::
+   :header-rows: 1
+   :widths: 38,72
+
+   * - Stage
+     - Description
+
+   * - :pipeline:`$geoNear`
+     - .. include:: /includes/extracts/geoNear-stage-toc-description.rst
+       .. include:: /includes/extracts/geoNear-stage-index-requirement.rst
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+    # ", "-separated width option should not fail
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. list-table::
+   :header-rows: 1
+   :widths: 38, 72
+
+   * - Stage
+     - Description
+
+   * - :pipeline:`$geoNear`
+     - .. include:: /includes/extracts/geoNear-stage-toc-description.rst
+       .. include:: /includes/extracts/geoNear-stage-index-requirement.rst
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+    # "  "-separated width option should not fail
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. list-table::
+   :header-rows: 1
+   :widths: 38  72
+
+   * - Stage
+     - Description
+
+   * - :pipeline:`$geoNear`
+     - .. include:: /includes/extracts/geoNear-stage-toc-description.rst
+       .. include:: /includes/extracts/geoNear-stage-index-requirement.rst
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+    # Nesting
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -1227,6 +1291,7 @@ def test_list_table() -> None:
     page.finish(diagnostics)
     assert len(diagnostics) == 0
 
+    # Nested list-tables
     page, diagnostics = parse_rst(
         parser,
         path,


### PR DESCRIPTION
[JIRA.](https://jira.mongodb.org/browse/DOP-1269)

- Allow for additional delimiters for width options per the [rst list-table directive](https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table).
  - ` `
  - `, `
  -  `  `
- Test for these new options

