### PR TITLE
DOP-2088: Temporarily un-deprecate directive.class

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -275,7 +275,7 @@ argument_type = "string"
 
 [directive.class]
 help = """Set a class on the next element."""
-deprecated = true
+# deprecated = true
 argument_type = "string"
 content_type = "block"
 


### PR DESCRIPTION
This directive should be removed once we implement a proper new way of doing this.