### PR TITLE
DOP-2356: Add version 5.0 to mongo-web-shell directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -11,7 +11,7 @@ card_type = ["small", "large"]
 charts_theme = ["light", "dark"]
 devhub_type = ["article", "quickstart", "how-to", "video", "live"]
 guide_categories = ["Getting Started"]
-mws_version = ["3.4", "3.6", "4.0", "4.2", "4.4", "latest"]
+mws_version = ["3.4", "3.6", "4.0", "4.2", "4.4", "5.0", "latest"]
 output_format = ["html"]
 user_level = ["beginner", "intermediate", "advanced"]
 


### PR DESCRIPTION
Adds "5.0" as a valid version for the `mongo-web-shell` directive.