### PR TITLE
DOP-1230: Postprocess directive arguments

### DIFF
--- a/snooty/eventparser.py
+++ b/snooty/eventparser.py
@@ -67,6 +67,10 @@ class EventParser(EventListeners):
                 for child in d.term:
                     self._iterate(child, filename)
 
+            if isinstance(d, n.Directive):
+                for arg in d.argument:
+                    self._iterate(arg, filename)
+
             for child in d.children:
                 self._iterate(child, filename)
         self._on_object_exit_event(d, filename)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -572,3 +572,20 @@ def test_substitutions(backend: Backend) -> None:
         substitution_reference,
         """<substitution_reference name="weather"><substitution_reference name="sun"><text>sun</text></substitution_reference></substitution_reference>""",
     )
+
+
+def test_process_arguments(backend: Backend) -> None:
+    """Ensure that directive arguments are ingested by postprocess layer"""
+    note_id = FileId("note.txt")
+    ast = backend.pages[note_id].ast
+    note = ast.children[0]
+    assert isinstance(note, n.Directive)
+
+    print(ast_to_testing_string(note))
+    check_ast_testing_string(
+        note,
+        """<directive name="note">
+        <text>What's new in</text>
+        <substitution_reference name="service"><text>Atlas</text></substitution_reference>
+        <paragraph><text>Describe what's new.</text></paragraph></directive>""",
+    )

--- a/test_data/test_postprocessor/source/note.txt
+++ b/test_data/test_postprocessor/source/note.txt
@@ -1,0 +1,3 @@
+.. note:: What's new in |service|
+
+   Describe what's new.


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-1320)] Include directive arguments in the postprocess iteration so that they can be postprocessed 😁 You can see it is fixed in this [staging link](https://docs-mongodbcom-staging.corp.mongodb.com/snooty-setup/cloud-docs/sophstad/DOP-1296/)!