### PR TITLE
DOP-1589: Support required arguments

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -998,10 +998,24 @@ def make_docutils_directive_handler(
     name: str,
     options: Dict[str, object],
 ) -> Type[docutils.parsers.rst.Directive]:
+    optional_args = 0
+    required_args = 0
+
+    argument_type = directive.argument_type
+    if argument_type:
+        if (
+            isinstance(argument_type, specparser.DirectiveOption)
+            and argument_type.required
+        ):
+            required_args = 1
+        else:
+            optional_args = 1
+
     class DocutilsDirective(base_class):  # type: ignore
         directive_spec = directive
         has_content = bool(directive.content_type)
-        optional_arguments = 1 if directive.argument_type else 0
+        optional_arguments = optional_args
+        required_arguments = required_args
         final_argument_whitespace = True
         option_spec = options
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -127,7 +127,7 @@ example = """.. versionadded:: ${1:v1.0}
 [directive.deprecated]
 argument_type = {type = "string", required = false}
 content_type = "block"
-example = """.. deprecated:: ${1:v1.0}
+example = """.. deprecated:: ${1:v1.0 (Optional)}
    ${2:Explanation to inform the reader what should be used instead. Explanation is optional.}
 """
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -109,21 +109,23 @@ example = """.. tip:: ${1:Title}
    ${2:Tip content}
 """
 
-[directive.versionchanged]
-argument_type = "string"
+[directive._baseversiondirective]
+argument_type = {type = "string", required = true}
 content_type = "block"
+
+[directive.versionchanged]
+inherit = "_baseversiondirective"
 example = """.. versionchanged:: ${1:v1.0}
    ${2:Describe what changed in that version. Description is optional.}
 """
 
 [directive.versionadded]
-argument_type = "string"
-content_type = "block"
+inherit = "_baseversiondirective"
 example = """.. versionadded:: ${1:v1.0}
    ${2:Describe what was added in that version. Description is optional.}
 """
 [directive.deprecated]
-argument_type = "string"
+argument_type = {type = "string", required = false}
 content_type = "block"
 example = """.. deprecated:: ${1:v1.0}
    ${2:Explanation to inform the reader what should be used instead. Explanation is optional.}

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -156,7 +156,7 @@ class Directive:
     help: Optional[str]
     example: Optional[str]
     content_type: Optional[StringOrStringlist]
-    argument_type: ArgumentType
+    argument_type: Union[DirectiveOption, ArgumentType]
     required_context: Optional[str]
     domain: Optional[str]
     deprecated: bool = field(default=False)
@@ -227,7 +227,7 @@ class RstObject:
             help=self.help,
             example=None,
             content_type="block",
-            argument_type="string",
+            argument_type=DirectiveOption(type="string", required=True),
             required_context=None,
             domain=self.domain,
             deprecated=self.deprecated,

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1705,6 +1705,24 @@ def test_callable_target() -> None:
 </root>""",
     )
 
+    # Ensure that a missing argument doesn't crash
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. method::
+
+   Creates an index.
+""",
+    )
+    page.finish(diagnostics)
+    assert [type(diag) for diag in diagnostics] == [DocUtilsParseError]
+    check_ast_testing_string(
+        page.ast,
+        """
+<root></root>""",
+    )
+
 
 def test_no_weird_targets() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))


### PR DESCRIPTION
Make rstobject directive arguments required. Currently, the parser crashes if no argument is passed to a callable rstobject.