### PR TITLE
DOP-1429: Support alternative no-title ref_role syntax

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -51,7 +51,7 @@ RoleHandlerType = Callable[
     Tuple[List[docutils.nodes.Node], List[docutils.nodes.Node]],
 ]
 PAT_EXPLICIT_TITLE = re.compile(
-    r"^(?P<label>.+?)\s*(?<!\x00)<(?P<target>.*?)>$", re.DOTALL
+    r"^(?P<label>.*?)\s*(?<!\x00)<(?P<target>.*?)>$", re.DOTALL
 )
 PAT_WHITESPACE = re.compile(r"^\x20*")
 PAT_BLOCK_HAS_ARGUMENT = re.compile(r"^\x20*\.\.\x20[^\s]+::\s*\S+")
@@ -826,13 +826,14 @@ class BaseTocTreeDirective(docutils.parsers.rst.Directive):
         slug: Optional[str] = None
         if match:
             title, target = match["label"], match["target"]
-        elif child.startswith("<") and child.endswith(">"):
+        else:
+            target = child
+
+        if not title and util.PAT_URI.match(target):
             # If entry is surrounded by <> tags, assume it is a URL and log an error.
             err = "toctree nodes with URLs must include titles"
             error_node = self.state.document.reporter.error(err, line=self.lineno)
             return None, [error_node]
-        else:
-            target = child
 
         parsed = urllib.parse.urlparse(target)
         if parsed.scheme:

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1072,7 +1072,7 @@ inherit = "ref"
 
 [role.term]
 help = """Link to a term in the glossary."""
-type = {domain = "std", name = "term"}
+type = {domain = "std", name = "term", format = []}
 
 [role.issue]
 help = """Link to a JIRA ticket."""

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -589,6 +589,7 @@ def test_roles() -> None:
 * :binary:`~bin.mongod`
 * :binary:`mongod <~bin.mongod>`
 * :guilabel:`Test <foo>`
+* :term:`<foo>`
 """,
     )
     page.finish(diagnostics)
@@ -637,11 +638,18 @@ def test_roles() -> None:
                   target="bin.mongod"><literal><text>mongod</text></literal></ref_role>
             </paragraph>
             </listItem>
+
             <listItem>
             <paragraph>
             <role name="guilabel">
             <text>Test &lt;foo&gt;</text>
             </role>
+            </paragraph>
+            </listItem>
+
+            <listItem>
+            <paragraph>
+            <ref_role domain="std" name="term" target="foo"></ref_role>
             </paragraph>
             </listItem>
             </list>

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 _K = TypeVar("_K", bound=Hashable)
 PAT_INVALID_ID_CHARACTERS = re.compile(r"[^\w_\.\-]")
+PAT_URI = re.compile(r"^(?P<schema>[a-z]+)://")
 SOURCE_FILE_EXTENSIONS = {".txt", ".rst", ".yaml"}
 RST_EXTENSIONS = {".txt", ".rst"}
 


### PR DESCRIPTION
This also tweaks a warning's logic a bit: we actually check for a url before complaining about a url, matching Sphinx's logic