### PR TITLE
DOP-277: Suggest blockquote directive when unexpected indentation is encountered

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -63,8 +63,18 @@ class Diagnostic:
         return diag
 
 
-class UnexpectedIndentation(Diagnostic):
+class UnexpectedIndentation(Diagnostic, MakeCorrectionMixin):
     severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__("Unexpected indentation", start, end)
+
+    def did_you_mean(self) -> List[str]:
+        return [".. blockquote::"]
 
 
 class InvalidURL(Diagnostic):

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -221,9 +221,7 @@ class JSONVisitor:
             # We are uninterested in docutils blockquotes: they're too easy to accidentally
             # invoke. Treat them as an error.
             self.diagnostics.append(
-                UnexpectedIndentation(
-                    "Unexpected indentation", util.get_line(node.children[0])
-                )
+                UnexpectedIndentation(util.get_line(node.children[0]))
             )
             raise docutils.nodes.SkipDeparture()
         elif isinstance(node, rstparser.target_directive):

--- a/snooty/test_diagnostic.py
+++ b/snooty/test_diagnostic.py
@@ -5,7 +5,7 @@ import pytest
 
 
 def test_diagnostics() -> None:
-    diagnostic = UnexpectedIndentation("foo", (0, 0), 10)
+    diagnostic = UnexpectedIndentation((0, 0), 10)
     assert isinstance(diagnostic, UnexpectedIndentation)
     assert diagnostic.severity == Diagnostic.Level.error
     assert diagnostic.start == (0, 0)


### PR DESCRIPTION
[DOP-277] When an unexpected indentation is encountered, provide a more helpful error message by suggesting use of the `.. blockquote::` directive via `MakeCorrectionMixin`.