### PR TITLE
DOP-1337 Add search-results directive to rstspec

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -899,6 +899,10 @@ example = """.. topic:: ${1:Title of block}
    ${0:Content}
 """
 
+[directive.search-results]
+help = """Shows search results from browser query params (no arguments)."""
+argument_type = "none"
+
 ###### Roles
 [role.sub]
 help = """Used to denote subscript text."""

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -901,7 +901,6 @@ example = """.. topic:: ${1:Title of block}
 
 [directive.search-results]
 help = """Shows search results from browser query params (no arguments)."""
-argument_type = "none"
 
 ###### Roles
 [role.sub]


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-1337)
[Spec](https://docs.google.com/document/d/10TAxNOdWDp_vi-D_NTnA_YDQXLeyoPsFa2Banx1Srsw/edit#heading=h.tkooaeqt2p7i)

This PR simply adds a new directive to the rstSpec file for `search-results`. This directive takes no arguments.

Questions:
- Since this is a simple directive I was not sure if tests may be necessary, thoughts?
- Is the argument type correct? (I believe None is not defined in toml, but "none" works :) )
- Missing anything?