### PR TITLE
Patch: restore hlist & blockquote

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -601,10 +601,17 @@ example = """.. related::
    * https://url-of-related-article}
 """
 
-##### Guides (LEGACY)
+##### Guides (LEGACY - do not deprecate until removed in dependent docs repos)
 [directive.hlist]
 content_type = "list"
 options.columns = "nonnegative_integer"
+
+[directive.blockquote]
+help = """A block of content which is quoted from another source."""
+content_type = "block"
+# example = """.. blockquote::
+#    ${0: quoted content}
+# """
 
 ##### Internal "mongodb" directives
 [directive."mongodb:button"]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -601,6 +601,11 @@ example = """.. related::
    * https://url-of-related-article}
 """
 
+##### Guides (LEGACY)
+[directive.hlist]
+content_type = "list"
+options.columns = "nonnegative_integer"
+
 ##### Internal "mongodb" directives
 [directive."mongodb:button"]
 help = "Make a button."


### PR DESCRIPTION
These directives were removed in 1864c69 but have some trailing uses - this changeset restores them.