### PR TITLE
DOCSP-12335: bump node version

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1120,11 +1120,11 @@ type = {link = "https://metacpan.org/pod/MongoDB::%s"}
 
 [role.node-docs]
 help = """Link to a page in the Node.js driver's documentation."""
-type = {link = "http://mongodb.github.io/node-mongodb-native/3.5/%s"}
+type = {link = "http://mongodb.github.io/node-mongodb-native/3.6/%s"}
 
 [role.node-api]
 help = """Link to a page in the Node.js driver's API reference."""
-type = {link = "http://mongodb.github.io/node-mongodb-native/3.5/api/%s"}
+type = {link = "http://mongodb.github.io/node-mongodb-native/3.6/api/%s"}
 
 [role.ruby-api]
 help = """Link to a page in the Ruby driver's API reference."""


### PR DESCRIPTION
JIRA:
https://jira.mongodb.org/browse/DOCSP-12335