### PR TITLE
DOP-2055: Add IA support

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -355,7 +355,7 @@ class MissingTocTreeEntry(Diagnostic):
         self.entry = entry
 
 
-class InvalidToctree(Diagnostic, MakeCorrectionMixin):
+class InvalidTocTree(Diagnostic, MakeCorrectionMixin):
     severity = Diagnostic.Level.error
 
     def __init__(

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -364,7 +364,7 @@ class InvalidToctree(Diagnostic, MakeCorrectionMixin):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            "Projects with both toctree and ia directives are not supported",
+            """Projects with both "toctree" and "ia" directives are not supported""",
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -355,6 +355,40 @@ class MissingTocTreeEntry(Diagnostic):
         self.entry = entry
 
 
+class InvalidToctree(Diagnostic, MakeCorrectionMixin):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            "Projects with both toctree and ia directives are not supported",
+            start,
+            end,
+        )
+
+    def did_you_mean(self) -> List[str]:
+        return [".. ia::"]
+
+
+class InvalidIAEntry(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        msg: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"Invalid IA entry: {msg}",
+            start,
+            end,
+        )
+
+
 class UnknownTabset(Diagnostic):
     severity = Diagnostic.Level.error
 
@@ -535,3 +569,21 @@ class FetchError(Diagnostic):
             start,
             end,
         )
+
+
+class InvalidChild(Diagnostic, MakeCorrectionMixin):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        child: str,
+        parent: str,
+        suggestion: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(f"{child} is not a valid child of {parent}", start, end)
+        self.suggestion = suggestion
+
+    def did_you_mean(self) -> List[str]:
+        return [f".. {self.suggestion}::"]

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -601,6 +601,15 @@ class IAHandler:
                 )
                 continue
 
+            if not entry.options.get("url"):
+                self.diagnostics[fileid_stack.current].append(
+                    InvalidIAEntry(
+                        "IA entry directives must include url",
+                        node.span[0],
+                    )
+                )
+                continue
+
             parsed = urllib.parse.urlparse(entry.options.get("url"))
             if parsed.scheme:
                 url = entry.options.get("url")
@@ -608,6 +617,12 @@ class IAHandler:
             else:
                 url = None
                 slug = entry.options.get("url")
+
+            if slug and not self.heading_handler.get_title(clean_slug(slug)):
+                self.diagnostics[fileid_stack.current].append(
+                    MissingTocTreeEntry(slug, node.span[0])
+                )
+                continue
 
             title: Sequence[n.InlineNode] = []
             if len(entry.argument) > 0:
@@ -617,23 +632,22 @@ class IAHandler:
 
             snooty_name = entry.options.get("snooty-name")
             if snooty_name and not url:
-                line = node.span[0]
                 self.diagnostics[fileid_stack.current].append(
                     InvalidIAEntry(
                         "IA entry directives with snooty-name option must include url",
-                        line,
+                        node.span[0],
                     )
                 )
                 continue
 
             if url and not title:
-                line = node.span[0]
                 self.diagnostics[fileid_stack.current].append(
                     InvalidIAEntry(
                         "IA entries to external URLs must include titles",
-                        line,
+                        node.span[0],
                     )
                 )
+                continue
 
             self.ia.append(
                 IAHandler.IAData(

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -30,7 +30,7 @@ from .diagnostics import (
     InvalidChild,
     InvalidIAEntry,
     InvalidInclude,
-    InvalidToctree,
+    InvalidTocTree,
     MissingOption,
     MissingTab,
     MissingTocTreeEntry,
@@ -778,7 +778,7 @@ class Postprocessor:
         iatree = self.build_iatree()
         toctree = self.build_toctree()
         if iatree and toctree.get("children"):
-            self.diagnostics[FileId("index.txt")].append(InvalidToctree(0))
+            self.diagnostics[FileId("index.txt")].append(InvalidTocTree(0))
 
         tree = iatree or toctree
         document.update(
@@ -1068,7 +1068,7 @@ class Postprocessor:
             return {}
         if not isinstance(starting_page.ast, n.Root):
             return {}
-        if not starting_page.ast.options.get("ia"):
+        if "ia" not in starting_page.ast.options:
             return {}
 
         title: Sequence[n.InlineNode] = self.heading_handler.get_title("index") or [
@@ -1083,6 +1083,7 @@ class Postprocessor:
         return root
 
     def iterate_ia(self, page: Page, result: Dict[str, SerializableType]) -> None:
+        """Construct a tree of similar structure to toctree. Starting from root, identify ia object on page and recurse on its entries to build a tree. Includes all potential properties of an entry including title, URI, project name, and primary status."""
         if not isinstance(page.ast, n.Root):
             return
 
@@ -1205,7 +1206,7 @@ class Postprocessor:
             self.find_toctree_nodes(fileid, child_ast, node, visited_file_ids)
 
     def breadcrumbs(self, tree: Dict[str, SerializableType]) -> Dict[str, List[str]]:
-        """Generate breadcrumbs for each page represented in the toctree"""
+        """Generate breadcrumbs for each page represented in the provided toctree"""
         page_dict: Dict[str, List[str]] = {}
         all_paths: List[Any] = []
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -478,6 +478,7 @@ class HeadingHandler:
 
 
 class IAHandler:
+    """Identify IA directive on a page and save a list of its entries as a page-level option."""
     class IAData(NamedTuple):
         title: Sequence[n.InlineNode]
         url: Optional[str]
@@ -516,7 +517,11 @@ class IAHandler:
         if not isinstance(node, n.Directive) or not node.name == "ia":
             return
 
-        self.ia = []
+        if self.ia:
+            self.diagnostics[fileid_stack.current].append(
+                DuplicateDirective(node.name, node.start[0])
+            )
+            return
 
         for entry in node.get_child_of_type(n.Directive):
             if entry.name != "entry":

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import os.path
 import typing
+import urllib.parse
 from collections import defaultdict
 from copy import deepcopy
 from typing import (
@@ -11,6 +12,7 @@ from typing import (
     Iterable,
     List,
     MutableSequence,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -24,7 +26,10 @@ from .diagnostics import (
     DuplicateDirective,
     ExpectedPathArg,
     ExpectedTabs,
+    InvalidChild,
+    InvalidIAEntry,
     InvalidInclude,
+    InvalidToctree,
     MissingOption,
     MissingTab,
     MissingTocTreeEntry,
@@ -472,6 +477,107 @@ class HeadingHandler:
             )
 
 
+class IAHandler:
+    class IAData(NamedTuple):
+        title: Sequence[n.InlineNode]
+        url: Optional[str]
+        slug: Optional[str]
+        snooty_name: Optional[str]
+        primary: bool
+
+        def serialize(self) -> n.SerializedNode:
+            result: n.SerializedNode = {
+                "primary": self.primary,
+                "title": [node.serialize() for node in self.title],
+            }
+
+            if self.snooty_name:
+                result["snootyName"] = self.snooty_name
+            if self.slug:
+                result["slug"] = self.slug
+            if self.url:
+                result["url"] = self.url
+
+            return result
+
+    def __init__(
+        self,
+        diagnostics: Dict[FileId, List[Diagnostic]],
+        heading_handler: HeadingHandler,
+    ) -> None:
+        self.ia: List[IAHandler.IAData] = []
+        self.diagnostics = diagnostics
+        self.heading_handler = heading_handler
+
+    def reset(self, fileid_stack: FileIdStack, page: Page) -> None:
+        self.ia = []
+
+    def __call__(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if not isinstance(node, n.Directive) or not node.name == "ia":
+            return
+
+        self.ia = []
+
+        for entry in node.get_child_of_type(n.Directive):
+            if entry.name != "entry":
+                line = node.span[0]
+                self.diagnostics[fileid_stack.current].append(
+                    InvalidChild(entry.name, "ia", "entry", line)
+                )
+                continue
+
+            parsed = urllib.parse.urlparse(entry.options.get("url"))
+            if parsed.scheme:
+                url = entry.options.get("url")
+                slug = None
+            else:
+                url = None
+                slug = entry.options.get("url")
+
+            title: Sequence[n.InlineNode] = []
+            if len(entry.argument) > 0:
+                title = entry.argument
+            elif slug:
+                title = self.heading_handler.get_title(clean_slug(slug)) or []
+
+            snooty_name = entry.options.get("snooty-name")
+            if snooty_name and not url:
+                line = node.span[0]
+                self.diagnostics[fileid_stack.current].append(
+                    InvalidIAEntry(
+                        "IA entry directives with snooty-name option must include url",
+                        line,
+                    )
+                )
+                continue
+
+            if url and not title:
+                line = node.span[0]
+                self.diagnostics[fileid_stack.current].append(
+                    InvalidIAEntry(
+                        "IA entries to external URLs must include titles",
+                        line,
+                    )
+                )
+
+            self.ia.append(
+                IAHandler.IAData(
+                    title,
+                    url,
+                    slug,
+                    snooty_name,
+                    bool(entry.options.get("primary", False)),
+                )
+            )
+
+    def finalize_ia(self, fileid_stack: FileIdStack, page: Page) -> None:
+        if not self.ia:
+            return
+
+        if isinstance(page.ast, n.Root):
+            page.ast.options["ia"] = [entry.serialize() for entry in self.ia]
+
+
 class Postprocessor:
     """Handles all postprocessing operations on parsed AST files.
 
@@ -534,12 +640,18 @@ class Postprocessor:
 
         target_handler = TargetHandler(self.targets)
         named_reference_handler = NamedReferenceHandler(self.diagnostics)
+        ia_handler = IAHandler(self.diagnostics, self.heading_handler)
         self.run_event_parser(
             [
                 (EventParser.OBJECT_START_EVENT, target_handler),
                 (EventParser.OBJECT_START_EVENT, named_reference_handler),
+                (EventParser.OBJECT_START_EVENT, ia_handler),
             ],
-            [(EventParser.PAGE_START_EVENT, target_handler.reset)],
+            [
+                (EventParser.PAGE_START_EVENT, target_handler.reset),
+                (EventParser.PAGE_START_EVENT, ia_handler.reset),
+                (EventParser.PAGE_END_EVENT, ia_handler.finalize_ia),
+            ],
         )
         self.run_event_parser(
             [
@@ -562,14 +674,31 @@ class Postprocessor:
             for k, v in self.heading_handler.slug_title_mapping.items()
         }
         # Run postprocessing operations related to toctree and append to metadata document
+        iatree = self.build_iatree()
+        toctree = self.build_toctree()
+        if iatree and toctree.get("children"):
+            self.diagnostics[FileId("index.txt")].append(InvalidToctree(0))
+
+        tree = iatree or toctree
         document.update(
             {
-                "toctree": self.build_toctree(),
-                "toctreeOrder": self.toctree_order(),
-                "parentPaths": self.breadcrumbs(),
+                "toctree": toctree,
+                "toctreeOrder": self.toctree_order(tree),
+                "parentPaths": self.breadcrumbs(tree),
             }
         )
+
+        if iatree:
+            document["iatree"] = iatree
+
         return document
+
+    def _get_page_from_slug(self, current_page: Page, slug: str) -> Optional[Page]:
+        relative, _ = util.reroot_path(
+            FileId(slug), current_page.source_path, self.project_config.source_path
+        )
+        fileid_with_ext = self.slug_fileid_mapping[relative.as_posix()]
+        return self.pages.get(fileid_with_ext)
 
     def run_event_parser(
         self,
@@ -827,6 +956,45 @@ class Postprocessor:
             fileid_dict[slug] = fileid
         self.slug_fileid_mapping = fileid_dict
 
+    def build_iatree(self) -> Dict[str, SerializableType]:
+        starting_page = self.pages.get(FileId("index.txt"))
+
+        if not starting_page:
+            return {}
+        if not isinstance(starting_page.ast, n.Root):
+            return {}
+        if not starting_page.ast.options.get("ia"):
+            return {}
+
+        title: Sequence[n.InlineNode] = self.heading_handler.get_title("index") or [
+            n.Text((0,), self.project_config.title)
+        ]
+        root: Dict[str, SerializableType] = {
+            "title": [node.serialize() for node in title],
+            "slug": "/",
+            "children": [],
+        }
+        self.iterate_ia(starting_page, root)
+        return root
+
+    def iterate_ia(self, page: Page, result: Dict[str, SerializableType]) -> None:
+        if not isinstance(page.ast, n.Root):
+            return
+
+        ia = page.ast.options.get("ia")
+        if not isinstance(ia, List):
+            return
+        for entry in ia:
+            curr: Dict[str, SerializableType] = {**entry, "children": []}
+            if isinstance(result["children"], List):
+                result["children"].append(curr)
+
+            slug = curr.get("slug")
+            if isinstance(slug, str):
+                child = self._get_page_from_slug(page, slug)
+                if child:
+                    self.iterate_ia(child, curr)
+
     def build_toctree(self) -> Dict[str, SerializableType]:
         """Build property toctree"""
 
@@ -931,15 +1099,15 @@ class Postprocessor:
         for child_ast in ast.children:
             self.find_toctree_nodes(fileid, child_ast, node, visited_file_ids)
 
-    def breadcrumbs(self) -> Dict[str, List[str]]:
+    def breadcrumbs(self, tree: Dict[str, SerializableType]) -> Dict[str, List[str]]:
         """Generate breadcrumbs for each page represented in the toctree"""
         page_dict: Dict[str, List[str]] = {}
         all_paths: List[Any] = []
 
         # Find all node to leaf paths for each node in the toctree
-        if "children" in self.toctree:
-            assert isinstance(self.toctree["children"], List)
-            for node in self.toctree["children"]:
+        if "children" in tree:
+            assert isinstance(tree["children"], List)
+            for node in tree["children"]:
                 paths: List[str] = []
                 get_paths(node, [], paths)
                 all_paths.extend(paths)
@@ -947,15 +1115,15 @@ class Postprocessor:
         # Populate page_dict with a list of parent paths for each slug
         for path in all_paths:
             for i in range(len(path)):
-                slug = clean_slug(path[i])
+                slug = path[i]
                 page_dict[slug] = path[:i]
         return page_dict
 
-    def toctree_order(self) -> List[str]:
+    def toctree_order(self, tree: Dict[str, SerializableType]) -> List[str]:
         """Return a pre-order traversal of the toctree to be used for internal page navigation"""
         order: List[str] = []
 
-        pre_order(self.toctree, order)
+        pre_order(tree, order)
         return order
 
 
@@ -977,6 +1145,9 @@ def get_paths(node: Dict[str, Any], path: List[str], all_paths: List[Any]) -> No
         # Skip urls
         if "slug" in node:
             path.append(clean_slug(node["slug"]))
+            all_paths.append(path)
+        elif "snootyName" in node:
+            path.append(node["snootyName"])
             all_paths.append(path)
     else:
         # Recursively build the path

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -548,6 +548,7 @@ class HeadingHandler:
 
 class IAHandler:
     """Identify IA directive on a page and save a list of its entries as a page-level option."""
+
     class IAData(NamedTuple):
         title: Sequence[n.InlineNode]
         url: Optional[str]
@@ -753,7 +754,8 @@ class Postprocessor:
             k: [node.serialize() for node in v]
             for k, v in self.heading_handler.slug_title_mapping.items()
         }
-        # Run postprocessing operations related to toctree and append to metadata document
+        # Run postprocessing operations related to toctree and append to metadata document.
+        # If iatree is found, use it to generate breadcrumbs and parent paths and save it to metadata as well.
         iatree = self.build_iatree()
         toctree = self.build_toctree()
         if iatree and toctree.get("children"):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -554,11 +554,10 @@ class IAHandler:
         url: Optional[str]
         slug: Optional[str]
         project_name: Optional[str]
-        primary: bool
+        primary: Optional[bool]
 
         def serialize(self) -> n.SerializedNode:
             result: n.SerializedNode = {
-                "primary": self.primary,
                 "title": [node.serialize() for node in self.title],
             }
 
@@ -568,6 +567,8 @@ class IAHandler:
                 result["slug"] = self.slug
             if self.url:
                 result["url"] = self.url
+            if self.primary is not None:
+                result["primary"] = self.primary
 
             return result
 
@@ -659,7 +660,7 @@ class IAHandler:
                     url,
                     slug,
                     project_name,
-                    bool(entry.options.get("primary", False)),
+                    bool(entry.options.get("primary", False)) if project_name else None,
                 )
             )
 
@@ -1250,7 +1251,7 @@ def get_paths(node: Dict[str, Any], path: List[str], all_paths: List[Any]) -> No
         if "slug" in node:
             path.append(clean_slug(node["slug"]))
             all_paths.append(path)
-        elif "project_name" in node:
+        elif "project_name" in node and node.get("primary"):
             path.append(node["project_name"])
             all_paths.append(path)
     else:

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -963,16 +963,18 @@ example = """.. topic:: ${1:Title of block}
 help = """Shows search results from browser query params (no arguments)."""
 
 [directive.ia]
+help = """Creates a hierarchy of entry directives that function as children of this page."""
 content_type = "block"
 
 [directive.entry]
+help = """Specifies a Snooty project, internal page, or external url that represents a child of this page."""
 argument_type = "string"
 options.url = "string"
-options.snooty-name = "string"
+options.project-name = "string"
 options.primary = "flag"
 example = """.. entry:: ${0: string}
    ${1::url: (string)
-   :snooty-name: (string) [optional]
+   :project-name: (string) [optional]
    :primary: (optional)}
 """
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -970,10 +970,10 @@ argument_type = "string"
 options.url = "string"
 options.snooty-name = "string"
 options.primary = "flag"
-example = """.. item:: ${0: string}
-   ${1::item: (string)
-   :snooty-name: (string)
-   :hidden: (optional)}
+example = """.. entry:: ${0: string}
+   ${1::url: (string)
+   :snooty-name: (string) [optional]
+   :primary: (optional)}
 """
 
 ###### Roles

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -964,6 +964,20 @@ example = """.. topic:: ${1:Title of block}
 [directive.search-results]
 help = """Shows search results from browser query params (no arguments)."""
 
+[directive.ia]
+content_type = "block"
+
+[directive.entry]
+argument_type = "string"
+options.url = "string"
+options.snooty-name = "string"
+options.primary = "flag"
+example = """.. item:: ${0: string}
+   ${1::item: (string)
+   :snooty-name: (string)
+   :hidden: (optional)}
+"""
+
 ###### Roles
 [role.kbd]
 help = """Mark a sequence of keystrokes."""

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -14,7 +14,12 @@ from .diagnostics import (
     TargetNotFound,
 )
 from .types import FileId
-from .util_test import ast_to_testing_string, check_ast_testing_string, make_test
+from .util_test import (
+    ast_to_testing_string,
+    check_ast_testing_string,
+    check_toctree_testing_string,
+    make_test,
+)
 
 
 def test_ia() -> None:
@@ -95,6 +100,21 @@ Page One Title
 </root>
 """,
         )
+        check_toctree_testing_string(
+            result.metadata["iatree"],
+            """
+<toctree slug="/">
+    <title><text>untitled</text></title>
+    <toctree slug="/page1">
+        <title><text>Page One Title</text></title>
+        <toctree url="https://google.com" />
+    </toctree>
+    <toctree url="https://docs.mongodb.com/snooty/" snootyName="snooty" primary="True">
+        <title><text>Snooty Item</text></title>
+    </toctree>
+</toctree>
+""",
+        )
 
 
 # ensure that broken links still generate titles
@@ -170,42 +190,19 @@ def test_toctree_self_add() -> None:
         assert not [
             diagnostics for diagnostics in result.diagnostics.values() if diagnostics
         ], "Should not raise any diagnostics"
-        assert result.metadata.get("toctree") == {
-            "title": [
-                {
-                    "type": "text",
-                    "position": {"start": {"line": 0}},
-                    "value": "untitled",
-                }
-            ],
-            "slug": "/",
-            "children": [
-                {
-                    "title": None,
-                    "slug": "page1",
-                    "children": [],
-                    "options": {"drawer": True},
-                },
-                {
-                    "title": [
-                        {
-                            "type": "text",
-                            "position": {"start": {"line": 0}},
-                            "value": "Overview",
-                        }
-                    ],
-                    "slug": "/",
-                    "children": [],
-                    "options": {"drawer": True},
-                },
-                {
-                    "title": None,
-                    "slug": "page2",
-                    "children": [],
-                    "options": {"drawer": True},
-                },
-            ],
-        }
+        check_toctree_testing_string(
+            result.metadata["toctree"],
+            """
+<toctree slug="/">
+    <title><text>untitled</text></title>
+    <toctree slug="page1" drawer="True" />
+    <toctree slug="/" drawer="True">
+        <title><text>Overview</text></title>
+    </toctree>
+    <toctree slug="page2" drawer="True" />
+</toctree>
+""",
+        )
 
 
 def test_case_sensitive_labels() -> None:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -54,6 +54,8 @@ Page One Title
 
    .. entry::
       :url: https://google.com
+
+.. ia::
 """,
         }
     ) as result:
@@ -84,8 +86,9 @@ Page One Title
 
         active_file = "page1.txt"
         diagnostics = result.diagnostics[FileId(active_file)]
-        assert len(diagnostics) == 1
+        assert len(diagnostics) == 2
         assert isinstance(diagnostics[0], InvalidIAEntry)
+        assert isinstance(diagnostics[1], DuplicateDirective)
         page = result.pages[FileId(active_file)]
         check_ast_testing_string(
             page.ast,
@@ -96,6 +99,7 @@ Page One Title
 <directive name="ia">
 <directive name="entry" url="https://google.com" />
 </directive>
+<directive name="ia" />
 </section>
 </root>
 """,

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -62,6 +62,10 @@ Page One Title
       :url: /nonexistent
 
    .. entry:: Title
+
+   .. entry:: Snooty Item Two
+      :url: https://docs.mongodb.com/snooty/
+      :project-name: snooty
 """,
         }
     ) as result:
@@ -76,7 +80,7 @@ Page One Title
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="index.txt" ia="[{'primary': False, 'title': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'Page One Title'}], 'slug': '/page1'}, {'primary': True, 'title': [{'type': 'text', 'position': {'start': {'line': 6}}, 'value': 'Snooty Item'}], 'project_name': 'snooty', 'url': 'https://docs.mongodb.com/snooty/'}]">
+<root fileid="index.txt" ia="[{'title': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'Page One Title'}], 'slug': '/page1'}, {'title': [{'type': 'text', 'position': {'start': {'line': 6}}, 'value': 'Snooty Item'}], 'project_name': 'snooty', 'url': 'https://docs.mongodb.com/snooty/', 'primary': True}]">
 <directive name="ia">
 <directive name="entry" url="/page1" />
 <directive name="entry" url="https://docs.mongodb.com/snooty/" project-name="snooty" primary="True">
@@ -102,7 +106,7 @@ Page One Title
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page1.txt">
+<root fileid="page1.txt" ia="[{'title': [{'type': 'text', 'position': {'start': {'line': 15}}, 'value': 'Snooty Item Two'}], 'project_name': 'snooty', 'url': 'https://docs.mongodb.com/snooty/', 'primary': False}]">
 <section>
 <heading id="page-one-title"><text>Page One Title</text></heading>
 <directive name="ia">
@@ -110,6 +114,9 @@ Page One Title
 <directive name="entry" url="/nonexistent" />
 <directive name="entry">
 <text>Title</text>
+</directive>
+<directive name="entry" url="https://docs.mongodb.com/snooty/" project-name="snooty">
+<text>Snooty Item Two</text>
 </directive>
 </directive>
 </section>
@@ -123,6 +130,9 @@ Page One Title
     <title><text>untitled</text></title>
     <toctree slug="/page1">
         <title><text>Page One Title</text></title>
+        <toctree url="https://docs.mongodb.com/snooty/" project_name="snooty">
+            <title><text>Snooty Item Two</text></title>
+        </toctree>
     </toctree>
     <toctree url="https://docs.mongodb.com/snooty/" project_name="snooty" primary="True">
         <title><text>Snooty Item</text></title>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -36,11 +36,11 @@ def test_ia() -> None:
 
    .. entry:: Snooty Item
       :url: https://docs.mongodb.com/snooty/
-      :snooty-name: snooty
+      :project-name: snooty
       :primary:
 
    .. entry:: Invalid
-      :snooty-name: invalid
+      :project-name: invalid
 
    .. note::
 
@@ -76,13 +76,13 @@ Page One Title
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="index.txt" ia="[{'primary': False, 'title': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'Page One Title'}], 'slug': '/page1'}, {'primary': True, 'title': [{'type': 'text', 'position': {'start': {'line': 6}}, 'value': 'Snooty Item'}], 'snootyName': 'snooty', 'url': 'https://docs.mongodb.com/snooty/'}]">
+<root fileid="index.txt" ia="[{'primary': False, 'title': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'Page One Title'}], 'slug': '/page1'}, {'primary': True, 'title': [{'type': 'text', 'position': {'start': {'line': 6}}, 'value': 'Snooty Item'}], 'project_name': 'snooty', 'url': 'https://docs.mongodb.com/snooty/'}]">
 <directive name="ia">
 <directive name="entry" url="/page1" />
-<directive name="entry" url="https://docs.mongodb.com/snooty/" snooty-name="snooty" primary="True">
+<directive name="entry" url="https://docs.mongodb.com/snooty/" project-name="snooty" primary="True">
 <text>Snooty Item</text>
 </directive>
-<directive name="entry" snooty-name="invalid">
+<directive name="entry" project-name="invalid">
 <text>Invalid</text>
 </directive>
 <directive name="note" />
@@ -124,7 +124,7 @@ Page One Title
     <toctree slug="/page1">
         <title><text>Page One Title</text></title>
     </toctree>
-    <toctree url="https://docs.mongodb.com/snooty/" snootyName="snooty" primary="True">
+    <toctree url="https://docs.mongodb.com/snooty/" project_name="snooty" primary="True">
         <title><text>Snooty Item</text></title>
     </toctree>
 </toctree>

--- a/snooty/test_postprocess_old_and_monolithic.py
+++ b/snooty/test_postprocess_old_and_monolithic.py
@@ -8,7 +8,11 @@ from .diagnostics import AmbiguousTarget, MissingTocTreeEntry, TargetNotFound
 from .parser import Project
 from .test_project import Backend
 from .types import BuildIdentifierSet, FileId
-from .util_test import ast_to_testing_string, check_ast_testing_string
+from .util_test import (
+    ast_to_testing_string,
+    check_ast_testing_string,
+    check_toctree_testing_string,
+)
 
 ROOT_PATH = Path("test_data")
 
@@ -216,72 +220,27 @@ def test_role_explicit_title(backend: Backend) -> None:
 
 
 def test_toctree(backend: Backend) -> None:
-    assert backend.metadata["toctree"] == {
-        "children": [
-            {
-                "children": [],
-                "options": {"drawer": True},
-                "slug": "page1",
-                "title": [
-                    {
-                        "position": {"start": {"line": 4}},
-                        "type": "text",
-                        "value": "Print this heading",
-                    }
-                ],
-            },
-            {
-                "options": {"drawer": False},
-                "slug": "page2",
-                "title": [
-                    {
-                        "position": {"start": {"line": 19}},
-                        "type": "text",
-                        "value": "Heading is not at the top for some reason",
-                    }
-                ],
-                "children": [
-                    {
-                        "children": [],
-                        "title": [
-                            {
-                                "position": {"start": {"line": 0}},
-                                "type": "text",
-                                "value": "MongoDB Connector for Business Intelligence",
-                            }
-                        ],
-                        "url": "https://docs.mongodb.com/bi-connector/current/",
-                    },
-                    {
-                        "children": [],
-                        "options": {"drawer": False},
-                        "slug": "page3",
-                        "title": None,
-                    },
-                    {
-                        "children": [],
-                        "options": {"drawer": True},
-                        "slug": "page4",
-                        "title": [
-                            {
-                                "position": {"start": {"line": 0}},
-                                "type": "text",
-                                "value": "Page Four",
-                            }
-                        ],
-                    },
-                ],
-            },
-        ],
-        "title": [
-            {
-                "position": {"start": {"line": 0}},
-                "type": "text",
-                "value": "MongoDB title",
-            }
-        ],
-        "slug": "/",
-    }
+    check_toctree_testing_string(
+        backend.metadata["toctree"],
+        """
+<toctree slug="/">
+    <title><text>MongoDB title</text></title>
+    <toctree slug="page1" drawer="True">
+        <title><text>Print this heading</text></title>
+    </toctree>
+    <toctree slug="page2" drawer="False">
+        <title><text>Heading is not at the top for some reason</text></title>
+        <toctree url="https://docs.mongodb.com/bi-connector/current/">
+            <title><text>MongoDB Connector for Business Intelligence</text></title>
+        </toctree>
+        <toctree slug="page3" drawer="False" />
+        <toctree slug="page4" drawer="True">
+            <title><text>Page Four</text></title>
+        </toctree>
+    </toctree>
+</toctree>
+""",
+    )
 
     assert any(
         isinstance(x, MissingTocTreeEntry)


### PR DESCRIPTION
- Add support for `ia` and `entry` directives
  - Save their contents to page-level options, as well as to a sitewide `iatree` entry in the `metadata` document
  - If `iatree` exists, use it to generate breadcrumbs and in-order traversal of site (i.e. have it replace `toctree`)
- Add new new testing util, `check_toctree_testing_string()`, which uses an approach similar to `check_ast_testing_string()` to enable tests that are more legible than a direct dict comparison
  - Convert existing tests to use function