### PR TITLE
(DOCSP-12508): Centralize Realm extlink roles & custom directives

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1538,6 +1538,12 @@ help = """JSON Expression Expansion"""
 [rstobject."mongodb:json-operator"]
 help = """JSON Expression Operator"""
 
+[rstobject."mongodb:sync-client-message"]
+help = """Realm Sync Protocol Client->Server Request"""
+
+[rstobject."mongodb:sync-server-message"]
+help = """Realm Sync Protocol Server->Client Request"""
+
 [rstobject."mongodb:action"]
 help = """Service Actions"""
 prefix = "action"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1298,25 +1298,16 @@ type = {link = "http://source.wiredtiger.com/mongodb-3.4%s"}
 type = {link = "https://github.com/mongodb/specifications/blob/master/source%s"}
 
 [role."js-sdk"]
-type = {link = "https://docs.mongodb.com/stitch-sdks/js/4/%s"}
+type = {link = "https://docs.mongodb.com/realm-sdks/js/latest/%s"}
 
-[role."android-sdk"]
-type = {link = "https://docs.mongodb.com/stitch-sdks/java/4/%s"}
-
-[role."ios-sdk"]
-type = {link = "https://docs.mongodb.com/stitch-sdks/swift/6/%s"}
-
-[role."fb-dev-docs"]
-type = {link = "https://developers.facebook.com/docs/%s"}
+[role."facebook"]
+type = {link = "https://developers.facebook.com/%s"}
 
 [role."fcm"]
 type = {link = "https://firebase.google.com/docs/%s"}
 
-[role."google-dev"]
+[role."google"]
 type = {link = "https://developers.google.com/%s"}
-
-[role."google-android-ref"]
-type = {link = "https://developers.google.com/android/reference/com/google/android/gms/%s"}
 
 [role."github"]
 type = {link = "https://github.com/%s"}
@@ -1324,17 +1315,14 @@ type = {link = "https://github.com/%s"}
 [role."github-dev"]
 type = {link = "https://developer.github.com/%s"}
 
-[role."electricimp"]
-type = {link = "https://electricimp.com/%s"}
-
 [role."twilio"]
 type = {link = "https://www.twilio.com/%s"}
 
 [role."mdn"]
 type = {link = "https://developer.mozilla.org/en-US/docs/%s"}
 
-[role."apollo-docs"]
-type = {link = "https://www.apollographql.com/docs%s"}
+[role."apollo"]
+type = {link = "https://www.apollographql.com/%s"}
 
 [role."aws-docs"]
 type = {link = "https://docs.aws.amazon.com/%s"}
@@ -1346,7 +1334,7 @@ type = {link = "https://docs.aws.amazon.com/sdk-for-go/api/service/%s"}
 type = {link = "https://docs.aws.amazon.com/IAM/latest/%s"}
 
 [role."aws-reference"]
-type = {link = "https://docs.aws.amazon.com/general/latest/gr/%s"}
+type = {link = "https://docs.aws.amazon.com/general/latest/%s"}
 
 [role."reactjs"]
 type = {link = "https://reactjs.org/%s"}
@@ -1354,11 +1342,11 @@ type = {link = "https://reactjs.org/%s"}
 [role."jwt-io"]
 type = {link = "https://jwt.io/%s"}
 
-[role."android-dev"]
+[role."android"]
 type = {link = "https://developer.android.com/%s"}
 
-[role."apple-dev"]
-type = {link = "https://developer.apple.com/documentation/%s"}
+[role."apple"]
+type = {link = "https://developer.apple.com/%s"}
 
 ### Types of objects (directive & role pairs)
 [rstobject."py:class"]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1348,6 +1348,42 @@ type = {link = "https://developer.android.com/%s"}
 [role."apple"]
 type = {link = "https://developer.apple.com/%s"}
 
+[role."admin-api-endpoint"]
+type = {link = "https://docs.mongodb.com/realm/admin/api/v3/#%s"}
+
+[role."java-sdk"]
+type = {link = "https://docs.mongodb.com/realm-sdks/java/10.0.0-BETA.8/%s"}
+
+[role."kotlin-sdk"]
+type = {link = "https://docs.mongodb.com/realm-sdks/kotlin/10.0.0-BETA.8/%s"}
+
+[role."swift-sdk"]
+type = {link = "https://docs.mongodb.com/realm-sdks/swift/10.0.0-beta.5/%s"}
+
+[role."objc-sdk"]
+type = {link = "https://docs.mongodb.com/realm-sdks/objc/10.0.0-beta.5/%s"}
+
+[role."codesandbox"]
+type = {link = "https://codesandbox.io/%s"}
+
+[role."graphql"]
+type = {link = "https://graphql.org/%s"}
+
+[role."nodejs"]
+type = {link = "https://nodejs.org/%s"}
+
+[role."npm"]
+type = {link = "https://www.npmjs.com/%s"}
+
+[role."rubygems"]
+type = {link = "https://rubygems.org/%s"}
+
+[role."typescript"]
+type = {link = "https://www.typescriptlang.org/%s"}
+
+[role."node-driver"]
+type = {link = "https://mongodb.github.io/node-mongodb-native/3.6/api/%s"}
+
 ### Types of objects (directive & role pairs)
 [rstobject."py:class"]
 


### PR DESCRIPTION
This has a sibling PR that preps the Realm docs to match the updated config: https://github.com/mongodb/docs-realm/pull/491

## Jira

https://jira.mongodb.org/browse/DOCSP-12508

## Sources

- [mongodb_conf.py](https://github.com/mongodb/docs-tools/blob/master/sphinxext/mongodb_conf.py#L311)
- [conf.py](https://github.com/mongodb/docs-realm/blob/master/conf.py)