### PR TITLE
DOP-1857: Allow "reusable" references

### DIFF
--- a/snooty/builders/man.py
+++ b/snooty/builders/man.py
@@ -358,6 +358,9 @@ class SnootyToTroffTree:
             )
         ]
 
+    def handle_NamedReference(self, node: n.NamedReference) -> List[ManNode]:
+        return []
+
     def handle_Role(self, node: n.Role) -> List[ManNode]:
         return self.children(node.children)
 

--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -57,11 +57,13 @@ def test_step() -> None:
         <reference refuri="https://en.wikipedia.org/wiki/Package_manager">
         <text>package management system</text>
         </reference>
+        <named_reference refname="package management system" refuri="https://en.wikipedia.org/wiki/Package_manager" />
     </heading>
     <paragraph>
         <text>Issue the following command to import the\n</text>
         <reference refuri="https://www.mongodb.org/static/pgp/server-3.4.asc">
         <text>MongoDB public GPG Key</text></reference>
+        <named_reference refname="MongoDB public GPG Key" refuri="https://www.mongodb.org/static/pgp/server-3.4.asc" />
     </paragraph></section></directive>
 <directive name="step">
     <section>

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -369,6 +369,14 @@ class Reference(InlineParent):
 
 
 @dataclass
+class NamedReference(InlineParent):
+    __slots__ = ("refname", "refuri")
+    type = "named_reference"
+    refname: str
+    refuri: str
+
+
+@dataclass
 class Role(InlineParent):
     __slots__ = ("domain", "name", "target", "flag")
     type = "role"

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -339,7 +339,7 @@ class DirectiveArgument(Parent[InlineNode]):
 
 @dataclass
 class Target(Parent[Node]):
-    __slots__ = ("domain", "name", "refuri", "html_id")
+    __slots__ = ("domain", "name", "html_id")
     type = "target"
     domain: str
     name: str

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -343,7 +343,6 @@ class Target(Parent[Node]):
     type = "target"
     domain: str
     name: str
-    refuri: Optional[str]
     html_id: Optional[str]
 
 
@@ -369,7 +368,7 @@ class Reference(InlineParent):
 
 
 @dataclass
-class NamedReference(InlineParent):
+class NamedReference(InlineNode):
     __slots__ = ("refname", "refuri")
     type = "named_reference"
     refname: str

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -223,9 +223,7 @@ class JSONVisitor:
             )
             raise docutils.nodes.SkipDeparture()
         elif isinstance(node, rstparser.target_directive):
-            self.state.append(
-                n.Target((line,), [], node["domain"], node["name"], None, None)
-            )
+            self.state.append(n.Target((line,), [], node["domain"], node["name"], None))
         elif isinstance(node, rstparser.directive):
             directive = self.handle_directive(node, line)
             if directive:
@@ -282,13 +280,11 @@ class JSONVisitor:
             node_id = node["names"][0]
 
             if "refuri" in node:
-                self.state.append(
-                    n.NamedReference((line,), [], node_id, node["refuri"])
-                )
+                self.state.append(n.NamedReference((line,), node_id, node["refuri"]))
                 return
 
             children: Any = [n.TargetIdentifier((line,), [], [node_id])]
-            self.state.append(n.Target((line,), children, "std", "label", None, None))
+            self.state.append(n.Target((line,), children, "std", "label", None))
         elif isinstance(node, rstparser.target_identifier):
             self.state.append(n.TargetIdentifier((line,), [], node["ids"]))
         elif isinstance(node, docutils.nodes.definition_list):
@@ -440,7 +436,7 @@ class JSONVisitor:
                 term_text = "".join(term.get_text() for term in item.term)
                 identifier = n.TargetIdentifier(item.start, [], [term_text])
                 identifier.children = item.term[:]
-                target = n.InlineTarget(item.start, [], "std", "term", None, None)
+                target = n.InlineTarget(item.start, [], "std", "term", None)
                 target.children = [identifier]
                 item.term.append(target)
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -275,17 +275,20 @@ class JSONVisitor:
             assert (
                 len(node["ids"]) <= 1
             ), f"Too many ids in this node: {self.docpath} {node}"
-            if "refuri" in node:
-                raise docutils.nodes.SkipNode()
-
             if not node["ids"]:
                 self.diagnostics.append(InvalidURL(util.get_line(node)))
                 raise docutils.nodes.SkipNode()
 
             node_id = node["names"][0]
+
+            if "refuri" in node:
+                self.state.append(
+                    n.NamedReference((line,), [], node_id, node["refuri"])
+                )
+                return
+
             children: Any = [n.TargetIdentifier((line,), [], [node_id])]
-            refuri = node["refuri"] if "refuri" in node else None
-            self.state.append(n.Target((line,), children, "std", "label", refuri, None))
+            self.state.append(n.Target((line,), children, "std", "label", None, None))
         elif isinstance(node, rstparser.target_identifier):
             self.state.append(n.TargetIdentifier((line,), [], node["ids"]))
         elif isinstance(node, docutils.nodes.definition_list):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -268,6 +268,10 @@ class IncludeHandler:
 
 
 class NamedReferenceHandler:
+    """Identify non-anonymous hyperlinks (i.e. those defined with a single underscore) and save them according to {name: url}.
+    Attach the associated URL to any uses of this named reference.
+    """
+
     def __init__(self, diagnostics: Dict[FileId, List[Diagnostic]]) -> None:
         self.named_references: Dict[str, str] = {}
         self.diagnostics = diagnostics


### PR DESCRIPTION
[DOP-1857] Allow references/links defined with only a single underscore to be reused by name elsewhere in the corpus.