### PR TITLE
DOP-1750: Fix :copyable: true handling

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -744,7 +744,7 @@ class BaseTabsDirective(BaseDocutilsDirective):
 class BaseCodeDirective(docutils.parsers.rst.Directive):
     def run(self) -> List[docutils.nodes.Node]:
         source, line = self.state_machine.get_source_and_line(self.lineno)
-        copyable = "copyable" not in self.options or self.options["copyable"] == "true"
+        copyable = "copyable" not in self.options or self.options["copyable"]
         linenos = "linenos" in self.options
 
         try:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -329,7 +329,7 @@ for (i = 0; i &lt; 10; i++) {
    :end-before: end example 1
    :dedent: 4
    :linenos:
-   :copyable: false
+   :copyable: true
    :emphasize-lines: 1,2-4
    :lines: 1
 """,
@@ -339,7 +339,7 @@ for (i = 0; i &lt; 10; i++) {
     check_ast_testing_string(
         page.ast,
         """<root fileid="test.rst">
-        <directive name="literalinclude" caption="Sample Code" copyable="False" dedent="4" linenos="True" end-before="end example 1" language="python" start-after="start example 1" emphasize-lines="1,2-4" lines="1">
+        <directive name="literalinclude" caption="Sample Code" copyable="True" dedent="4" linenos="True" end-before="end example 1" language="python" start-after="start example 1" emphasize-lines="1,2-4" lines="1">
         <text>/test_parser/includes/sample_code.py</text>
         <code emphasize_lines="[(1, 1), (2, 4)]" lang="python" caption="Sample Code" linenos="True">print("test dedent")</code>
         </directive>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -207,7 +207,7 @@ def test_codeblock() -> None:
         tabs_path,
         """
 .. code-block:: sh
-   :copyable: false
+   :copyable: true
    :emphasize-lines: 1, 2-3
    :linenos:
 
@@ -220,7 +220,7 @@ def test_codeblock() -> None:
     check_ast_testing_string(
         page.ast,
         """<root fileid="test.rst">
-        <code lang="sh" emphasize_lines="[(1, 1), (2, 3)]" linenos="True">foo\nbar\nbaz</code>
+        <code lang="sh" emphasize_lines="[(1, 1), (2, 3)]" copyable="True" linenos="True">foo\nbar\nbaz</code>
         </root>""",
     )
 
@@ -329,7 +329,7 @@ for (i = 0; i &lt; 10; i++) {
    :end-before: end example 1
    :dedent: 4
    :linenos:
-   :copyable: true
+   :copyable: false
    :emphasize-lines: 1,2-4
    :lines: 1
 """,
@@ -339,7 +339,7 @@ for (i = 0; i &lt; 10; i++) {
     check_ast_testing_string(
         page.ast,
         """<root fileid="test.rst">
-        <directive name="literalinclude" caption="Sample Code" copyable="True" dedent="4" linenos="True" end-before="end example 1" language="python" start-after="start example 1" emphasize-lines="1,2-4" lines="1">
+        <directive name="literalinclude" caption="Sample Code" copyable="False" dedent="4" linenos="True" end-before="end example 1" language="python" start-after="start example 1" emphasize-lines="1,2-4" lines="1">
         <text>/test_parser/includes/sample_code.py</text>
         <code emphasize_lines="[(1, 1), (2, 4)]" lang="python" caption="Sample Code" linenos="True">print("test dedent")</code>
         </directive>


### PR DESCRIPTION
[DOP-1750] We weren't correctly handling the case where `:copyable: true` was explicitly specified. Fix that!