### PR TITLE
DOP-1570: Add simple "did you mean" feature

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -5,6 +5,13 @@ from .n import SerializableType
 from . import n
 
 
+class MakeCorrectionMixin:
+    def did_you_mean(self) -> List[str]:
+        """Suggest one or more possible corrections to the reStructuredText that this
+           diagnostic is about."""
+        raise NotImplementedError()
+
+
 class Diagnostic:
     def __init__(
         self,
@@ -333,23 +340,33 @@ class MissingTocTreeEntry(Diagnostic):
         self.entry = entry
 
 
-class IncorrectMonospaceSyntax(Diagnostic):
+class IncorrectMonospaceSyntax(Diagnostic, MakeCorrectionMixin):
     severity = Diagnostic.Level.warning
 
     def __init__(
         self,
+        text: str,
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__("Monospace text uses two backticks (``)", start, end)
+        self.text = text
+
+    def did_you_mean(self) -> List[str]:
+        return [f"``{self.text}``"]
 
 
-class IncorrectLinkSyntax(Diagnostic):
+class IncorrectLinkSyntax(Diagnostic, MakeCorrectionMixin):
     severity = Diagnostic.Level.error
 
     def __init__(
         self,
+        parts: Tuple[str, str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__("Malformed external link", start, end)
+        self.parts = parts
+
+    def did_you_mean(self) -> List[str]:
+        return [f"`{self.parts[0]} <{self.parts[1]}>`__"]

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -200,9 +200,11 @@ def handle_role_null(
     """Handle unnamed roles by raising a warning."""
     match = PAT_EXPLICIT_TITLE.match(text)
     if match:
-        diagnostic: Diagnostic = IncorrectLinkSyntax(lineno)
+        diagnostic: Diagnostic = IncorrectLinkSyntax(
+            (match.group(1), match.group(2)), lineno
+        )
     else:
-        diagnostic = IncorrectMonospaceSyntax(lineno)
+        diagnostic = IncorrectMonospaceSyntax(text, lineno)
 
     return (
         [docutils.nodes.literal(rawtext, text), snooty_diagnostic(diagnostic),],

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -13,6 +13,7 @@ from .diagnostics import (
     InvalidField,
     InvalidLiteralInclude,
     InvalidURL,
+    MakeCorrectionMixin,
     MalformedGlossary,
 )
 from .parser import parse_rst, JSONVisitor, InlineJSONVisitor
@@ -1958,8 +1959,10 @@ def test_malformed_monospace() -> None:
 
     page, diagnostics = parse_rst(parser, path, """`malformed syntax`""",)
     page.finish(diagnostics)
-    assert [type(d) for d in diagnostics] == [IncorrectMonospaceSyntax]
-    print(ast_to_testing_string(page.ast))
+    assert [
+        (type(d), d.did_you_mean() if isinstance(d, MakeCorrectionMixin) else "")
+        for d in diagnostics
+    ] == [(IncorrectMonospaceSyntax, ["``malformed syntax``"])]
     check_ast_testing_string(
         page.ast,
         """
@@ -1977,8 +1980,15 @@ def test_malformed_external_link() -> None:
         parser, path, """`Atlas Data Lake <https://docs.mongodb.com/datalake/>`"""
     )
     page.finish(diagnostics)
-    assert [type(d) for d in diagnostics] == [IncorrectLinkSyntax]
-    print(ast_to_testing_string(page.ast))
+    assert [
+        (type(d), d.did_you_mean() if isinstance(d, MakeCorrectionMixin) else "")
+        for d in diagnostics
+    ] == [
+        (
+            IncorrectLinkSyntax,
+            ["`Atlas Data Lake <https://docs.mongodb.com/datalake/>`__"],
+        )
+    ]
     check_ast_testing_string(
         page.ast,
         """


### PR DESCRIPTION
Example output:

```
ERROR(includes/glossary-terms.rst:9ish): Malformed external link
    Did you mean: `Atlas Data Lake <https://docs.mongodb.com/datalake/>`__
```