### PR TITLE
DOP-2174: Add card-tag refrole

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1029,8 +1029,8 @@ type = "text"
 help = """Show a file path."""
 type = "text"
 
-[role.card-tag]
-help = """Create a tag that links to a named target."""
+[role.card-ref]
+help = """Create a styled reference that links to a named target."""
 inherit = "ref"
 
 [role.command]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1029,8 +1029,9 @@ type = "text"
 help = """Show a file path."""
 type = "text"
 
-[role.card-ref]
-help = """Create a styled reference that links to a named target."""
+[role."mongodb:card-ref"]
+help = """Create a reference, embedded within landing cards, with additional styling, that links to a named target."""
+example = """:card-ref:`Android <android-intro>`"""
 inherit = "ref"
 
 [role.command]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1029,6 +1029,10 @@ type = "text"
 help = """Show a file path."""
 type = "text"
 
+[role.card-tag]
+help = """Create a tag that links to a named target."""
+inherit = "ref"
+
 [role.command]
 deprecated = true
 type = "text"


### PR DESCRIPTION
[DOP-2174](https://jira.mongodb.org/browse/DOP-2174).

Add card-tag role to represent the Realm landing page's [new Card tag components](https://www.figma.com/file/hPTwMb9uHOypYLckYDg072/Realm-PLP?node-id=0%3A1) (see: `Android ->`, `iOS ->`, etc). We expect the following rST:

```
.. card::
   :options: blah

   Card text.

   :card-tag:`Android <android-intro>`
```