### PR TITLE
Add missing source to LSP diagnostics

### DIFF
--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -232,6 +232,7 @@ class WorkspaceEntry:
                 "severity": DiagnosticSeverity.from_diagnostic(diagnostic.severity),
                 "message": diagnostic.message,
                 "code": type(diagnostic).__name__,
+                "source": "snooty",
             }
             for diagnostic in self.diagnostics
         ]

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -33,6 +33,7 @@ class LSPDiagnostic:
     severity: int
     range: LSPRange
     code: str
+    source: str
 
 
 def test_debounce() -> None:
@@ -73,6 +74,7 @@ def test_workspace_entry() -> None:
         1,
         LSPRange(LSPPosition(10, 0), LSPPosition(10, 1000)),
         "InvalidTableStructure",
+        "snooty",
     )
 
     assert parsed[1] == LSPDiagnostic(
@@ -80,6 +82,7 @@ def test_workspace_entry() -> None:
         2,
         LSPRange(LSPPosition(10, 0), LSPPosition(12, 1000)),
         "DocUtilsParseError",
+        "snooty",
     )
 
 


### PR DESCRIPTION
This addresses feedback that we received from Nic, and allows users of the vscode extension to filter out only snooty problems