### PR TITLE
fix watchdog dependency with updating correct version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = "~= 3.7"
 requires = [
     "pymongo[srv,tls] ~= 3.11.1",
     "docutils == 0.16",
-    "watchdog ~= 0.10.3",
+    "watchdog ~= 1.0.1",
     "requests ~= 2.24.0",
     "toml ~= 0.10.1",
     "pyyaml ~= 5.3.1",


### PR DESCRIPTION
Recently, the `watchdog` package dropped its compatibility of older Python (version<3.6) and update the big version number of itself. This cause a problem that someway if you want to use `snooty` with Python (version>=3.7), you'll get an error like below:

```
Collecting watchdog~=0.10.3
  Using cached https://pypi.python.org/packages/.../watchdog-0.10.5.tar.gz (99 kB)
ERROR: Package 'watchdog' requires a different Python: 3.8.5 not in '>=2.7, <3.6'
```

See also: 
https://github.com/vscode-restructuredtext/vscode-restructuredtext/issues/257
https://github.com/pypa/pip/issues/9121#issuecomment-745893622

The change of `watchdog` doesn't affect `snooty` since both of them support Python 3.7+, and `make clean && make test` is also passed with Python 3.8.5 on Linux.