### PR TITLE
DOP-371: Correctly represent page flags

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -148,7 +148,10 @@ class JSONVisitor:
             if isinstance(top, n.Root):
                 for field in node.children:
                     key = field.children[0].astext()
-                    value = field.children[1].astext()
+                    value: Union[str, bool] = field.children[1].astext()
+                    # Correctly handle flags (e.g. :noprevnext:)
+                    if value == "":
+                        value = True
                     top.options[key] = value
                 raise docutils.nodes.SkipNode()
 

--- a/snooty/test_legacy_guides.py
+++ b/snooty/test_legacy_guides.py
@@ -21,7 +21,7 @@ def test_legacy_guides() -> None:
     def make_correct(fileid: FileId) -> str:
         return "".join(
             (
-                f'<root fileid="{fileid.as_posix()}" guide="">',
+                f'<root fileid="{fileid.as_posix()}" guide="True">',
                 '<section><heading id="sample-app"><text>Sample App</text></heading>',
                 '<directive name="author"><text>MongoDB</text></directive>',
                 '<directive name="category"><text>Getting Started</text></directive>',


### PR DESCRIPTION
[DOP-371] Fixes a small issue that's been bothering me for a while! Page flags are currently represented as empty strings rather than booleans. E.g. `:noprevnext:` becomes this:
```python
{'noprevnext': ''}
```
instead of this:
```python
{'noprevnext': True}
```

This is possible because of #220, when the page options object was modified to allow all `SerializableType` data. Will open a small corresponding front end PR when this is merged in! Thanks 😀 