### PR TITLE
DOP-2332: tab drivers Mongo Shell -> MongoDB Shell

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1588,7 +1588,7 @@ platforms = [
   {id = "linux", title = "Linux"},
 ]
 drivers = [
-  {id = "shell", title = "Mongo Shell"},
+  {id = "shell", title = "MongoDB Shell"},
   {id = "compass", title = "Compass"},
   {id = "c", title = "C"},
   {id = "cpp", title = "C++11"},

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -488,10 +488,10 @@ def test_language_selector() -> None:
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="tabs.txt" selectors="{'drivers': {'shell': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'Mongo Shell'}], 'python': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'Python'}]}}">
+<root fileid="tabs.txt" selectors="{'drivers': {'shell': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'MongoDB Shell'}], 'python': [{'type': 'text', 'position': {'start': {'line': 3}}, 'value': 'Python'}]}}">
 <directive name="tabs-pillstrip"><text>languages</text></directive>
 <directive name="tabs" hidden="True" tabset="drivers">
-<directive name="tab" tabid="shell"><text>Mongo Shell</text>
+<directive name="tab" tabid="shell"><text>MongoDB Shell</text>
 <paragraph><text>Shell</text></paragraph>
 </directive>
 <directive name="tab" tabid="python"><text>Python</text>


### PR DESCRIPTION
Updates tab drivers reference "Mongo Shell" to "MongoDB Shell"

[SHE-RA](https://jira.mongodb.org/browse/DOP-2332) 🦸‍♀️

[Docs staging](https://docs-mongodbcom-staging.corp.mongodb.com/master/docs/cgoecknerwald/master/tutorial/insert-documents/)