### PR TITLE
DOP-1810: fix handling of pymongo, motor, and phplib links

### DIFF
--- a/snooty/intersphinx.py
+++ b/snooty/intersphinx.py
@@ -117,7 +117,7 @@ class Inventory:
             # These are hard-coded in Sphinx as well. Support these names for compatibility.
             if domain_and_role == "std:cmdoption":
                 domain_and_role = "std:option"
-            if domain_and_role == "py:method":
+            elif domain_and_role == "py:method":
                 domain_and_role = "py:meth"
 
             uri_base = uri

--- a/snooty/intersphinx.py
+++ b/snooty/intersphinx.py
@@ -114,9 +114,11 @@ class Inventory:
 
             name, domain_and_role, raw_priority, uri, raw_dispname = match.groups()
 
-            # This is hard-coded in Sphinx as well. Support this name for compatibility.
+            # These are hard-coded in Sphinx as well. Support these names for compatibility.
             if domain_and_role == "std:cmdoption":
                 domain_and_role = "std:option"
+            if domain_and_role == "py:method":
+                domain_and_role = "py:meth"
 
             uri_base = uri
             if uri.endswith("$"):
@@ -139,7 +141,6 @@ class Inventory:
                 name, (domain, role), priority, uri_base, uri, dispname
             )
             inventory.targets[f"{domain_and_role}:{name}"] = target_definition
-
         return inventory
 
 
@@ -181,5 +182,4 @@ def fetch_inventory(url: str, cache_dir: Path = DEFAULT_CACHE_DIR) -> Inventory:
 
     with open(inventory_path, "wb") as f:
         f.write(res.content)
-
     return Inventory.parse(base_url, res.content)

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1468,6 +1468,9 @@ type = {link = "https://docs.microsoft.com/en-us/xamarin/%s"}
 [rstobject."py:meth"]
 type = "callable"
 
+[rstobject."py:method"]
+inherit = "py:meth"
+
 [rstobject."js:func"]
 [rstobject."mongodb:httpaction"]
 [rstobject."mongodb:mailgunaction"]
@@ -1599,11 +1602,11 @@ prefix = "asetting"
 [rstobject."mongodb:apierror"]
 help = """Error Code for Public API"""
 
-[rstobject.phpclass]
+[rstobject."mongodb:phpclass"]
 help = """PHP Library class"""
 prefix = "phpclass"
 
-[rstobject.phpmethod]
+[rstobject."mongodb:phpmethod"]
 help = """PHP Library method"""
 prefix = "phpmethod"
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1468,9 +1468,6 @@ type = {link = "https://docs.microsoft.com/en-us/xamarin/%s"}
 [rstobject."py:meth"]
 type = "callable"
 
-[rstobject."py:method"]
-inherit = "py:meth"
-
 [rstobject."js:func"]
 [rstobject."mongodb:httpaction"]
 [rstobject."mongodb:mailgunaction"]


### PR DESCRIPTION
Updates intersphinx parse so that it correctly matches `:py:meth:` (the sphinx-recommended syntax) to `py:method` as described in the intersphinx inventories. Adds the mongodb domain to the `phpmethod` and `phpclass` roles so that those intersphinx links work.

To repro:
1. build server docs on prod snooty-parser note that there will be target not found errors for motor, pymongo and phplibrary
2. delete your ~/.cache/snooty folder
3. build the server docs using this PR's version of snooty-parser and notice those errors are GONE
4. rejoice!