### PR TITLE
DOP-1511: Correctly handle incorrect monospacing

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -331,3 +331,14 @@ class MissingTocTreeEntry(Diagnostic):
     ) -> None:
         super().__init__(f"Could not locate toctree entry {entry}", start, end)
         self.entry = entry
+
+
+class IncorrectMonospaceSyntax(Diagnostic):
+    severity = Diagnostic.Level.warning
+
+    def __init__(
+        self,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__("Monospace text uses two backticks (``)", start, end)

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -801,7 +801,7 @@ class InlineJSONVisitor(JSONVisitor):
 
     def dispatch_visit(self, node: docutils.nodes.Node) -> None:
         if isinstance(node, docutils.nodes.Body) and not isinstance(
-            node, docutils.nodes.Inline
+            node, (docutils.nodes.Inline, docutils.nodes.system_message)
         ):
             return
 
@@ -809,7 +809,7 @@ class InlineJSONVisitor(JSONVisitor):
 
     def dispatch_departure(self, node: docutils.nodes.Node) -> None:
         if isinstance(node, docutils.nodes.Body) and not isinstance(
-            node, docutils.nodes.Inline
+            node, (docutils.nodes.Inline, docutils.nodes.system_message)
         ):
             return
 

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -32,7 +32,7 @@ from typing_extensions import Protocol
 from .gizaparser.parse import load_yaml
 from .gizaparser import nodes
 from .types import ProjectConfig
-from .diagnostics import Diagnostic
+from .diagnostics import Diagnostic, IncorrectMonospaceSyntax
 from .flutter import checked, check_type, LoadError
 from . import util
 from . import specparser
@@ -198,8 +198,13 @@ def handle_role_null(
     content: List[object] = [],
 ) -> Tuple[List[docutils.nodes.Node], List[docutils.nodes.Node]]:
     """Handle unnamed roles by raising a warning."""
-    msg = inliner.reporter.error("Monospace text uses two backticks (``)", line=lineno)
-    return [], [msg]
+    return (
+        [
+            docutils.nodes.literal(rawtext, text),
+            snooty_diagnostic(IncorrectMonospaceSyntax(lineno)),
+        ],
+        [],
+    )
 
 
 class TextRoleHandler:


### PR DESCRIPTION
The change to `parser.py` is key. The docutils class hierarchy is confusing and strange.