### PR TITLE
DOP-2424: Fix substitution lifting

### DIFF
--- a/snooty/builders/man.py
+++ b/snooty/builders/man.py
@@ -256,6 +256,11 @@ class SnootyToTroffTree:
     ) -> List[ManNode]:
         return self.children(node.children)
 
+    def handle_BlockSubstitutionReference(
+        self, node: n.BlockSubstitutionReference
+    ) -> List[ManNode]:
+        return self.children(node.children)
+
     def handle_Root(self, node: n.Root) -> List[ManNode]:
         return self.children(node.children)
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -78,7 +78,7 @@ NO_CHILDREN = (n.SubstitutionReference,)
 logger = logging.getLogger(__name__)
 
 
-def eligable_for_paragraph_to_block_substitution(node: docutils.nodes.Node) -> bool:
+def eligible_for_paragraph_to_block_substitution(node: docutils.nodes.Node) -> bool:
     """Test if a docutils node should emit a BlockSubstitutionReference *instead* of a normal
     Paragraph."""
     return (
@@ -375,7 +375,7 @@ class JSONVisitor:
             except IndexError:
                 pass
         elif isinstance(node, docutils.nodes.substitution_reference):
-            if node.parent and eligable_for_paragraph_to_block_substitution(
+            if node.parent and eligible_for_paragraph_to_block_substitution(
                 node.parent
             ):
                 block_substitution_node = n.BlockSubstitutionReference(
@@ -387,7 +387,7 @@ class JSONVisitor:
 
             raise docutils.nodes.SkipChildren()
         elif isinstance(node, docutils.nodes.paragraph):
-            if eligable_for_paragraph_to_block_substitution(node):
+            if eligible_for_paragraph_to_block_substitution(node):
                 # We don't want a paragraph node here: instead, we'll (next) create a BlockSubstitutionReference node
                 raise docutils.nodes.SkipDeparture()
             self.state.append(n.Paragraph((line,), []))

--- a/snooty/util_test.py
+++ b/snooty/util_test.py
@@ -41,7 +41,9 @@ def toctree_to_testing_string(ast: Any) -> str:
     ]
 
     attr_pairs.extend((k, v) for k, v in ast.get("options", {}).items())
-    attrs = " ".join('{}="{}"'.format(k, escape(str(v))) for k, v in attr_pairs)
+    attrs = " ".join(
+        '{}="{}"'.format(k, escape(str(v), {'"': "&quot;"})) for k, v in attr_pairs
+    )
     contents = (
         escape(value)
         if value
@@ -83,7 +85,9 @@ def ast_to_testing_string(ast: Any) -> str:
     ]
 
     attr_pairs.extend((k, v) for k, v in ast.get("options", {}).items())
-    attrs = " ".join('{}="{}"'.format(k, escape(str(v))) for k, v in attr_pairs)
+    attrs = " ".join(
+        '{}="{}"'.format(k, escape(str(v), {'"': "&quot;"})) for k, v in attr_pairs
+    )
     contents = (
         escape(value)
         if value


### PR DESCRIPTION
The bug observed was caused by us popping the parent Paragraph node, but continuing to call `handle_departure()` for it causing a double state-pop.

Adding an assertion in list construction also caught a somewhat obscure issue where a `snooty_diagnostic` docutils node would also cause an undesired state pop.

There were also escaping issues in `ast_to_testing_string()` causing a test failure. It would be nice to use a proper XML generator rather than... this.