### PR TITLE
DOP-1675: Don't include binary name unless requested in :option: links

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -330,6 +330,9 @@ class RefRoleHandler:
         if self.target_type == specparser.TargetType.callable:
             target = strip_parameters(target)
         elif self.target_type == specparser.TargetType.cmdline_option:
+            if not label:
+                label = target
+
             target = ".".join(target.split())
 
         node: docutils.nodes.Element = ref_role(self.domain, self.name, lineno, target)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -177,7 +177,7 @@ Program 2
         <root fileid="includes/fact.rst">
             <paragraph>
                 <ref_role domain="std" name="option" target="program1.--verbose" fileid="['program1', 'std-option-program1.--verbose']">
-                    <literal><text>program1 --verbose</text></literal>
+                    <literal><text>--verbose</text></literal>
                 </ref_role>
             </paragraph>
 
@@ -223,7 +223,7 @@ Program 2
         <root fileid="includes/fact.rst">
             <paragraph>
                 <ref_role domain="std" name="option" target="program2.--verbose" fileid="['program2', 'std-option-program2.--verbose']">
-                    <literal><text>program2 --verbose</text></literal>
+                    <literal><text>--verbose</text></literal>
                 </ref_role>
             </paragraph>
 

--- a/snooty/test_postprocess_old_and_monolithic.py
+++ b/snooty/test_postprocess_old_and_monolithic.py
@@ -421,7 +421,7 @@ def test_program_option(backend: Backend) -> None:
         roles[1].children[0].children[0],
         f"""
         <ref_role domain="std" name="option" target="a-program.-f" fileid="['a-program', '{option1_2.html_id}']">
-        <literal><text>a-program -f</text></literal>
+        <literal><text>-f</text></literal>
         </ref_role>
     """,
     )
@@ -429,7 +429,7 @@ def test_program_option(backend: Backend) -> None:
         roles[2].children[0].children[0],
         f"""
         <ref_role domain="std" name="option" target="a-program.--config" fileid="['a-program', '{option1_2.html_id}']">
-        <literal><text>a-program --config</text></literal>
+        <literal><text>--config</text></literal>
         </ref_role>
     """,
     )
@@ -437,7 +437,7 @@ def test_program_option(backend: Backend) -> None:
         roles[3].children[0].children[0],
         """
         <ref_role domain="std" name="option" target="a-second-program.-v" fileid="['a-program', 'std-option-a-second-program.--version']">
-        <literal><text>a-second-program -v</text></literal>
+        <literal><text>-v</text></literal>
         </ref_role>
     """,
     )


### PR DESCRIPTION
For rstobjects with type `specparser.TargetType.cmdline_option` (only std:option right now), if no label is given, just use the original target name as written for the label instead of looking it up during postprocess.