### PR TITLE
DOP-1450: define and formally support tabs in rstspec.toml

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -350,7 +350,7 @@ class UnknownTabset(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"""Tabset "{tabset} is not defined in rstspec.toml", start, end,"""
+            f"""Tabset "{tabset}"" is not defined in rstspec.toml""", start, end
         )
         self.tabset = tabset
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -350,7 +350,7 @@ class UnknownTabset(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"""Tabset "{tabset}"" is not defined in rstspec.toml""", start, end
+            f"""Tabset "{tabset}" is not defined in rstspec.toml""", start, end
         )
         self.tabset = tabset
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -340,6 +340,21 @@ class MissingTocTreeEntry(Diagnostic):
         self.entry = entry
 
 
+class UnknownTabset(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        tabset: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"tabset {tabset} is not defined in rstspec.toml", start, end,
+        )
+        self.tabset = tabset
+
+
 class UnknownTabID(Diagnostic):
     severity = Diagnostic.Level.error
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -386,7 +386,9 @@ class TabMustBeDirective(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"Tabs must be directives. This tab is of type {tab_type}", start, end
+            f"Tab sets may only contain tab directives, but found {tab_type}",
+            start,
+            end,
         )
         self.tab_type = tab_type
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -340,6 +340,42 @@ class MissingTocTreeEntry(Diagnostic):
         self.entry = entry
 
 
+class UnknownTabID(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        tabid: str,
+        tabset: str,
+        reason: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"tab id {tabid} given in {tabset} tabset is unrecognized: {reason}",
+            start,
+            end,
+        )
+        self.tabid = tabid
+        self.tabset = tabset
+        self.reason = reason
+
+
+class TabMustBeDirective(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        tab_type: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"Tabs must be directives. This tab is of type {tab_type}", start, end
+        )
+        self.tab_type = tab_type
+
+
 class IncorrectMonospaceSyntax(Diagnostic, MakeCorrectionMixin):
     severity = Diagnostic.Level.warning
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -350,7 +350,7 @@ class UnknownTabset(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"tabset {tabset} is not defined in rstspec.toml", start, end,
+            f"""Tabset "{tabset} is not defined in rstspec.toml", start, end,"""
         )
         self.tabset = tabset
 
@@ -367,7 +367,7 @@ class UnknownTabID(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"tab id {tabid} given in {tabset} tabset is unrecognized: {reason}",
+            f"""tab id "{tabid}" given in "{tabset}" tabset is unrecognized: {reason}""",
             start,
             end,
         )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -60,6 +60,7 @@ from .diagnostics import (
     InvalidTableStructure,
     MalformedGlossary,
     InvalidField,
+    UnknownTabset,
     UnknownTabID,
     TabMustBeDirective,
 )
@@ -440,11 +441,16 @@ class JSONVisitor:
     def handle_tabset(self, node: n.Directive, line: int) -> None:
         tabset = node.options["tabset"]
         # retrieve dictionary associated with this specific tabset
+        if tabset not in specparser.SPEC.tabs:
+            self.diagnostics.append(UnknownTabset(tabset, line))
+            print("unknown tabset!! ")
+            return
+
         tab_definitions_list = specparser.SPEC.tabs[tabset]
         tabid_list: List[str] = []
 
         for idx, child in enumerate(node.children):
-            if not isinstance(child, n.Directive):
+            if not isinstance(child, n.Directive) or child.name != "tab":
                 self.diagnostics.append(
                     TabMustBeDirective(str(type(child).__class__.__name__), line)
                 )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -22,6 +22,7 @@ from typing import (
     Set,
     List,
     Iterable,
+    cast,
 )
 from typing_extensions import Protocol
 import docutils.utils
@@ -480,8 +481,10 @@ class JSONVisitor:
                 )
                 return
 
-        if isinstance(node.children, List):
-            node.children.sort(key=lambda x: tabid_list.index(x.options["tabid"]))
+        node.children = sorted(
+            node.children,
+            key=lambda x: tabid_list.index(cast(n.Directive, x).options["tabid"]),
+        )
 
     def handle_directive(
         self, node: docutils.nodes.Node, line: int

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -478,7 +478,6 @@ class JSONVisitor:
                         line,
                     )
                 )
-                print("its unknown we are returning!")
                 return
 
         if isinstance(node.children, List):

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -999,7 +999,8 @@ def make_docutils_directive_handler(
     base_class: Type[docutils.parsers.rst.Directive],
     name: str,
     options: Dict[str, object],
-) -> Type[docutils.parsers.rst.Directive]:    optional_args = 0
+) -> Type[docutils.parsers.rst.Directive]:
+    optional_args = 0
     required_args = 0
 
     argument_type = directive.argument_type
@@ -1011,7 +1012,7 @@ def make_docutils_directive_handler(
             required_args = 1
         else:
             optional_args = 1
-            
+ 
     class DocutilsDirective(base_class):  # type: ignore
         directive_spec = directive
         has_content = bool(directive.content_type)

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -58,6 +58,7 @@ PAT_WHITESPACE = re.compile(r"^\x20*")
 PAT_BLOCK_HAS_ARGUMENT = re.compile(r"^\x20*\.\.\x20[^\s]+::\s*\S+")
 PAT_OPTION = re.compile(r"((?:/|--|-|\+)?[^\s=]+)(=?\s*.*)")
 PAT_ISO_8601 = re.compile(r"^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])$")
+PAT_PARAMETERS = re.compile(r"\s*\(.*?\)\s*$")
 
 #: Hard-coded sequence of domains in which to search for a directives
 #: and roles if no domain is explicitly provided.. Eventually this should
@@ -998,7 +999,19 @@ def make_docutils_directive_handler(
     base_class: Type[docutils.parsers.rst.Directive],
     name: str,
     options: Dict[str, object],
-) -> Type[docutils.parsers.rst.Directive]:
+) -> Type[docutils.parsers.rst.Directive]:    optional_args = 0
+    required_args = 0
+
+    argument_type = directive.argument_type
+    if argument_type:
+        if (
+            isinstance(argument_type, specparser.DirectiveOption)
+            and argument_type.required
+        ):
+            required_args = 1
+        else:
+            optional_args = 1
+            
     class DocutilsDirective(base_class):  # type: ignore
         directive_spec = directive
         has_content = bool(directive.content_type)
@@ -1046,7 +1059,7 @@ def register_spec_with_docutils(
         }
 
         base_class: Any = BaseDocutilsDirective
-        
+
         # Tabs have special handling because of the need to support legacy syntax
         if name == "tabs" or name.startswith("tabs-"):
             base_class = BaseTabsDirective

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -92,10 +92,11 @@ def parse_explicit_title(text: str) -> Tuple[str, Optional[str]]:
 def strip_parameters(target: str) -> str:
     """Remove trailing ALGOL-style parameters from a target name;
        e.g. foo(bar, baz) -> foo."""
-    if not target.endswith(")"):
+    match = PAT_PARAMETERS.search(target)
+    if not match:
         return target
 
-    starting_index = target.rfind("(")
+    starting_index = match.start()
     if starting_index == -1:
         return target
 
@@ -1003,7 +1004,6 @@ def make_docutils_directive_handler(
         has_content = bool(directive.content_type)
         optional_arguments = optional_args
         required_arguments = required_args
-        required_arguments = required_args
         final_argument_whitespace = True
         option_spec = options
 
@@ -1046,6 +1046,7 @@ def register_spec_with_docutils(
         }
 
         base_class: Any = BaseDocutilsDirective
+        
         # Tabs have special handling because of the need to support legacy syntax
         if name == "tabs" or name.startswith("tabs-"):
             base_class = BaseTabsDirective

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -1077,7 +1077,7 @@ def register_spec_with_docutils(
         tabs_base_class: Any = BaseTabsDirective
         directive = specparser.Directive(
             inherit=None,
-            help="help with tabset",
+            help=None,
             example=None,
             content_type="block",
             argument_type=None,

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -1012,7 +1012,7 @@ def make_docutils_directive_handler(
             required_args = 1
         else:
             optional_args = 1
- 
+
     class DocutilsDirective(base_class):  # type: ignore
         directive_spec = directive
         has_content = bool(directive.content_type)

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -1062,7 +1062,7 @@ def register_spec_with_docutils(
         base_class: Any = BaseDocutilsDirective
 
         # Tabs have special handling because of the need to support legacy syntax
-        if name == "tabs" or name.startswith("tabs-"):
+        if name == "tabs":
             base_class = BaseTabsDirective
         elif name in SPECIAL_DIRECTIVE_HANDLERS:
             base_class = SPECIAL_DIRECTIVE_HANDLERS[name]
@@ -1074,6 +1074,7 @@ def register_spec_with_docutils(
 
     # Define tabsets
     for name in spec.tabs:
+        tabs_name = "tabs-" + name
         tabs_base_class: Any = BaseTabsDirective
         directive = specparser.Directive(
             inherit=None,
@@ -1083,7 +1084,7 @@ def register_spec_with_docutils(
             argument_type=None,
             required_context=None,
             domain=None,
-            name=name,
+            name=tabs_name,
             options={"tabid": specparser.PrimitiveType.string},
         )
 
@@ -1096,7 +1097,7 @@ def register_spec_with_docutils(
             directive, tabs_base_class, "tabs", tabs_options
         )
 
-        builder.add_directive(name, DocutilsDirective)
+        builder.add_directive(tabs_name, DocutilsDirective)
 
     # Docutils builtins
     builder.add_directive("unicode", docutils.parsers.rst.directives.misc.Unicode)

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -109,25 +109,23 @@ example = """.. tip:: ${1:Title}
    ${2:Tip content}
 """
 
-[directive._baseversiondirective]
-argument_type = {type = "string", required = true}
-content_type = "block"
-
 [directive.versionchanged]
-inherit = "_baseversiondirective"
+argument_type = "string"
+content_type = "block"
 example = """.. versionchanged:: ${1:v1.0}
    ${2:Describe what changed in that version. Description is optional.}
 """
 
 [directive.versionadded]
-inherit = "_baseversiondirective"
+argument_type = "string"
+content_type = "block"
 example = """.. versionadded:: ${1:v1.0}
    ${2:Describe what was added in that version. Description is optional.}
 """
 [directive.deprecated]
-argument_type = {type = "string", required = false}
+argument_type = "string"
 content_type = "block"
-example = """.. deprecated:: ${1:v1.0 (Optional)}
+example = """.. deprecated:: ${1:v1.0}
    ${2:Explanation to inform the reader what should be used instead. Explanation is optional.}
 """
 
@@ -371,6 +369,7 @@ inherit = "tabs"
 
 [directive.tabs-realm-auth-providers]
 inherit = "tabs"
+
 
 [directive.tab]
 argument_type = "string"
@@ -1564,3 +1563,106 @@ prefix = "opsmgrkube"
 [rstobject."mongodb:autoencryptkeyword"]
 help = "Automatic Client-Side Field Level Encrytion Rules Keyword"
 prefix = "autoencryptkeyword"
+
+[tabs]
+cloudproviders = [
+  {id = "aws", title = "AWS"},
+  {id = "azure", title = "Azure"},
+  {id = "gcp", title = "GCP"},
+]
+k8sorchestrator = [
+  {id = "k8s", title = "Kubernetes"},
+  {id = "openshift", title = "OpenShift"},
+]
+cloud = [
+  {id = "cloud", title = "Cloud (Atlas)"},
+  {id = "local", title = "Local Instance"},
+]
+platforms = [
+  {id = "windows", title = "Windows"},
+  {id = "macos", title = "macOS"},
+  {id = "debian", title = "Ubuntu/Debian"},
+  {id = "rhel", title = "RHEL/CentOS/SLES/AMZ"},
+  {id = "linux", title = "Linux"},
+]
+drivers = [
+  {id = "shell", title = "Mongo Shell"},
+  {id = "compass", title = "Compass"},
+  {id = "python", title = "Python"},
+  {id = "java-sync", title = "Java (Sync)"},
+  {id = "nodejs", title = "Node.js"},
+  {id = "php", title = "PHP"},
+  {id = "motor", title = "Motor"},
+  {id = "java-async", title = "Java (Async)"},
+  {id = "c", title = "C"},
+  {id = "cpp", title = "C++11"},
+  {id = "csharp", title = "C#"},
+  {id = "perl", title = "Perl"},
+  {id = "ruby", title = "Ruby"},
+  {id = "scala", title = "Scala"},
+  {id = "go", title = "Go"},
+  {id = "swift-sync", title = "Swift (Sync)"},
+  {id = "swift-async", title = "Swift (Async)"},
+]
+auth = [
+  {id = "uidpwd", title = "Username and Password"},
+  {id = "ldap", title = "LDAP"},
+  {id = "kerberos", title = "Kerberos"},
+]
+stitch-auth-providers = [
+  {id = "anon-user", title = "Anonymous"},
+  {id = "local-userpass", title = "Email/Password"},
+  {id = "oauth2-google", title = "Google"},
+  {id = "oauth2-facebook", title = "Facebook"},
+  {id = "api-key", title = "API Key Authentication"},
+  {id = "custom-token", title = "Custom"},
+]
+deployments = [
+  {id = "standalone", title = "Standalone"},
+  {id = "repl", title = "Replica Set"},
+  {id = "shard", title = "Sharded Cluster"},
+]
+stitch-sdks = [
+  {id = "functions", title = "afaunctions"},
+  {id = "json-expressions", title = "Json Expressions"},
+  {id = "javascript", title = "JavaScript SDK"},
+  {id = "android", title = "Android SDK"},
+  {id = "ios", title = "iOS SDK"},
+]
+stitch-interfaces = [
+  {id = "stitch-ui", title = "Stitch UI"},
+  {id = "import-export", title = "Import/Export"},
+]
+realm-languages = [
+  {id = "swift", title = "Swift"},
+  {id = "kotlin", title = "Kotlin"},
+  {id = "typescript", title = "TypeScript"},
+  {id = "java", title = "Java"},
+  {id = "objective-c", title = "Objective C"},
+  {id = "javascript", title = "JavaScript"},
+  {id = "c-sharp", title = "C#"},
+]
+realm-sdks = [
+  {id = "functions", title = "Functions"},
+  {id = "json-expressions", title = "JSON Expressions"},
+  {id = "graphql", title = "GraphQL"},
+  {id = "ios", title = "iOS SDK"},
+  {id = "android", title = "Android SDK"},
+  {id = "dotnet", title = ".NET SDK"},
+  {id = "xamarin", title = "Xamarin SDK"},
+  {id = "javascript", title = "JavaScript SDKs"},
+  {id = "node", title = "Node.js SDK"},
+  {id = "react-native", title = "React Native SDK"},
+]
+realm-admin-interfaces = [
+  {id = "ui", title = "Realm UI"},
+  {id = "cli", title = "Realm CLI"},
+  {id = "api", title = "Admin API"},
+  {id = "github", title = "GitHub Deploy"},
+  {id = "code-deploy", title = "Code Deploy"},
+]
+realm-auth-providers = [
+  {id = "aws", title = "AWS"},
+  {id = "azure", title = "Azure"},
+  {id = "gcp", title = "GCP"},
+]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1565,12 +1565,12 @@ help = "Automatic Client-Side Field Level Encrytion Rules Keyword"
 prefix = "autoencryptkeyword"
 
 [tabs]
-cloudproviders = [
+cloud-providers = [
   {id = "aws", title = "AWS"},
   {id = "azure", title = "Azure"},
   {id = "gcp", title = "GCP"},
 ]
-k8sorchestrator = [
+k8s-orchestrator = [
   {id = "k8s", title = "Kubernetes"},
   {id = "openshift", title = "OpenShift"},
 ]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -109,23 +109,25 @@ example = """.. tip:: ${1:Title}
    ${2:Tip content}
 """
 
-[directive.versionchanged]
-argument_type = "string"
+[directive._baseversiondirective]
+argument_type = {type = "string", required = true}
 content_type = "block"
+
+[directive.versionchanged]
+inherit = "_baseversiondirective"
 example = """.. versionchanged:: ${1:v1.0}
    ${2:Describe what changed in that version. Description is optional.}
 """
 
 [directive.versionadded]
-argument_type = "string"
-content_type = "block"
+inherit = "_baseversiondirective"
 example = """.. versionadded:: ${1:v1.0}
    ${2:Describe what was added in that version. Description is optional.}
 """
 [directive.deprecated]
-argument_type = "string"
+argument_type = {type = "string", required = false}
 content_type = "block"
-example = """.. deprecated:: ${1:v1.0}
+example = """.. deprecated:: ${1:v1.0 (Optional)}
    ${2:Explanation to inform the reader what should be used instead. Explanation is optional.}
 """
 
@@ -369,7 +371,6 @@ inherit = "tabs"
 
 [directive.tabs-realm-auth-providers]
 inherit = "tabs"
-
 
 [directive.tab]
 argument_type = "string"
@@ -1665,8 +1666,4 @@ realm-auth-providers = [
   {id = "aws", title = "AWS"},
   {id = "azure", title = "Azure"},
   {id = "gcp", title = "GCP"},
-<<<<<<< HEAD
 ]
-=======
-]
->>>>>>> ad75cb9a812eb37d65cced2eb73e51507b3f18fb

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -149,6 +149,15 @@ class DirectiveOption:
 
 @checked
 @dataclass
+class TabDefinition:
+    """a docstring"""
+
+    id: str
+    title: str
+
+
+@checked
+@dataclass
 class Directive:
     """Declaration of a reStructuredText directive (block content)."""
 
@@ -156,7 +165,7 @@ class Directive:
     help: Optional[str]
     example: Optional[str]
     content_type: Optional[StringOrStringlist]
-    argument_type: Union[DirectiveOption, ArgumentType]
+    argument_type: ArgumentType
     required_context: Optional[str]
     domain: Optional[str]
     deprecated: bool = field(default=False)
@@ -221,13 +230,29 @@ class RstObject:
         default_factory=lambda: {FormattingType.monospace}
     )
 
+    def directive(self) -> Directive:
+        return Directive(
+            inherit=None,
+            help=self.help,
+            example=None,
+            content_type="block",
+            argument_type="string",
+            required_context=None,
+            domain=self.domain,
+            deprecated=self.deprecated,
+            options={},
+            fields=[],
+            name=self.name,
+            rstobject=self,
+        )
+
     def create_directive(self) -> Directive:
         return Directive(
             inherit=None,
             help=self.help,
             example=None,
             content_type="block",
-            argument_type=DirectiveOption(type="string", required=True),
+            argument_type="string",
             required_context=None,
             domain=self.domain,
             deprecated=self.deprecated,
@@ -260,6 +285,7 @@ class Spec:
     directive: Dict[str, Directive] = field(default_factory=dict)
     role: Dict[str, Role] = field(default_factory=dict)
     rstobject: Dict[str, RstObject] = field(default_factory=dict)
+    tabs: Dict[str, List[TabDefinition]] = field(default_factory=dict)
 
     @classmethod
     def loads(cls, data: str) -> "Spec":
@@ -300,6 +326,7 @@ class Spec:
     ) -> Callable[[str], object]:
         """Return a validation function for a given argument type. This function will take in a
            string, and either throw an exception or return an output value."""
+
         if isinstance(option_spec, DirectiveOption):
             option_spec = option_spec.type
 

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -252,7 +252,7 @@ class RstObject:
             help=self.help,
             example=None,
             content_type="block",
-            argument_type="string",
+            argument_type=DirectiveOption(type="string", required=True),
             required_context=None,
             domain=self.domain,
             deprecated=self.deprecated,
@@ -326,7 +326,6 @@ class Spec:
     ) -> Callable[[str], object]:
         """Return a validation function for a given argument type. This function will take in a
            string, and either throw an exception or return an output value."""
-
         if isinstance(option_spec, DirectiveOption):
             option_spec = option_spec.type
 

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -150,8 +150,6 @@ class DirectiveOption:
 @checked
 @dataclass
 class TabDefinition:
-    """a docstring"""
-
     id: str
     title: str
 

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -165,7 +165,7 @@ class Directive:
     help: Optional[str]
     example: Optional[str]
     content_type: Optional[StringOrStringlist]
-    argument_type: ArgumentType
+    argument_type: Union[DirectiveOption, ArgumentType]
     required_context: Optional[str]
     domain: Optional[str]
     deprecated: bool = field(default=False)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1690,7 +1690,7 @@ def test_callable_target() -> None:
         parser,
         path,
         """
-.. method:: db.collection.ensureIndex(keys, options)
+.. method:: db.collection.ensureIndex (keys, options)
 
    Creates an index on the specified field if the index does not already exist.
 
@@ -1705,7 +1705,7 @@ def test_callable_target() -> None:
         """
 <root>
     <target domain="mongodb" name="method">
-    <directive_argument><literal><text>db.collection.ensureIndex(keys, options)</text></literal></directive_argument>
+    <directive_argument><literal><text>db.collection.ensureIndex (keys, options)</text></literal></directive_argument>
     <target_identifier ids="['db.collection.ensureIndex']"><text>db.collection.ensureIndex()</text></target_identifier>
     <paragraph>
     <text>Creates an index on the specified field if the index does not already exist.</text>
@@ -1722,6 +1722,22 @@ def test_callable_target() -> None:
 </root>""",
     )
 
+    # Ensure that a missing argument doesn't crash
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. method::
+   Creates an index.
+""",
+    )
+    page.finish(diagnostics)
+    assert [type(diag) for diag in diagnostics] == [DocUtilsParseError]
+    check_ast_testing_string(
+        page.ast,
+        """
+<root></root>""",
+    )
 
 def test_no_weird_targets() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1728,6 +1728,7 @@ def test_callable_target() -> None:
         path,
         """
 .. method::
+
    Creates an index.
 """,
     )
@@ -1738,6 +1739,7 @@ def test_callable_target() -> None:
         """
 <root></root>""",
     )
+
 
 def test_no_weird_targets() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -16,6 +16,7 @@ from .diagnostics import (
     MakeCorrectionMixin,
     MalformedGlossary,
     UnknownTabID,
+    UnknownTabset,
 )
 from .parser import parse_rst, JSONVisitor, InlineJSONVisitor
 
@@ -65,6 +66,12 @@ def test_tabs() -> None:
             <paragraph><text>Windows Content</text></paragraph>
             </directive>
         </directive>
+    
+        <directive name="tabs" tabset="platfors">
+            <directive name="tab" tabid="linux">
+            <paragraph><text>Linux Content</text></paragraph>
+            </directive>
+        </directive>
 
         <directive name="tabs" hidden="True"><directive name="tab" tabid="trusty">
         <text>Ubuntu 14.04 (Trusty)</text><paragraph><text>
@@ -75,7 +82,8 @@ def test_tabs() -> None:
     )
 
     assert isinstance(diagnostics[0], UnknownTabID)
-    assert isinstance(diagnostics[1], DocUtilsParseError)
+    assert isinstance(diagnostics[1], UnknownTabset)
+    assert isinstance(diagnostics[2], DocUtilsParseError)
 
 
 def test_tabs_invalid_yaml() -> None:

--- a/snooty/util_test.py
+++ b/snooty/util_test.py
@@ -67,11 +67,7 @@ def ast_to_testing_string(ast: Any) -> str:
             + "</term>"
             + contents
         )
-    print(
-        "<{}{}>{}</{}>".format(
-            ast["type"], " " + attrs if attrs else "", contents, ast["type"]
-        )
-    )
+        
     return "<{}{}>{}</{}>".format(
         ast["type"], " " + attrs if attrs else "", contents, ast["type"]
     )

--- a/snooty/util_test.py
+++ b/snooty/util_test.py
@@ -67,7 +67,11 @@ def ast_to_testing_string(ast: Any) -> str:
             + "</term>"
             + contents
         )
-
+    print(
+        "<{}{}>{}</{}>".format(
+            ast["type"], " " + attrs if attrs else "", contents, ast["type"]
+        )
+    )
     return "<{}{}>{}</{}>".format(
         ast["type"], " " + attrs if attrs else "", contents, ast["type"]
     )

--- a/snooty/util_test.py
+++ b/snooty/util_test.py
@@ -67,6 +67,7 @@ def ast_to_testing_string(ast: Any) -> str:
             + "</term>"
             + contents
         )
+
     return "<{}{}>{}</{}>".format(
         ast["type"], " " + attrs if attrs else "", contents, ast["type"]
     )

--- a/test_data/test_tabs.rst
+++ b/test_data/test_tabs.rst
@@ -20,6 +20,7 @@
 
            Trusty content
 
+
 .. tabs-platforms::
 
    tabs:
@@ -27,6 +28,7 @@
         content: |
 
            Windows content
+           
 
 .. tabs::
    :tabset: platforms
@@ -34,14 +36,27 @@
    .. tab::
       :tabid: windows
 
-      Windows content
-
-.. tabs-platforms::
+      Windows Content
 
    .. tab::
-      :tabid: windows
+      :tabid: linux
 
-      Windows content
+      Linux Content 
+
+   .. tab::
+      :tabid: macos
+
+      macOS Content 
+
+
+.. tabs::
+   :tabset: platforms
+
+   .. tab::
+      :tabid: bobs_your_uncle
+
+      Windows Content
+
 
 .. tabs::
    :hidden: true

--- a/test_data/test_tabs.rst
+++ b/test_data/test_tabs.rst
@@ -20,6 +20,7 @@
 
            Trusty content
 
+
 .. tabs-platforms::
 
    tabs:
@@ -54,6 +55,14 @@
       :tabid: bobs_your_uncle
 
       Windows Content
+
+.. tabs::
+   :tabset: platfors
+
+   .. tab::
+      :tabid: linux
+
+      Linux Content
 
 
 .. tabs::


### PR DESCRIPTION
relevant ticket: https://jira.mongodb.org/browse/DOP-1450


The changes included in the PR are: 

1. adding tabset definitions in `rstspec.toml`
2. register these directives with `docutils` in `rstparser.py`
3. if an unknown tabset is given, raise a diagnostic in `handle_tabset` in `parser.py` 
4. add the appropriate title (via adding a <directive_argument> to named tabs in `handle_tabset`
5. If an unknown tab ID is given, raise a diagnostic in `handle_tabset`
6. finally, sort tabs according to their order in the tab definition in `handle_tabset`
