### PR TITLE
DOP-2249: Add -yaml tag to YAML-generated steps

### DIFF
--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -107,7 +107,7 @@ class Step(Inheritable, HeadingMixin):
 
 def step_to_page(page: Page, step: Step, rst_parser: EmbeddedRstParser) -> n.Directive:
     rendered = step.render(page, rst_parser)
-    directive = n.Directive((step.line,), [], "", "step", [], {})
+    directive = n.Directive((step.line,), [], "", "step-yaml", [], {})
     directive.children = [rendered]
     return directive
 
@@ -129,7 +129,7 @@ class GizaStepsCategory(GizaCategory[Step]):
         page, rst_parser = page_factory(output_filename)
         page.category = "steps"
         source_fileid = self.project_config.get_fileid(source_path)
-        steps_directive = n.Directive((0,), [], "", "steps", [], {})
+        steps_directive = n.Directive((0,), [], "", "steps-yaml", [], {})
         steps_directive.children = [
             step_to_page(page, step, rst_parser) for step in steps
         ]

--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -47,8 +47,8 @@ def test_step() -> None:
         pages[0].ast,
         """
 <root fileid="includes/steps-test.yaml">
-<directive name="steps">
-<directive name="step">
+<directive name="steps-yaml">
+<directive name="step-yaml">
     <section>
     <heading id="import-the-public-key-used-by-the-package-management-system">
         <text>Import the </text>
@@ -65,7 +65,7 @@ def test_step() -> None:
         <text>MongoDB public GPG Key</text></reference>
         <named_reference refname="MongoDB public GPG Key" refuri="https://www.mongodb.org/static/pgp/server-3.4.asc" />
     </paragraph></section></directive>
-<directive name="step">
+<directive name="step-yaml">
     <section>
     <heading id="create-a-etc-apt-sources-list-d-mongodb-org-3-4-list-file-for-mongodb">
         <text>Create a </text><literal><text>
@@ -81,7 +81,7 @@ def test_step() -> None:
         <paragraph><text>action-content</text></paragraph>
         <paragraph><text>action-post</text></paragraph>
     </section></section></directive>
-<directive name="step"><section>
+<directive name="step-yaml"><section>
     <heading id="reload-local-package-database">
         <text>Reload local package database.</text>
     </heading>
@@ -90,7 +90,7 @@ def test_step() -> None:
     </paragraph>
     <code copyable="True" lang="sh">sudo apt-get update\n</code>
     </section></directive>
-<directive name="step"><section>
+<directive name="step-yaml"><section>
     <heading id="install-the-mongodb-packages">
         <text>Install the MongoDB packages.</text>
     </heading>
@@ -142,8 +142,8 @@ replacement:
         page.ast,
         """
 <root fileid="includes/steps-configure-mcli-cm.yaml">
-    <directive name="steps">
-        <directive name="step">
+    <directive name="steps-yaml">
+        <directive name="step-yaml">
             <section>
                 <heading id="create-a-profile"><text>Create a profile.</text></heading>
                 <paragraph><text>foobar</text></paragraph>

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -173,12 +173,12 @@ def test_text_doc_get_page_ast() -> None:
 
             <directive name="include"><text>/includes/steps/migrate-compose-pr.rst</text>
             <root fileid="includes/steps-migrate-compose-pr.yaml">
-            <directive name="steps">
-            <directive name="step"><section><heading id="mongodb-atlas-account"><text>MongoDB Atlas account</text>
+            <directive name="steps-yaml">
+            <directive name="step-yaml"><section><heading id="mongodb-atlas-account"><text>MongoDB Atlas account</text>
             </heading><paragraph><text>If you don't have an Atlas account, </text>
             <ref_role domain="std" name="doc" fileid="['/cloud/atlas', '']"><text>create one</text></ref_role>
             <text> now.</text></paragraph></section></directive>
-            <directive name="step"><section><heading id="compose-mongodb-deployment">
+            <directive name="step-yaml"><section><heading id="compose-mongodb-deployment">
             <text>Compose MongoDB deployment</text></heading>
             </section></directive></directive>
             </root></directive></section></root>"""

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -184,7 +184,7 @@ def test_get_ast() -> None:
         <paragraph><text>Test.</text></paragraph>
         <directive name="include"><text>/includes/steps/test.rst</text>
             <root fileid="includes/steps-test.yaml">
-            <directive name="steps"><directive name="step"><section><heading id="identify-the-privileges-granted-by-a-role">
+            <directive name="steps-yaml"><directive name="step-yaml"><section><heading id="identify-the-privileges-granted-by-a-role">
             <text>Identify the privileges granted by a role.</text></heading>
             <paragraph><text>this is a test step.</text></paragraph></section></directive></directive>
             </root>


### PR DESCRIPTION
[DOP-2249](https://jira.mongodb.org/browse/DOP-2249). 

[Relevant frontend PR](https://github.com/mongodb/snooty/compare/DOP-2249).

Broke into a separate ticket to reduce bulk of the [landing-domain overhaul PR](https://github.com/mongodb/snooty-parser/pull/314).

This ticket aims to differentiate YAML-generated versus rST-generated `step`/`steps` in the parser. (rST step/steps directives forthcoming.)

## Staging
[Realm staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/realm/cgoecknerwald/DOP-2249/sdk/ios/install/), [Realm live](https://docs.mongodb.com/realm/sdk/ios/install/), [rST](https://github.com/mongodb/docs-realm/blob/master/source/sdk/ios/install.txt#L50)