### PR TITLE
DOP-1836: Add extra-compact card-group style

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -5,7 +5,7 @@ version = 0
 alignment = ["left", "center", "right"]
 backlinks = ["entry", "top", "none"]
 card_type = ["small", "large"]
-card_style = ["default", "compact"]
+card_style = ["default", "compact", "extra-compact"]
 charts_theme = ["light", "dark"]
 devhub_type = ["article", "quickstart", "how-to", "video", "live"]
 guide_categories = ["Getting Started"]
@@ -798,7 +798,7 @@ options.columns = "nonnegative_integer"
 options.style = "card_style"
 example = """.. card-group::
    ${1::columns: 2}
-   :style: ${2:|default,compact| (Optional)}
+   :style: ${2:|default,compact,extra-compact| (Optional)}
 
    ${0: Card content}
 """


### PR DESCRIPTION
Adds `extra-compact` card group style to support card groups that appear on pages in docs-landing ([see InVision](https://mongodb.invisionapp.com/console/share/3EZ68OEPSKB/587712512)). For example:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/9298431/115446622-7f48eb00-a1e5-11eb-8833-cf71992db6ac.png">
Am very open to renaming this! I went with "extra-compact" because these cards use the same layout as `compact` but the icons are even smaller.