### PR TITLE
DOP-1632: Fix tab sort

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -446,7 +446,6 @@ class JSONVisitor:
         except KeyError:
             self.diagnostics.append(UnknownTabset(tabset, line))
             return
-        tabid_list: List[str] = []
 
         for idx, child in enumerate(node.children):
             if (not isinstance(child, n.Directive)) or child.name != "tab":
@@ -473,7 +472,6 @@ class JSONVisitor:
                 if entry.id == tabid:
                     child.argument = [n.Text((line,), entry.title)]
                     unknown_tabid = False
-                    tabid_list.insert(t_idx, tabid)
 
             if unknown_tabid:
                 self.diagnostics.append(
@@ -486,6 +484,8 @@ class JSONVisitor:
                 )
                 return
 
+        # Sort tab directives based on order defined in rstspec.toml
+        tabid_list = [tab.id for tab in tab_definitions_list]
         node.children = sorted(
             node.children,
             key=lambda x: tabid_list.index(cast(n.Directive, x).options["tabid"]),

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -135,6 +135,46 @@ def test_tabs_invalid_yaml() -> None:
     assert diagnostics[0].start[0] == 6
 
 
+def test_tabs_reorder() -> None:
+    tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+    page, diagnostics = parse_rst(
+        parser,
+        tabs_path,
+        """
+.. tabs-drivers::
+
+   .. tab::
+      :tabid: nodejs
+
+      This tab should be second
+
+   .. tab::
+      :tabid: python
+
+      This tab should be first
+""",
+    )
+    page.finish(diagnostics)
+    assert not diagnostics
+    check_ast_testing_string(
+        page.ast,
+        r"""
+<root>
+<directive name="tabs" tabset="drivers">
+<directive name="tab" tabid="python"><text>Python</text>
+<paragraph><text>This tab should be first</text></paragraph>
+</directive>
+<directive name="tab" tabid="nodejs"><text>Node.js</text>
+<paragraph><text>This tab should be second</text></paragraph>
+</directive>
+</directive>
+</root>
+""",
+    )
+
+
 def test_codeblock() -> None:
     tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "")


### PR DESCRIPTION
[DOP-1632] Fix sorting of tabs by using key of tabids directly from `rstspec.toml`.