### PR TITLE
DOP-1883: update URL of kotlin SDK to avoid redirect chain

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1410,7 +1410,7 @@ type = {link = "https://docs.mongodb.com/realm/admin/api/v3/#%s", ensure_trailin
 type = {link = "https://docs.mongodb.com/realm-sdks/java/latest/%s"}
 
 [role."kotlin-sdk"]
-type = {link = "https://docs.mongodb.com/realm-sdks/kotlin/latest/%s"}
+type = {link = "https://docs.mongodb.com/realm-sdks/kotlin/latest/kotlin-extensions/%s"}
 
 [role."swift-sdk"]
 type = {link = "https://docs.mongodb.com/realm-sdks/swift/latest/%s"}


### PR DESCRIPTION
@nlarew Turns out we have a lovely redirect chain when crawling the Realm pages because we're linking to the wrong root URL for the Kotlin docs (from here: https://github.com/realm/realm-java/blob/1cfe291f90d1ce5c58a1ab9b44e41c225ee9f8e7/build.gradle#L238).

This will point us at the actual root folder, which will get rid of some of the jumps that we have to crawl to index the pages, apparently. If you could review, I'd be most obliged! This is only used once in the realm docs, for the TOC.