### PR TITLE
DOP-1581: extlinks should use target for label if no label set *not* the uri

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -54,6 +54,7 @@ RoleHandlerType = Callable[
 PAT_EXPLICIT_TITLE = re.compile(
     r"^(?P<label>.*?)\s*(?<!\x00)<(?P<target>.*?)>$", re.DOTALL
 )
+PAT_ROLE_NAME = re.compile(r"^:[a-zA-Z]*:")
 PAT_WHITESPACE = re.compile(r"^\x20*")
 PAT_BLOCK_HAS_ARGUMENT = re.compile(r"^\x20*\.\.\x20[^\s]+::\s*\S+")
 PAT_OPTION = re.compile(r"((?:/|--|-|\+)?[^\s=]+)(=?\s*.*)")
@@ -88,6 +89,16 @@ def parse_explicit_title(text: str) -> Tuple[str, Optional[str]]:
         return unescape(match["target"]), unescape(match["label"])
 
     return (unescape(text), None)
+
+
+def parse_role(rawtext: str) -> str:
+
+    match = PAT_ROLE_NAME.match(rawtext)
+
+    if match:
+        return match.group()
+
+    return ""
 
 
 def strip_parameters(target: str) -> str:
@@ -373,10 +384,14 @@ class LinkRoleHandler:
         content: List[object] = [],
     ) -> Tuple[List[docutils.nodes.Node], List[docutils.nodes.Node]]:
         target, label = parse_explicit_title(text)
+        role = parse_role(rawtext)
+
+        if role == ":rfc:" and not label:
+            label = "".join(["RFC-", target])
 
         url = self.url_template % target
         if not label:
-            label = url
+            label = target
         node: docutils.nodes.Node = docutils.nodes.reference(
             label, label, internal=False, refuri=url
         )

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -54,7 +54,6 @@ RoleHandlerType = Callable[
 PAT_EXPLICIT_TITLE = re.compile(
     r"^(?P<label>.*?)\s*(?<!\x00)<(?P<target>.*?)>$", re.DOTALL
 )
-PAT_ROLE_NAME = re.compile(r"^:[a-zA-Z]*:")
 PAT_WHITESPACE = re.compile(r"^\x20*")
 PAT_BLOCK_HAS_ARGUMENT = re.compile(r"^\x20*\.\.\x20[^\s]+::\s*\S+")
 PAT_OPTION = re.compile(r"((?:/|--|-|\+)?[^\s=]+)(=?\s*.*)")
@@ -89,16 +88,6 @@ def parse_explicit_title(text: str) -> Tuple[str, Optional[str]]:
         return unescape(match["target"]), unescape(match["label"])
 
     return (unescape(text), None)
-
-
-def parse_role(rawtext: str) -> str:
-
-    match = PAT_ROLE_NAME.match(rawtext)
-
-    if match:
-        return match.group()
-
-    return ""
 
 
 def strip_parameters(target: str) -> str:
@@ -384,9 +373,8 @@ class LinkRoleHandler:
         content: List[object] = [],
     ) -> Tuple[List[docutils.nodes.Node], List[docutils.nodes.Node]]:
         target, label = parse_explicit_title(text)
-        role = parse_role(rawtext)
 
-        if role == ":rfc:" and not label:
+        if typ == "rfc" and not label:
             label = "".join(["RFC-", target])
 
         url = self.url_template % target

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -663,6 +663,8 @@ def test_roles() -> None:
 * :manual:`Introduction to MongoDB </introduction/>`
 * :rfc:`1149`
 * :rfc:`RFC-1149 <1149>`
+* :issue:`TOOLS-2456`
+* :issue:`this jira issue <TOOLS-2456>`
 * :binary:`~bin.mongod`
 * :binary:`mongod <~bin.mongod>`
 * :guilabel:`Test <foo>`
@@ -682,7 +684,7 @@ def test_roles() -> None:
             <listItem>
             <paragraph>
             <reference refuri="https://docs.mongodb.com/manual/introduction/">
-            <text>https://docs.mongodb.com/manual/introduction/</text>
+            <text>/introduction/</text>
             </reference>
             </paragraph>
             </listItem>
@@ -693,12 +695,22 @@ def test_roles() -> None:
             </listItem>
             <listItem>
             <paragraph>
-            <reference refuri="https://tools.ietf.org/html/1149"><text>https://tools.ietf.org/html/1149</text></reference>
+            <reference refuri="https://tools.ietf.org/html/1149"><text>RFC-1149</text></reference>
             </paragraph>
             </listItem>
             <listItem>
             <paragraph>
             <reference refuri="https://tools.ietf.org/html/1149"><text>RFC-1149</text></reference>
+            </paragraph>
+            </listItem>
+            <listItem>
+            <paragraph>
+            <reference refuri="https://jira.mongodb.org/browse/TOOLS-2456"><text>TOOLS-2456</text></reference>
+            </paragraph>
+            </listItem>
+            <listItem>
+            <paragraph>
+            <reference refuri="https://jira.mongodb.org/browse/TOOLS-2456"><text>this jira issue</text></reference>
             </paragraph>
             </listItem>
             <listItem>


### PR DESCRIPTION
Jira link: https://jira.mongodb.org/browse/DOP-1581

- extlinks will use the 'target' for the label if no label is set

- handles special case for `:rfc:`, where we'd ideally like the label to be `RFC-123465` rather than just `123465`. This brings parity to sphinx's built-in rfc role and will generally behave the way writers expect it to.



It is entirely possible that there's an easier way to know what role we're parsing, but I couldn't figure it out, so this was my solution 😁 