### PR TITLE
DOP-2443: Implement Chapters on the postprocessor

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -611,3 +611,44 @@ class InvalidChild(Diagnostic, MakeCorrectionMixin):
 
 class ConfigurationProblem(Diagnostic):
     severity = Diagnostic.Level.error
+
+
+class ChapterAlreadyExists(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        chapterName: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(f'Chapter "{chapterName}" already exists', start, end)
+
+
+class InvalidChapter(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        message: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(f"Invalid chapter: {message}", start, end)
+
+
+class MissingChild(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        directive: str,
+        expectedChild: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f'Directive "{directive}" expects at least one child of type "{expectedChild}"; found 0',
+            start,
+            end,
+        )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -820,9 +820,6 @@ class GuidesHandler(Handler):
 
             handleChapters(node)
 
-            print("handled?")
-            print(self.chapters)
-
 
 class IAHandler(Handler):
     """Identify IA directive on a page and save a list of its entries as a page-level option."""
@@ -1381,8 +1378,6 @@ class Postprocessor:
         chapters = context[GuidesHandler].chapters
         if chapters:
             document["chapters"] = chapters
-            print("document_chapters")
-            print(document["chapters"])
 
         return document
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -754,10 +754,11 @@ class GuidesHandler(Handler):
         line = chapter.span[0]
 
         # A chapter should always have at least one guide
-        if not len(guides):
+        if not guides:
             self.context.diagnostics[current_file].append(
                 MissingChild("chapter", "guide", line)
             )
+            return
 
         title_argument = chapter.argument
         if not title_argument:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -722,6 +722,8 @@ class GuidesHandler(Handler):
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         def handleChapter(chapter: n.Directive) -> None:
+            """Saves a chapter's data into the handler's dictionary of chapters"""
+
             guides: List[str] = []
 
             for child in chapter.get_child_of_type(n.Directive):
@@ -784,12 +786,16 @@ class GuidesHandler(Handler):
                 )
 
         def handleInclude(node: n.Directive) -> None:
+            """Looks for chapters nested within include directives."""
+
             if len(node.children) == 1:
                 root = node.children[0]
                 if isinstance(root, n.Root):
                     handleChapters(root)
 
         def handleChapters(chapters: n.Parent[n.Node]) -> None:
+            """Handles the nested directives found under the chapters directive."""
+
             line = chapters.span[0]
 
             for child in chapters.get_child_of_type(n.Directive):

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -683,6 +683,27 @@ example = """.. card-group::
    ${0: Card content}
 """
 
+[directive."mongodb:chapter"]
+help = "A container for a group of MongoDB guides."
+example = """.. chapter:: ${1: string}
+   :description: ${2: string}
+   :image: ${3: /path/to/image.png}
+
+   ${0: chapter content}
+"""
+argument_type = "string"
+content_type = "block"
+options.description = {type = "string", required = true}
+options.image = ["path", "uri"]
+
+[directive."mongodb:chapters"]
+help = "A container for a group of chapter directives."
+example = """.. chapters::
+   
+   ${0: chapters content}
+"""
+content_type = "block"
+
 [directive."mongodb:cta"]
 help = "Call to action directing users to a new part of the site"
 example = """..cta::
@@ -690,6 +711,12 @@ example = """..cta::
    ${0::manual:`Read the Introduction to MongoDB </introduction>`}
 """
 content_type = "block"
+
+[directive."mongodb:guide"]
+help = "Denotes a guide page."
+example = """.. guide:: ${0: /path/to/guide.txt}"""
+argument_type = ["path", "uri"]
+content_type = "string"
 
 [directive."mongodb:introduction"]
 content_type = "block"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -150,12 +150,6 @@ Page One Title
 
 
 def test_chapters() -> None:
-    # Test that chapters array is generated
-    # Maybe test alongside ^ that it appears in metadata document
-    # Test that chapters on other page are not saved
-    # Test that chapters with non-chapter directive error
-    # Test that chapter with non-guide directive error
-
     # Chapters are generated properly and page ast should look as expected
     with make_test(
         {

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -227,13 +227,13 @@ Guides
             == "This is the description for the Atlas chapter."
         )
         assert chapters["Atlas"]["guides"] == ["path/to/guide1", "path/to/guide2"]
-        assert chapters["Atlas"]["chapterNumber"] == 1
+        assert chapters["Atlas"]["chapter_number"] == 1
         assert (
             chapters["CRUD"]["description"]
             == "This is the description for the CRUD chapter."
         )
         assert chapters["CRUD"]["guides"] == ["path/to/guide3"]
-        assert chapters["CRUD"]["chapterNumber"] == 2
+        assert chapters["CRUD"]["chapter_number"] == 2
 
     # Diagnostic errors reported
     with make_test(

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2,14 +2,19 @@
    Eventually most postprocessor tests should probably be moved into this format."""
 
 from pathlib import Path
+from typing import Any, Dict, cast
 
 from . import diagnostics
 from .diagnostics import (
+    ChapterAlreadyExists,
+    DocUtilsParseError,
     DuplicateDirective,
     ExpectedTabs,
+    InvalidChapter,
     InvalidChild,
     InvalidContextError,
     InvalidIAEntry,
+    MissingChild,
     MissingTab,
     MissingTocTreeEntry,
     SubstitutionRefError,
@@ -142,6 +147,188 @@ Page One Title
 </toctree>
 """,
         )
+
+
+def test_chapters() -> None:
+    # Test that chapters array is generated
+    # Maybe test alongside ^ that it appears in metadata document
+    # Test that chapters on other page are not saved
+    # Test that chapters with non-chapter directive error
+    # Test that chapter with non-guide directive error
+
+    # Chapters are generated properly and page ast should look as expected
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+======
+Guides
+======
+
+.. chapters::
+
+    .. chapter:: Atlas
+        :description: This is the description for the Atlas chapter.
+        :image: /images/atlas.png
+
+        .. guide:: /path/to/guide1.txt
+        .. guide:: /path/to/guide2.txt
+
+    .. include:: /chapters/crud.rst
+            """,
+            Path(
+                "source/chapters/crud.rst"
+            ): """
+.. chapter:: CRUD
+    :description: This is the description for the CRUD chapter.
+    :image: /images/crud.png
+
+    .. guide:: /path/to/guide3.txt
+            """,
+        }
+    ) as result:
+        assert not [
+            diagnostics for diagnostics in result.diagnostics.values() if diagnostics
+        ]
+        page = result.pages[FileId("index.txt")]
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="index.txt">
+	<section>
+		<heading id="guides">
+			<text>Guides</text>
+		</heading>
+		<directive domain="mongodb" name="chapters">
+			<directive domain="mongodb" name="chapter" description="This is the description for the Atlas chapter." image="/images/atlas.png">
+				<text>Atlas</text>
+				<directive domain="mongodb" name="guide">
+					<text>/path/to/guide1.txt</text>
+				</directive>
+				<directive domain="mongodb" name="guide">
+					<text>/path/to/guide2.txt</text>
+				</directive>
+			</directive>
+			<directive name="include">
+				<text>/chapters/crud.rst</text>
+				<root fileid="chapters/crud.rst">
+					<directive domain="mongodb" name="chapter" description="This is the description for the CRUD chapter." image="/images/crud.png">
+						<text>CRUD</text>
+						<directive domain="mongodb" name="guide">
+							<text>/path/to/guide3.txt</text>
+						</directive>
+					</directive>
+				</root>
+			</directive>
+		</directive>
+	</section>
+</root>
+            """,
+        )
+        chapters = cast(Dict[str, Any], result.metadata["chapters"])
+        assert len(chapters) == 2
+        assert (
+            chapters["Atlas"]["description"]
+            == "This is the description for the Atlas chapter."
+        )
+        assert chapters["Atlas"]["guides"] == ["path/to/guide1", "path/to/guide2"]
+        assert chapters["Atlas"]["chapterNumber"] == 1
+        assert (
+            chapters["CRUD"]["description"]
+            == "This is the description for the CRUD chapter."
+        )
+        assert chapters["CRUD"]["guides"] == ["path/to/guide3"]
+        assert chapters["CRUD"]["chapterNumber"] == 2
+
+    # Diagnostic errors reported
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+======
+Guides
+======
+
+.. chapters::
+
+   .. chapter:: Missing Description
+      :image: /images/atlas.png
+
+      .. guide:: /path/to/guide1.txt
+
+   .. chapter:: Good Chapter Here
+      :description: The description exists! No errors
+      :image: /images/description.png
+
+      .. guide:: /path/to/guide2.txt
+   
+   .. chapter::
+      :description: No title! Error! Also no guides
+    
+   .. guide:: /path/to/guide3.txt
+
+   .. chapter:: Invalid nested chapter
+      :description: Also no guides found
+
+      .. chapter:: Should throw error
+         :description: Whoops
+
+         .. guide:: /path/to/guide4.txt
+            """,
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        assert len(diagnostics) == 6
+        assert isinstance(diagnostics[0], DocUtilsParseError)
+        assert isinstance(diagnostics[1], MissingChild)
+        assert isinstance(diagnostics[2], InvalidChapter)
+        assert isinstance(diagnostics[3], InvalidChild)
+        assert isinstance(diagnostics[4], InvalidChild)
+        assert isinstance(diagnostics[5], MissingChild)
+
+    # Test missing directives in "chapters" directive
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+======
+Guides
+======
+
+.. chapters::
+"""
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], MissingChild)
+
+    # Test duplicate chapters
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. chapters::
+   
+   .. chapter:: Test
+      :description: This is a chapter
+
+      .. guide:: /path/to/guide1.txt
+  
+   .. chapter:: Test
+      :description: This is a chapter
+
+      .. guide:: /path/to/guide1.txt
+            """,
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], ChapterAlreadyExists)
 
 
 # ensure that broken links still generate titles

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -258,10 +258,15 @@ Guides
 
       .. guide:: /path/to/guide2.txt
    
-   .. chapter::
-      :description: No title! Error! Also no guides
+   .. chapter:: No Guides
+      :description: No guides
     
    .. guide:: /path/to/guide3.txt
+
+   .. chapter::
+      :description: No title
+
+      .. guide:: /path/to/guide4.txt
 
    .. chapter:: Invalid nested chapter
       :description: Also no guides found
@@ -269,7 +274,7 @@ Guides
       .. chapter:: Should throw error
          :description: Whoops
 
-         .. guide:: /path/to/guide4.txt
+         .. guide:: /path/to/guide5.txt
             """,
         }
     ) as result:
@@ -277,8 +282,8 @@ Guides
         assert len(diagnostics) == 6
         assert isinstance(diagnostics[0], DocUtilsParseError)
         assert isinstance(diagnostics[1], MissingChild)
-        assert isinstance(diagnostics[2], InvalidChapter)
-        assert isinstance(diagnostics[3], InvalidChild)
+        assert isinstance(diagnostics[2], InvalidChild)
+        assert isinstance(diagnostics[3], InvalidChapter)
         assert isinstance(diagnostics[4], InvalidChild)
         assert isinstance(diagnostics[5], MissingChild)
 


### PR DESCRIPTION
DOP-2443

This PR adds the new `chapters`, `chapter`, and `guide` directive to the parser. A new handler has been added to the postprocessor to take care of all guides and chapters to construct their metadata. Metadata for individual guides that include their time and descriptions will be added in a separate PR.