### PR TITLE
DOP-1931: Modify the toctree handling so that index.txt can add itself to the toctree with RecursionError

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -902,13 +902,15 @@ class Postprocessor:
 
                     toctree_node = {
                         "title": title,
-                        "slug": slug,
+                        "slug": "/" if slug == "index" else slug,
                         "children": [],
                         "options": {"drawer": slug not in self.toc_landing_pages},
                     }
 
-                    new_ast = self.pages[slug_fileid].ast
-                    self.find_toctree_nodes(slug_fileid, new_ast, toctree_node)
+                    # Don't recurse on the index page
+                    if entry.slug != "/index":
+                        new_ast = self.pages[slug_fileid].ast
+                        self.find_toctree_nodes(slug_fileid, new_ast, toctree_node)
 
                 if toctree_node:
                     node["children"].append(toctree_node)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -918,7 +918,7 @@ class Postprocessor:
                             slug_fileid,
                             new_ast,
                             toctree_node,
-                            visited_file_ids | {slug_fileid},
+                            visited_file_ids.union({slug_fileid}),
                         )
 
                 if toctree_node:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -68,7 +68,7 @@ The :parameter:`title` stuff works
         )
 
 
-# Ensure that "index.txt" exclusively can add itself to the toctree
+# Ensure that "index.txt" can add itself to the toctree
 def test_toctree_self_add() -> None:
     with make_test(
         {
@@ -88,15 +88,42 @@ def test_toctree_self_add() -> None:
         assert not [
             diagnostics for diagnostics in result.diagnostics.values() if diagnostics
         ], "Should not raise any diagnostics"
-        page = result.pages[FileId("index.txt")]
-        check_ast_testing_string(
-            page.ast,
-            """
-<root fileid="index.txt">
-    <directive name="toctree" entries="[{'slug': '/page1'}, {'title': 'Overview', 'slug': '/index'}, {'slug': '/page2'}]"></directive>
-</root>
-            """,
-        )
+        assert result.metadata.get("toctree") == {
+            "title": [
+                {
+                    "type": "text",
+                    "position": {"start": {"line": 0}},
+                    "value": "untitled",
+                }
+            ],
+            "slug": "/",
+            "children": [
+                {
+                    "title": None,
+                    "slug": "page1",
+                    "children": [],
+                    "options": {"drawer": True},
+                },
+                {
+                    "title": [
+                        {
+                            "type": "text",
+                            "position": {"start": {"line": 0}},
+                            "value": "Overview",
+                        }
+                    ],
+                    "slug": "/",
+                    "children": [],
+                    "options": {"drawer": True},
+                },
+                {
+                    "title": None,
+                    "slug": "page2",
+                    "children": [],
+                    "options": {"drawer": True},
+                },
+            ],
+        }
 
 
 def test_case_sensitive_labels() -> None:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -68,6 +68,37 @@ The :parameter:`title` stuff works
         )
 
 
+# Ensure that "index.txt" exclusively can add itself to the toctree
+def test_toctree_self_add() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. toctree::
+
+    /page1
+    Overview </index>
+    /page2
+            """,
+            Path("source/page1.txt"): "",
+            Path("source/page2.txt"): "",
+        }
+    ) as result:
+        assert not [
+            diagnostics for diagnostics in result.diagnostics.values() if diagnostics
+        ], "Should not raise any diagnostics"
+        page = result.pages[FileId("index.txt")]
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="index.txt">
+    <directive name="toctree" entries="[{'slug': '/page1'}, {'title': 'Overview', 'slug': '/index'}, {'slug': '/page2'}]"></directive>
+</root>
+            """,
+        )
+
+
 def test_case_sensitive_labels() -> None:
     with make_test(
         {


### PR DESCRIPTION
[[JIRA]](https://jira.mongodb.org/browse/DOP-1931). 

### Staging
Docs are staged with the following added to the toctree: `Overview </index>`

[[Compass]](https://docs-mongodbcom-staging.corp.mongodb.com/master/compass/cgoecknerwald/master/).
[[BI-Connector]](https://docs-mongodbcom-staging.corp.mongodb.com/master/bi-connector/cgoecknerwald/master/).