### PR TITLE
DOP-2196: Remove \x00 characters from text nodes

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -264,7 +264,9 @@ class JSONVisitor:
             if directive:
                 self.state.append(directive)
         elif isinstance(node, docutils.nodes.Text):
-            self.state.append(n.Text((line,), str(node)))
+            # docutils will inject \0000 characters into text nodes when there are escape characters
+            text = str(node).replace("\x00", "")
+            self.state.append(n.Text((line,), text))
             return
         elif isinstance(node, docutils.nodes.literal_block):
             self.diagnostics.append(

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -2683,3 +2683,31 @@ Link to :opsmgr:`Ops Manager </page?q=true>`
 </root>
 """,
     )
+
+
+def test_escape() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        r"""
+.. |adl| replace:: Atlas Data Lake
+
+|adl|\s
+""",
+    )
+
+    page.finish(diagnostics)
+    assert not diagnostics
+
+    print(repr(ast_to_testing_string(page.ast)))
+    check_ast_testing_string(
+        page.ast,
+        """
+<root fileid="../test.rst">
+    <substitution_definition name="adl"><text>Atlas Data Lake</text></substitution_definition>
+    <paragraph><substitution_reference name="adl"></substitution_reference><text>s</text></paragraph>
+</root>""",
+    )

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -2686,9 +2686,13 @@ Link to :opsmgr:`Ops Manager </page?q=true>`
 
 
 def test_escape() -> None:
+    """Ensure that escaping characters after a substitution results in the proper output."""
     path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
+
+    # DOP-2196: Writers discovered that an |adl|\s substitution resulted in a box character rendering
+    # after Atlas Data Lake.
     page, diagnostics = parse_rst(
         parser,
         path,

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -2699,7 +2699,7 @@ def test_escape() -> None:
         r"""
 .. |adl| replace:: Atlas Data Lake
 
-|adl|\s
+|adl|\ss
 """,
     )
 
@@ -2712,6 +2712,6 @@ def test_escape() -> None:
         """
 <root fileid="../test.rst">
     <substitution_definition name="adl"><text>Atlas Data Lake</text></substitution_definition>
-    <paragraph><substitution_reference name="adl"></substitution_reference><text>s</text></paragraph>
+    <paragraph><substitution_reference name="adl"></substitution_reference><text>ss</text></paragraph>
 </root>""",
     )


### PR DESCRIPTION
docutils replaces escape characters with \x00. Our two options
are to either monkey-patch docutils to prevent that (risky, brittle),
or we can undo this once we ingest docutils output.

docutils provides an unescape() function, but it does a lot of things
based on input parameters, and let's just not play that game.