### PR TITLE
DOP-1489: Un-deprecate red role

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -947,9 +947,7 @@ type = "text"
 deprecated = true
 type = "text"
 
-# This is defined with .. role:: in the manual, which for architectural reasons we don't support.
 [role.red]
-deprecated = true
 type = "text"
 
 [role.icon-fa5]


### PR DESCRIPTION
[DOP-1489] Support use of `:red:` without `.. role:: red`.