### PR TITLE
DOP-2223: Fix names for node-api roles

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1191,11 +1191,11 @@ type = {link = "http://mongodb.github.io/node-mongodb-native/3.6/%s"}
 help = """Link to a page in the Node.js driver's API reference."""
 type = {link = "http://mongodb.github.io/node-mongodb-native/3.6/api/%s"}
 
-[role.node-api-4.0]
+[role."node-api-4.0"]
 help = """Link to a page in Node.js driver V4.0's API reference."""
 type = {link = "https://mongodb.github.io/node-mongodb-native/4.0%s"}
 
-[role.node-api-3.6]
+[role."node-api-3.6"]
 help = """Link to a page in Node.js driver V3.6's API reference."""
 type = {link = "http://mongodb.github.io/node-mongodb-native/3.6/api/%s"}
 


### PR DESCRIPTION
I did not realize before that the previous naming conventions of the new `node-api` roles would cause things to break. Added quotes to prevent this issue.