### PR TITLE
Dop 1878: Validation for children within ::tabs

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -401,7 +401,7 @@ class TabMustBeDirective(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"Tab sets may only contain tab directives, but found {tab_type}",
+            f"Tabs or Tab sets may only contain tab directives, but found {tab_type}",
             start,
             end,
         )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -445,6 +445,9 @@ class JSONVisitor:
         ):
             self.handle_tabset(popped)
 
+        elif isinstance(popped, n.Directive) and popped.name == "tabs":
+            self.validate_tabs_children(popped)
+
         elif (
             isinstance(popped, n.Directive)
             and f"{popped.domain}:{popped.name}" == ":glossary"
@@ -916,6 +919,15 @@ class JSONVisitor:
                 InvalidTableStructure(msg, util.get_line(node) + len(node.children) - 1)
             )
             return
+
+    def validate_tabs_children(self, node: n.Directive) -> None:
+        line = node.start[0]
+        for child in node.children:
+            if (not isinstance(child, n.Directive)) or child.name != "tab":
+                self.diagnostics.append(
+                    TabMustBeDirective(str(type(child).__class__.__name__), line)
+                )
+        return
 
     def add_static_asset(self, raw_path: str, upload: bool) -> StaticAsset:
         fileid, path = util.reroot_path(

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -921,12 +921,16 @@ class JSONVisitor:
             return
 
     def validate_tabs_children(self, node: n.Directive) -> None:
+        new_children: List[n.Node] = []
         line = node.start[0]
         for child in node.children:
             if (not isinstance(child, n.Directive)) or child.name != "tab":
                 self.diagnostics.append(
                     TabMustBeDirective(str(type(child).__class__.__name__), line)
                 )
+                continue
+            new_children.append(child)
+        node.children = new_children
         return
 
     def add_static_asset(self, raw_path: str, upload: bool) -> StaticAsset:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -102,9 +102,6 @@ def test_tabs() -> None:
                 <text>HTTP</text>
                 <paragraph><text>Tab Content</text></paragraph>
             </directive>
-            <directive name="tip">
-                <text>This isn't a tab</text>
-            </directive>
         </directive>
         </root>""",
     )

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -14,6 +14,7 @@ from .diagnostics import (
     InvalidURL,
     MakeCorrectionMixin,
     MalformedGlossary,
+    TabMustBeDirective,
     UnexpectedIndentation,
     UnknownTabID,
     UnknownTabset,
@@ -96,12 +97,21 @@ def test_tabs() -> None:
             </directive>
         </directive>
 
+        <directive name="tabs">
+            <directive name="tab" tabid="http">
+                <text>HTTP</text>
+                <paragraph><text>Tab Content</text></paragraph>
+            </directive>
+            <directive name="tip">
+                <text>This isn't a tab</text>
+            </directive>
+        </directive>
         </root>""",
     )
-
     assert isinstance(diagnostics[0], UnknownTabID)
     assert isinstance(diagnostics[1], UnknownTabset)
     assert isinstance(diagnostics[2], DocUtilsParseError)
+    assert isinstance(diagnostics[3], TabMustBeDirective)
 
     # Test a tab with no tabid
     parser = rstparser.Parser(project_config, JSONVisitor)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -668,6 +668,29 @@ def test_language_selector() -> None:
             TabMustBeDirective
         ]
 
+    # Ensure we gracefully handle invalid tabs
+    with make_test(
+        {
+            Path(
+                "source/tabs-six.txt"
+            ): """
+.. tabs::
+
+   .. tab::
+      :tabid: java-sync
+
+      Java (sync)
+
+   .. tip::
+
+      A tip
+"""
+        }
+    ) as result:
+        assert [type(d) for d in result.diagnostics[FileId("tabs-six.txt")]] == [
+            TabMustBeDirective
+        ]
+
 
 def test_correct_diagnostic_path() -> None:
     with make_test(

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -645,7 +645,7 @@ def test_language_selector() -> None:
             """,
         )
 
-    # Ensure we gracefully handle invalid tabs
+    # Ensure we gracefully handle invalid children in named tabs
     with make_test(
         {
             Path(
@@ -668,7 +668,7 @@ def test_language_selector() -> None:
             TabMustBeDirective
         ]
 
-    # Ensure we gracefully handle invalid tabs
+    # Ensure we gracefully handle invalid children in tabs::
     with make_test(
         {
             Path(

--- a/test_data/test_tabs.rst
+++ b/test_data/test_tabs.rst
@@ -83,4 +83,18 @@
    tabs:
      - bobs_your_uncle: foo
 
+.. tabs::
+
+   .. tab:: HTTP
+      :tabid: http
+   
+      This tab contains the syntax and parameters for creating a
+      collection for a |http| {+data-lake-store+}.
+   
+      .. include:: /includes/extracts/fact-http-beta-message.rst
+         
+   .. tip:: This isn't a tab
+   
+      Words words words.
+
 

--- a/test_data/test_tabs.rst
+++ b/test_data/test_tabs.rst
@@ -88,13 +88,6 @@
    .. tab:: HTTP
       :tabid: http
    
-      This tab contains the syntax and parameters for creating a
-      collection for a |http| {+data-lake-store+}.
-   
-      .. include:: /includes/extracts/fact-http-beta-message.rst
-         
+      Tab Content
+  
    .. tip:: This isn't a tab
-   
-      Words words words.
-
-


### PR DESCRIPTION
**Story**
https://jira.mongodb.org/browse/DOP-1878

**Notes**

- Adds a tab children validator for any `tabs` directive, ala the child validation logic for `tabsets`
- Alters copy of existing `tabset` warning