### PR TITLE
DOP-2045: Identify headings for 'On this page' box

### DIFF
--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -1159,6 +1159,9 @@ def test_contents_directive() -> None:
 Title
 =====
 
+.. contents::
+   :depth: 2
+
 First Heading
 -------------
 
@@ -1172,7 +1175,7 @@ Third Heading
 -------------
 
 .. contents::
-   :depth: 2
+   :depth: 3
 """,
             Path(
                 "source/no-contents.txt"
@@ -1186,19 +1189,18 @@ A Heading
 """,
         }
     ) as result:
-        for d in result.diagnostics[FileId("page.txt")]:
-            print(d.message)
-        assert not [
-            diagnostics for diagnostics in result.diagnostics.values() if diagnostics
-        ], "Should not raise any diagnostics"
+        diagnostics = result.diagnostics[FileId("page.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], DuplicateDirective)
         page = result.pages[FileId("page.txt")]
         print(ast_to_testing_string(page.ast))
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page.txt" headings="[{'depth': 2, 'id': 'first-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 6}}, 'value': 'First Heading'}]}, {'depth': 3, 'id': 'second-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 9}}, 'value': 'Second Heading'}]}, {'depth': 2, 'id': 'third-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 15}}, 'value': 'Third Heading'}]}]">
+<root fileid="page.txt" headings="[{'depth': 2, 'id': 'first-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 9}}, 'value': 'First Heading'}]}, {'depth': 3, 'id': 'second-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 12}}, 'value': 'Second Heading'}]}, {'depth': 2, 'id': 'third-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 18}}, 'value': 'Third Heading'}]}]">
 <section>
 <heading id="title"><text>Title</text></heading>
+<directive name="contents" depth="2" />
 <section>
 <heading id="first-heading"><text>First Heading</text></heading>
 <section>
@@ -1210,7 +1212,7 @@ A Heading
 </section>
 <section>
 <heading id="third-heading"><text>Third Heading</text></heading>
-<directive name="contents" depth="2" />
+<directive name="contents" depth="3" />
 </section>
 </section>
 </root>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -1173,7 +1173,17 @@ Third Heading
 
 .. contents::
    :depth: 2
-"""
+""",
+            Path(
+                "source/no-contents.txt"
+            ): """
+=======
+Title 2
+=======
+
+A Heading
+---------
+""",
         }
     ) as result:
         for d in result.diagnostics[FileId("page.txt")]:
@@ -1201,6 +1211,23 @@ Third Heading
 <section>
 <heading id="third-heading"><text>Third Heading</text></heading>
 <directive name="contents" depth="2" />
+</section>
+</section>
+</root>
+            """,
+        )
+
+        # No headings object attached to root without contents directive
+        page = result.pages[FileId("no-contents.txt")]
+        print(ast_to_testing_string(page.ast))
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="no-contents.txt">
+<section>
+<heading id="title-2"><text>Title 2</text></heading>
+<section>
+<heading id="a-heading"><text>A Heading</text></heading>
 </section>
 </section>
 </root>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -1147,3 +1147,62 @@ Reference `GitHub`_
 </root>
 """,
         )
+
+
+def test_contents_directive() -> None:
+    with make_test(
+        {
+            Path(
+                "source/page.txt"
+            ): """
+=====
+Title
+=====
+
+First Heading
+-------------
+
+Second Heading
+~~~~~~~~~~~~~~
+
+Omitted Heading
+^^^^^^^^^^^^^^^^
+
+Third Heading
+-------------
+
+.. contents::
+   :depth: 2
+"""
+        }
+    ) as result:
+        for d in result.diagnostics[FileId("page.txt")]:
+            print(d.message)
+        assert not [
+            diagnostics for diagnostics in result.diagnostics.values() if diagnostics
+        ], "Should not raise any diagnostics"
+        page = result.pages[FileId("page.txt")]
+        print(ast_to_testing_string(page.ast))
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="page.txt" headings="[{'depth': 2, 'id': 'first-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 6}}, 'value': 'First Heading'}]}, {'depth': 3, 'id': 'second-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 9}}, 'value': 'Second Heading'}]}, {'depth': 2, 'id': 'third-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 15}}, 'value': 'Third Heading'}]}]">
+<section>
+<heading id="title"><text>Title</text></heading>
+<section>
+<heading id="first-heading"><text>First Heading</text></heading>
+<section>
+<heading id="second-heading"><text>Second Heading</text></heading>
+<section>
+<heading id="omitted-heading"><text>Omitted Heading</text></heading>
+</section>
+</section>
+</section>
+<section>
+<heading id="third-heading"><text>Third Heading</text></heading>
+<directive name="contents" depth="2" />
+</section>
+</section>
+</root>
+            """,
+        )


### PR DESCRIPTION
[DOP-2045] Currently, the front end handles parsing the heading nodes that should appear in the "On this page" box. This has degraded performance of the component, as this operation is fairly expensive and really belongs in the parser. So, this PR adds that logic to the postprocess layer.

- Identify heading nodes up to _n_ specified by `:depth:`; if `:depth:` option is omitted, include all heading nodes in accordance with [docutils](https://docutils.sourceforge.io/0.4/docs/ref/rst/directives.html#table-of-contents).
- Save list of headings to `headings` field in page options