### PR TITLE
Improved :doc: link support.

### DIFF
--- a/snooty/types.py
+++ b/snooty/types.py
@@ -116,7 +116,12 @@ class ProjectConfig:
 
     @property
     def source_path(self) -> Path:
-        return self.root.joinpath(self.source)
+        result = self.root.joinpath(self.source)
+        if os.path.exists(result):
+            return result
+        # added support for projects that do not have "source" folder.
+        self.source = ""
+        return self.root
 
     @property
     def config_path(self) -> Path:

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -98,14 +98,20 @@ def ast_dive(ast: n.Node) -> Iterator[n.Node]:
 
 def add_doc_target_ext(target: str, docpath: PurePath, project_root: Path) -> Path:
     """Given the target file of a doc role, add the appropriate extension and return full file path"""
-    # Add .txt to end of doc role target path
+    # Add .txt or .rst to end of doc role target path
     target_path = PurePosixPath(target)
     # Adding the current suffix first takes into account dotted targets
-    new_suffix = target_path.suffix + ".txt"
-    target_path = target_path.with_suffix(new_suffix)
+    last: Path = Path()
+    for ext in RST_EXTENSIONS:
+        new_suffix = target_path.suffix + ext
+        temp_path = target_path.with_suffix(new_suffix)
 
-    fileid, resolved_target_path = reroot_path(target_path, docpath, project_root)
-    return resolved_target_path
+        fileid, resolved_target_path = reroot_path(temp_path, docpath, project_root)
+        last = resolved_target_path
+        if os.path.exists(resolved_target_path):
+            return resolved_target_path
+    # If none of the files exists, return the last attempted file path to trigger errors.
+    return last
 
 
 class FileWatcher:

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -100,6 +100,10 @@ def add_doc_target_ext(target: str, docpath: PurePath, project_root: Path) -> Pa
     """Given the target file of a doc role, add the appropriate extension and return full file path"""
     # Add .txt or .rst to end of doc role target path
     target_path = PurePosixPath(target)
+    if (target.endswith('/')):
+        # return directly if target is a folder.
+        fileid, resolved_target_path = reroot_path(target_path, docpath, project_root)
+        return resolved_target_path
     # Adding the current suffix first takes into account dotted targets
     last: Path = Path()
     for ext in RST_EXTENSIONS:


### PR DESCRIPTION
### Issues
For a non-Snooty project like [this](https://github.com/dockpanelsuite/dockpanelsuite_docs), `:doc:` links are currently broken, because

* The project does not have a source folder, so `source_path` is invalid during path calculation.
* The project uses .rst, not .txt, so `resolved_target_path` must support both extensions.

### Changes
Revised the related files to eliminate the issues.