### PR TITLE
DOP-1526: Fix double tabs-pillstrip bug

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -453,3 +453,18 @@ class ExpectedTabs(Diagnostic):
         super().__init__(
             "Expected tabs directive when tabs-selector directive in use", start, end,
         )
+
+
+class DuplicateDirective(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        name: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"""Directive "{name}" should only appear once per page""", start, end,
+        )
+        self.name = name

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -173,7 +173,9 @@ class TabsSelectorHandler:
 
             # Avoid overwriting previously seen tabsets if another tabs-pillstrip directive is encountered
             if tabset_name in self.selectors:
-                self.diagnostics[filename].append(DuplicateDirective(node.name, 0))
+                self.diagnostics[filename].append(
+                    DuplicateDirective(node.name, node.start[0])
+                )
                 return
 
             self.selectors[tabset_name] = []

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -29,6 +29,7 @@ from .diagnostics import (
     MissingTocTreeEntry,
     MissingTab,
     ExpectedTabs,
+    DuplicateDirective,
 )
 from . import specparser
 from . import n, util
@@ -172,6 +173,7 @@ class TabsSelectorHandler:
 
             # Avoid overwriting previously seen tabsets if another tabs-pillstrip directive is encountered
             if tabset_name in self.selectors:
+                self.diagnostics[filename].append(DuplicateDirective(node.name, 0))
                 return
 
             self.selectors[tabset_name] = []

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -169,6 +169,11 @@ class TabsSelectorHandler:
             # Handle naming discrepancy between .. tabs-pillstrip:: languages and .. tabs-drivers::
             if tabset_name == "languages":
                 tabset_name = "drivers"
+
+            # Avoid overwriting previously seen tabsets if another tabs-pillstrip directive is encountered
+            if tabset_name in self.selectors:
+                return
+
             self.selectors[tabset_name] = []
             return
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 from .util_test import make_test, check_ast_testing_string, ast_to_testing_string
 from .types import FileId
-from .diagnostics import TargetNotFound, ExpectedTabs, MissingTab
+from .diagnostics import TargetNotFound, ExpectedTabs, MissingTab, DuplicateDirective
 
 # ensure that broken links still generate titles
 def test_broken_link() -> None:
@@ -509,10 +509,9 @@ def test_language_selector() -> None:
 """
         }
     ) as result:
-        assert [
-            "python" in d.message and type(d) == MissingTab
-            for d in result.diagnostics[FileId("tabs-six.txt")]
-        ] == [True], "Incorrect diagnostics raised"
+        diagnostics = result.diagnostics[FileId("tabs-six.txt")]
+        assert isinstance(diagnostics[0], DuplicateDirective)
+        assert isinstance(diagnostics[1], MissingTab)
         page = result.pages[FileId("tabs-six.txt")]
         print(ast_to_testing_string(page.ast))
         check_ast_testing_string(


### PR DESCRIPTION
Fixes bug where previously encountered tabsets would be overwritten if the page included multiple `tabs-pillstrip` or `tabs-selector` directives.