### PR TITLE
Fix test_toctree() spacing

### DIFF
--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1793,12 +1793,12 @@ def test_toctree() -> None:
         path,
         """
 .. toctree::
-    :titlesonly:
+   :titlesonly:
 
-    Title here </test1>
-    /test2/faq
-    URL with title <https://docs.atlas.mongodb.com>
-    <https://docs.mongodb.com/stitch>
+   Title here </test1>
+   /test2/faq
+   URL with title <https://docs.atlas.mongodb.com>
+   <https://docs.mongodb.com/stitch>
 """,
     )
     page.finish(diagnostics)


### PR DESCRIPTION
Reduces number of spaces from 4 to 3 in `test_toctree()`