### PR TITLE
DOP-1523: Permit version admonitions to have no argument

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -762,14 +762,14 @@ class BaseCodeDirective(docutils.parsers.rst.Directive):
 
 
 class BaseVersionDirective(docutils.parsers.rst.Directive):
-    """Special handling for versionadded, versionchanged, and deprecated directives.
+    """Special handling for version change directives.
 
     These directives include one required argument and an optional argument on the next line.
     We need to ensure that these are both included in the `argument` field of the AST, and that
     subsequent indented directives are included as children of the node.
     """
 
-    required_arguments = 0
+    required_arguments = 1
     optional_arguments = 1
 
     def run(self) -> List[docutils.nodes.Node]:
@@ -780,7 +780,7 @@ class BaseVersionDirective(docutils.parsers.rst.Directive):
         node["options"] = self.options
 
         if self.arguments:
-            arguments = self.arguments[0].split(None, 1)
+            arguments = " ".join(self.arguments).split(None, 1)
             textnodes = []
             for argument_text in arguments:
                 text, messages = self.state.inline_text(argument_text, self.lineno)
@@ -796,6 +796,14 @@ class BaseVersionDirective(docutils.parsers.rst.Directive):
             )
 
         return [node]
+
+
+class DeprecatedVersionDirective(BaseVersionDirective):
+    """Variant of BaseVersionDirective for the deprecated directive, which does not
+       require an argument."""
+
+    required_arguments = 0
+    optional_arguments = 1
 
 
 class BaseTocTreeDirective(docutils.parsers.rst.Directive):
@@ -975,9 +983,9 @@ SPECIAL_DIRECTIVE_HANDLERS: Dict[str, Type[docutils.parsers.rst.Directive]] = {
     "code-block": BaseCodeDirective,
     "code": BaseCodeDirective,
     "sourcecode": BaseCodeDirective,
-    "deprecated": BaseVersionDirective,
     "versionadded": BaseVersionDirective,
     "versionchanged": BaseVersionDirective,
+    "deprecated": DeprecatedVersionDirective,
     "card-group": BaseCardGroupDirective,
     "toctree": BaseTocTreeDirective,
 }

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -769,7 +769,7 @@ class BaseVersionDirective(docutils.parsers.rst.Directive):
     subsequent indented directives are included as children of the node.
     """
 
-    required_arguments = 1
+    required_arguments = 0
     optional_arguments = 1
 
     def run(self) -> List[docutils.nodes.Node]:
@@ -779,9 +779,10 @@ class BaseVersionDirective(docutils.parsers.rst.Directive):
         node.source, node.line = source, line
         node["options"] = self.options
 
-        if self.arguments is not None:
+        if self.arguments:
+            arguments = self.arguments[0].split(None, 1)
             textnodes = []
-            for argument_text in self.arguments:
+            for argument_text in arguments:
                 text, messages = self.state.inline_text(argument_text, self.lineno)
                 textnodes.extend(text)
             argument = directive_argument("", "", *textnodes)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -466,6 +466,39 @@ def test_admonition() -> None:
     )
 
 
+def test_admonition_deprecated() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. deprecated:: v3.2
+
+   Content
+
+.. deprecated::
+
+   Content
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <directive name="deprecated"><text>v3.2</text>
+            <paragraph><text>Content</text></paragraph>
+        </directive>
+        <directive name="deprecated">
+            <paragraph><text>Content</text></paragraph>
+        </directive>
+        </root>""",
+    )
+
+
 def test_rst_replacement() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -466,6 +466,47 @@ def test_admonition() -> None:
     )
 
 
+def test_admonition_versionchanged() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. versionchanged:: v3.2
+
+   Content
+
+.. versionchanged:: v3.2
+   Content
+
+.. versionchanged:: v3.2
+
+.. versionchanged::
+
+   Content
+""",
+    )
+    page.finish(diagnostics)
+    assert [type(diag) for diag in diagnostics] == [DocUtilsParseError]
+    check_ast_testing_string(
+        page.ast,
+        """<root>
+        <directive name="versionchanged"><text>v3.2</text>
+            <paragraph><text>Content</text></paragraph>
+        </directive>
+
+        <directive name="versionchanged"><text>v3.2</text>
+            <text>Content</text>
+        </directive>
+
+        <directive name="versionchanged"><text>v3.2</text></directive>
+        </root>""",
+    )
+
+
 def test_admonition_deprecated() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")


### PR DESCRIPTION
This change scares me -- admonitions are a very gnarly and fragile part of docutils. We have a lot of test cases, but likely not every single situation a writer has ever come up with.