### PR TITLE
DOP-2117: Add layout option to landing Cards

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -4,9 +4,9 @@ version = 0
 [enum]
 alignment = ["left", "center", "right"]
 backlinks = ["entry", "top", "none"]
-card_type = ["small", "large"]
-card_style = ["default", "compact", "extra-compact"]
 card_layout = ["default", "carousel"]
+card_style = ["default", "compact", "extra-compact"]
+card_type = ["small", "large"]
 charts_theme = ["light", "dark"]
 devhub_type = ["article", "quickstart", "how-to", "video", "live"]
 guide_categories = ["Getting Started"]
@@ -796,12 +796,12 @@ options.uri = { type = ["path", "uri"], required = true }
 inherit = "_landing-block"
 help = """Container to hold a group of cards"""
 options.columns = "nonnegative_integer"
-options.style = "card_style"
 options.layout = "card_layout"
+options.style = "card_style"
 example = """.. card-group::
    ${1::columns: 2}
-   :style: ${2:|default,compact,extra-compact| (Optional)}
    :layout: ${3:|default,carousel| (Optional)}
+   :style: ${2:|default,compact,extra-compact| (Optional)}
 
    ${0: Card content}
 """

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -6,6 +6,7 @@ alignment = ["left", "center", "right"]
 backlinks = ["entry", "top", "none"]
 card_type = ["small", "large"]
 card_style = ["default", "compact", "extra-compact"]
+card_layout = ["default", "carousel"]
 charts_theme = ["light", "dark"]
 devhub_type = ["article", "quickstart", "how-to", "video", "live"]
 guide_categories = ["Getting Started"]
@@ -796,9 +797,11 @@ inherit = "_landing-block"
 help = """Container to hold a group of cards"""
 options.columns = "nonnegative_integer"
 options.style = "card_style"
+options.layout = "card_layout"
 example = """.. card-group::
    ${1::columns: 2}
    :style: ${2:|default,compact,extra-compact| (Optional)}
+   :layout: ${3:|default,carousel| (Optional)}
 
    ${0: Card content}
 """

--- a/snooty/test_landing.py
+++ b/snooty/test_landing.py
@@ -51,7 +51,7 @@ def test_landing_directives(backend: Backend) -> None:
     assert len(card_group.children) == 3
     check_ast_testing_string(
         card_group,
-        """<directive domain="landing" name="card-group" columns="3" style="compact">
+        """<directive domain="landing" name="card-group" columns="3" style="compact" layout="carousel">
             <directive domain="landing" name="card" headline="Run a self-managed database" cta="Get started with MongoDB" url="http://mongodb.com" icon="/images/pink.png" icon-alt="Alt text" tag="server" checksum="71bf03ab0c5b8d46f0c03b77db6bd18a77d984d216c62c3519dfb45c162cd86b">
                 <paragraph><text>Download and install the MongoDB database on your own\ninfrastructure.</text></paragraph>
             </directive>

--- a/test_data/test_landing/source/index.txt
+++ b/test_data/test_landing/source/index.txt
@@ -14,6 +14,7 @@ Landing Domain Directive Tests
 .. card-group::
    :columns: 3
    :style: compact
+   :layout: carousel
 
    .. card::
       :headline: Run a self-managed database


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-2117).

Currently, CardGroup layout is determined by the Card `style` option. For example, if `compact` is specified as a card style, the card layout will stack (rather than carousel) on mobile. This PR differentiates these two functions by adding a `layout` option to CardGroup.
 
Cards should "stack" vertically on mobile screens as the default option (currently used on Product Landing Pages). Writers should be able to specify 'carousel' to have cards carousel on mobile screens as a non-standard option. (See: [docs-landing](https://docs.mongodb.com) on mobile).

Expected benefits: no weird layout side effects when specifying Card `style`, ability to support new `layout`s in the future