### PR TITLE
DOP-981: Standardize toctree title nodes

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -505,7 +505,7 @@ class Postprocessor:
 
         # Build the toctree
         root: Dict[str, SerializableType] = {
-            "title": self.project_config.title,
+            "title": [n.Text((0,), self.project_config.title).serialize()],
             "slug": "/",
             "children": [],
         }
@@ -531,7 +531,9 @@ class Postprocessor:
                 toctree_node: Dict[str, object] = {}
                 if entry.url:
                     toctree_node = {
-                        "title": entry.title,
+                        "title": [n.Text((0,), entry.title).serialize()]
+                        if entry.title
+                        else None,
                         "url": entry.url,
                         "children": [],
                     }
@@ -546,7 +548,9 @@ class Postprocessor:
                     slug: str = slug_fileid.without_known_suffix
 
                     if entry.title:
-                        title: SerializableType = entry.title
+                        title: SerializableType = [
+                            n.Text((0,), entry.title).serialize()
+                        ]
                     else:
                         title_nodes = self.slug_title_mapping.get(slug)
                         title = (

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -225,19 +225,37 @@ def test_toctree(backend: Backend) -> None:
                 "children": [
                     {
                         "children": [],
-                        "title": "MongoDB Connector for Business Intelligence",
+                        "title": [
+                            {
+                                "position": {"start": {"line": 0}},
+                                "type": "text",
+                                "value": "MongoDB Connector for Business Intelligence",
+                            }
+                        ],
                         "url": "https://docs.mongodb.com/bi-connector/current/",
                     },
                     {
                         "children": [],
                         "options": {"drawer": False},
                         "slug": "page3",
-                        "title": None,
+                        "title": [
+                            {
+                                "position": {"start": {"line": 0}},
+                                "type": "text",
+                                "value": "Page Three",
+                            }
+                        ],
                     },
                 ],
             },
         ],
-        "title": "MongoDB title",
+        "title": [
+            {
+                "position": {"start": {"line": 0}},
+                "type": "text",
+                "value": "MongoDB title",
+            }
+        ],
         "slug": "/",
     }
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -238,11 +238,17 @@ def test_toctree(backend: Backend) -> None:
                         "children": [],
                         "options": {"drawer": False},
                         "slug": "page3",
+                        "title": None,
+                    },
+                    {
+                        "children": [],
+                        "options": {"drawer": True},
+                        "slug": "page4",
                         "title": [
                             {
                                 "position": {"start": {"line": 0}},
                                 "type": "text",
-                                "value": "Page Three",
+                                "value": "Page Four",
                             }
                         ],
                     },
@@ -264,7 +270,7 @@ def test_breadcrumbs(backend: Backend) -> None:
     # Ensure that the correct pages and assets exist for breadcrumbs
     pages: Dict[str, Any] = cast(Dict[str, Any], backend.metadata["parentPaths"])
 
-    assert len(pages) == 3
+    assert len(pages) == 4
     assert len(pages["page1"]) == 0
 
     assert len(pages["page2"]) == 0
@@ -276,7 +282,7 @@ def test_breadcrumbs(backend: Backend) -> None:
 def test_toctree_order(backend: Backend) -> None:
     # Ensure that the correct pages and assets exist for toctree order
     order: List[str] = cast(List[str], backend.metadata["toctreeOrder"])
-    assert order == ["/", "page1", "page2", "page3"]
+    assert order == ["/", "page1", "page2", "page3", "page4"]
 
 
 def test_target_titles(backend: Backend) -> None:

--- a/test_data/test_postprocessor/source/page2.txt
+++ b/test_data/test_postprocessor/source/page2.txt
@@ -28,4 +28,4 @@ Heading is not at the top for some reason
    .. toctree::
     :titlesonly: 
 
-    /page3
+    Page Three </page3>

--- a/test_data/test_postprocessor/source/page2.txt
+++ b/test_data/test_postprocessor/source/page2.txt
@@ -28,4 +28,5 @@ Heading is not at the top for some reason
    .. toctree::
     :titlesonly: 
 
-    Page Three </page3>
+    /page3
+    Page Four </page4>


### PR DESCRIPTION
[DOP-981] Standardize toctree `title` fields so that rather than mixing lists of text nodes and plain strings, all fields appear as a list of text nodes. Staged on Datalake for good measure and it looks [great](https://docs-mongodbcom-staging.corp.mongodb.com/master/datalake/sophstad/master/)!