### PR TITLE
DOP-1434: Automatically resolve ambiguous targets

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -947,7 +947,7 @@ class PageDatabase:
         postprocessor = self.postprocessor_factory()
 
         with util.PerformanceLogger.singleton().start("copy"):
-            copied_pages = util.fast_deep_copy(self.parsed)
+            copied_pages = {k: util.fast_deep_copy(v) for k, v in self.parsed.items()}
 
         with util.PerformanceLogger.singleton().start("postprocessing"):
             post_metadata, post_diagnostics = postprocessor.run(copied_pages)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -305,6 +305,10 @@ class Postprocessor:
             return
 
         if len(target_candidates) > 1:
+            # Try to prune down the options
+            target_candidates = self.attempt_disambugation(filename, target_candidates)
+
+        if len(target_candidates) > 1:
             line = node.span[0]
             candidate_descriptions = []
             for candidate in target_candidates:
@@ -333,6 +337,32 @@ class Postprocessor:
             for title_node in cloned_title_nodes:
                 deep_copy_position(node, title_node)
             injection_candidate.children = cloned_title_nodes
+
+    def attempt_disambugation(
+        self, fileid: FileId, candidates: Sequence[TargetDatabase.Result]
+    ) -> Sequence[TargetDatabase.Result]:
+        """Given multiple possible targets we can link to, attempt to narrow down the
+           list to one probably-intended target under a set of narrow circumstances."""
+
+        # If there is a single local candidate, choose that.
+        local_candidates: List[TargetDatabase.InternalResult] = [
+            candidate
+            for candidate in candidates
+            if isinstance(candidate, TargetDatabase.InternalResult)
+        ]
+        if len(local_candidates) == 1:
+            return [local_candidates[0]]
+
+        # If there is a target defined in the current context, use that.
+        current_fileid_candidates = [
+            candidate
+            for candidate in local_candidates
+            if candidate.result[0] == fileid.without_known_suffix
+        ]
+        if len(current_fileid_candidates) == 1:
+            return [current_fileid_candidates[0]]
+
+        return candidates
 
     def handle_substitutions(self) -> None:
         """Find and replace substitutions throughout project"""
@@ -459,7 +489,7 @@ class Postprocessor:
             assert include_page is not None
             ast = include_page.ast
             assert isinstance(ast, n.Parent)
-            node.children = ast.children
+            node.children = [util.fast_deep_copy(child) for child in ast.children]
 
     def build_slug_title_mapping(self, filename: FileId, node: n.Node) -> None:
         """Construct a slug-title mapping of all pages in property"""

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -49,3 +49,139 @@ Main Heading
 </root>
         """,
         )
+
+
+def test_same_page_target_resolution() -> None:
+    with make_test(
+        {
+            Path(
+                "source/program1.txt"
+            ): """
+=========
+Program 1
+=========
+
+.. program:: program1
+
+.. option:: --verbose
+
+   Verbose
+
+.. include:: /includes/fact.rst
+""",
+            Path(
+                "source/program2.txt"
+            ): """
+=========
+Program 2
+=========
+
+.. program:: program2
+
+.. option:: --verbose
+
+   Verbose
+
+.. include:: /includes/fact.rst
+""",
+            Path(
+                "source/includes/fact.rst"
+            ): """
+:option:`--verbose`
+
+:option:`program1 --verbose`
+
+:option:`program2 --verbose`
+""",
+        }
+    ) as result:
+        assert not [
+            diagnostics for diagnostics in result.diagnostics.values() if diagnostics
+        ], "Should not raise any diagnostics"
+        page = result.pages[FileId("program1.txt")]
+        check_ast_testing_string(
+            page.ast,
+            """
+<root><section>
+    <heading id="program-1"><text>Program 1</text></heading>
+
+    <target domain="std" name="program" html_id="std-program-program1">
+        <directive_argument>
+            <literal><text>program1</text></literal>
+        </directive_argument>
+        <target_identifier ids="['program1']"><text>program1</text></target_identifier>
+    </target>
+
+    <target domain="std" name="option" html_id="std-option-program1.--verbose">
+        <directive_argument><literal><text>--verbose</text></literal></directive_argument>
+        <target_identifier ids="['--verbose', 'program1.--verbose']"><text>program1 --verbose</text></target_identifier>
+        <paragraph><text>Verbose</text></paragraph>
+    </target>
+
+    <directive name="include">
+        <text>/includes/fact.rst</text>
+        <paragraph>
+            <ref_role domain="std" name="option" target="program1.--verbose" fileid="['program1', 'std-option-program1.--verbose']">
+                <literal><text>program1 --verbose</text></literal>
+            </ref_role>
+        </paragraph>
+
+        <paragraph>
+            <ref_role domain="std" name="option" target="program1.--verbose" fileid="['program1', 'std-option-program1.--verbose']">
+                <literal><text>program1 --verbose</text></literal>
+            </ref_role>
+        </paragraph>
+
+        <paragraph>
+            <ref_role domain="std" name="option" target="program2.--verbose" fileid="['program2', 'std-option-program2.--verbose']">
+                <literal><text>program2 --verbose</text></literal>
+            </ref_role>
+        </paragraph>
+    </directive>
+</section></root>
+        """,
+        )
+
+        page = result.pages[FileId("program2.txt")]
+        check_ast_testing_string(
+            page.ast,
+            """
+<root><section>
+    <heading id="program-2"><text>Program 2</text></heading>
+
+    <target domain="std" name="program" html_id="std-program-program2">
+        <directive_argument>
+            <literal><text>program2</text></literal>
+        </directive_argument>
+        <target_identifier ids="['program2']"><text>program2</text></target_identifier>
+    </target>
+
+    <target domain="std" name="option" html_id="std-option-program2.--verbose">
+        <directive_argument><literal><text>--verbose</text></literal></directive_argument>
+        <target_identifier ids="['--verbose', 'program2.--verbose']"><text>program2 --verbose</text></target_identifier>
+        <paragraph><text>Verbose</text></paragraph>
+    </target>
+
+    <directive name="include">
+        <text>/includes/fact.rst</text>
+        <paragraph>
+            <ref_role domain="std" name="option" target="program2.--verbose" fileid="['program2', 'std-option-program2.--verbose']">
+                <literal><text>program2 --verbose</text></literal>
+            </ref_role>
+        </paragraph>
+
+        <paragraph>
+            <ref_role domain="std" name="option" target="program1.--verbose" fileid="['program1', 'std-option-program1.--verbose']">
+                <literal><text>program1 --verbose</text></literal>
+            </ref_role>
+        </paragraph>
+
+        <paragraph>
+            <ref_role domain="std" name="option" target="program2.--verbose" fileid="['program2', 'std-option-program2.--verbose']">
+                <literal><text>program2 --verbose</text></literal>
+            </ref_role>
+        </paragraph>
+    </directive>
+</section></root>
+        """,
+        )

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -245,10 +245,10 @@ def split_domain(name: str) -> Tuple[str, str]:
     return parts[0], parts[1]
 
 
-def fast_deep_copy(d: Dict[_K, _T]) -> Dict[_K, _T]:
-    """Time-efficiently create deep copy of a dictionary containing trusted data.
+def fast_deep_copy(v: _T) -> _T:
+    """Time-efficiently create deep copy of trusted data.
        This implementation currently invokes pickle, so should NOT be called on untrusted objects."""
-    return {k: pickle.loads(pickle.dumps(v)) for k, v in d.items()}
+    return cast(_T, pickle.loads(pickle.dumps(v)))
 
 
 def make_html5_id(orig: str) -> str:


### PR DESCRIPTION
This PR also copies all included ASTs upon inclusion, correcting the previous behavior.

This adds roughly 1.5s to the postprocessor, which is small but significant and repeatable for that stage taken on its own.

```
Before:
parse rst      40.20
copy           3.14
postprocessing 10.31 <-- Here
commit         0.00
serialization  3.74

After:
parse rst      38.71
copy           2.88
postprocessing 11.84 <-- Here
commit         0.00
serialization  3.54
```