### PR TITLE
DOP-1434: Explain ambiguous target choices

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Tuple, Union, Dict, Optional
+from typing import Tuple, Union, Dict, Optional, List
 from pathlib import Path
 from .n import SerializableType
 from . import n
@@ -257,12 +257,18 @@ class AmbiguousTarget(Diagnostic):
         self,
         name: str,
         target: str,
+        candidates: List[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
-        super().__init__(f'Ambiguous target: "{name}:{target}"', start, end)
+        super().__init__(
+            f'Ambiguous target: "{name}:{target}". Locations: {", ".join(candidates)}',
+            start,
+            end,
+        )
         self.name = name
         self.target = target
+        self.candidates = candidates
 
 
 class TodoInfo(Diagnostic):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -306,8 +306,15 @@ class Postprocessor:
 
         if len(target_candidates) > 1:
             line = node.span[0]
+            candidate_descriptions = []
+            for candidate in target_candidates:
+                if isinstance(candidate, TargetDatabase.InternalResult):
+                    candidate_descriptions.append(candidate.result[0])
+                else:
+                    candidate_descriptions.append(candidate.url)
+
             self.diagnostics[filename].append(
-                AmbiguousTarget(node.name, node.target, line)
+                AmbiguousTarget(node.name, node.target, candidate_descriptions, line)
             )
 
         # Choose the most recently-defined target candidate if it is ambiguous

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -177,7 +177,11 @@ def test_validate_ref_targets(backend: Backend) -> None:
         and diagnostic.target == "global-writes-collections"
         for diagnostic in diagnostics
     )
-    assert any(isinstance(diagnostic, AmbiguousTarget) for diagnostic in diagnostics)
+    assert any(
+        isinstance(diagnostic, AmbiguousTarget)
+        and diagnostic.candidates == ["index", "index", "index"]
+        for diagnostic in diagnostics
+    )
 
     # Check that targets are matched case-sensitive
     assert any(


### PR DESCRIPTION
Diagnostic message is, for example, `Ambiguous target: "std:term:something". Locations: reference/glossary, https://docs.mongodb.com/manual/reference/glossary`