### PR TITLE
Optimize eventparser.py

### DIFF
--- a/snooty/eventparser.py
+++ b/snooty/eventparser.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from collections import defaultdict
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from . import n
 from .page import Page
@@ -33,46 +34,8 @@ class FileIdStack:
         return self._stack[-1]
 
 
-class EventListeners:
-    """Manage the listener functions associated with an event-based parse operation"""
-
-    def __init__(self) -> None:
-        self._universal_listeners: Set[Callable[..., Any]] = set()
-        self._event_listeners: Dict[str, Set[Callable[..., Any]]] = {}
-
-    def add_universal_listener(self, listener: Callable[..., Any]) -> None:
-        """Add a listener to be called on any event"""
-        self._universal_listeners.add(listener)
-
-    def add_event_listener(self, event: str, listener: Callable[..., Any]) -> None:
-        """Add a listener to be called when a particular type of event occurs"""
-        event = event.upper()
-        listeners: Set[Callable[..., Any]] = self._event_listeners.get(event, set())
-        listeners.add(listener)
-        self._event_listeners[event] = listeners
-
-    def get_event_listeners(self, event: str) -> Set[Callable[..., Any]]:
-        """Return all listeners of a particular type"""
-        event = event.upper()
-        return self._event_listeners.get(event, set())
-
-    def fire(
-        self,
-        event: str,
-        fileid: FileIdStack,
-        *args: Union[n.Node, Page],
-        **kwargs: Union[n.Node, Page],
-    ) -> None:
-        """Iterate through all universal listeners and all listeners of the specified type and call them"""
-        for listener in self.get_event_listeners(event):
-            listener(fileid, *args, **kwargs)
-
-        for listener in self._universal_listeners:
-            listener(fileid, *args, **kwargs)
-
-
-class EventParser(EventListeners):
-    """Initialize an event-based parse on a python dictionary"""
+class EventParser:
+    """Respond to listeners in response to node & page processing events."""
 
     PAGE_START_EVENT = "page_start"
     PAGE_END_EVENT = "page_end"
@@ -80,15 +43,30 @@ class EventParser(EventListeners):
     OBJECT_END_EVENT = "object_end"
 
     def __init__(self) -> None:
-        super(EventParser, self).__init__()
+        self._event_listeners: Dict[str, List[Callable[..., None]]] = defaultdict(list)
         self.fileid_stack = FileIdStack()
+
+    def add_event_listener(self, event: str, listener: Callable[..., None]) -> None:
+        """Add a listener to be called when a particular type of event occurs"""
+        listeners = self._event_listeners[event]
+        listeners.append(listener)
+
+    def fire_page(self, event: str, fileid: FileIdStack, page: Page) -> None:
+        """Iterate through all universal listeners and all listeners of the specified type and call them"""
+        for listener in self._event_listeners[event]:
+            listener(fileid, page)
+
+    def fire_node(self, event: str, fileid: FileIdStack, node: n.Node) -> None:
+        """Iterate through all universal listeners and all listeners of the specified type and call them"""
+        for listener in self._event_listeners[event]:
+            listener(fileid, node)
 
     def consume(self, d: Iterable[Tuple[FileId, Page]]) -> None:
         """Initializes a parse on the provided key-value map of pages"""
         for filename, page in d:
-            self._on_page_enter_event(page, filename)
+            self.fire_page(self.PAGE_START_EVENT, FileIdStack([filename]), page)
             self._iterate(page.ast, filename)
-            self._on_page_exit_event(page, filename)
+            self.fire_page(self.PAGE_END_EVENT, FileIdStack([filename]), page)
 
             self.fileid_stack.clear()
 
@@ -96,7 +74,7 @@ class EventParser(EventListeners):
         if isinstance(d, n.Root):
             self.fileid_stack.append(d.fileid)
 
-        self._on_object_enter_event(d, filename)
+        self.fire_node(self.OBJECT_START_EVENT, self.fileid_stack, d)
 
         if isinstance(d, n.Parent):
             if isinstance(d, n.DefinitionListItem):
@@ -110,23 +88,7 @@ class EventParser(EventListeners):
             for child in d.children:
                 self._iterate(child, filename)
 
-        self._on_object_exit_event(d, filename)
+        self.fire_node(self.OBJECT_END_EVENT, self.fileid_stack, d)
 
         if isinstance(d, n.Root):
             self.fileid_stack.pop()
-
-    def _on_page_enter_event(self, page: Page, filename: FileId) -> None:
-        """Called when an array is first encountered in tree"""
-        self.fire(self.PAGE_START_EVENT, FileIdStack([filename]), page=page)
-
-    def _on_page_exit_event(self, page: Page, filename: FileId) -> None:
-        """Called when an array is first encountered in tree"""
-        self.fire(self.PAGE_END_EVENT, FileIdStack([filename]), page=page)
-
-    def _on_object_enter_event(self, node: n.Node, filename: FileId) -> None:
-        """Called when an object is first encountered in tree"""
-        self.fire(self.OBJECT_START_EVENT, self.fileid_stack, node=node)
-
-    def _on_object_exit_event(self, node: n.Node, filename: FileId) -> None:
-        """Called when an object is first encountered in tree"""
-        self.fire(self.OBJECT_END_EVENT, self.fileid_stack, node=node)


### PR DESCRIPTION
* Usage of `*args` and `**kwargs` turned out to be expensive
* Remove unnecessary set construction and string mutation on every node notification
* Some unnecessary class removal and method inlining (mainly for readability but I saw small performance bumps)

Time of `before/after`:
CPython 3.9.5: 56% of the time of prior
Pyston 2.2.0: 49% of the time of prior

```
$ git checkout master; make clean; make performance-report SYSTEM_PYTHON=python3 | grep postprocessing
postprocessing 8.81
```

```
$ git checkout fleet-fox; make clean; make performance-report SYSTEM_PYTHON=python3 | grep postprocessing
postprocessing 4.91
```

```
$ git checkout master; make clean; make performance-report SYSTEM_PYTHON=pyston | grep postprocessing
postprocessing 6.10
```

```
$ git checkout fleet-fox; make clean; make performance-report SYSTEM_PYTHON=pyston | grep postprocessing
postprocessing 2.99
```