### PR TITLE
DOP-929: Update directive to mongodb:drivers-index-tiles

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -55,7 +55,8 @@ ${4:   :align:
 
 """
 
-[directive."ecosystem:landing-page-tiles"]
+# Intended for use on the ecosystem landing page only
+[directive."mongodb:drivers-index-tiles"]
 
 # Intended for use on the docs.mongodb.com/legacy landing site only
 [directive."mongodb:deprecated-version-selector"]


### PR DESCRIPTION
[DOP-929](https://jira.mongodb.org/browse/DOP-929) hands functionality back to writers on `docs-ecosystem/source/index.txt`. As part of this tech debt, we are also standardizing `ecosystem` to `drivers`, and `homepage` to `index`, as reflected here.

Rather than having a standalone `ecosystem` domain, I thought it prudent to merge this into the larger `mongodb` domain on the thought that this page may need to include other directives within the `mongodb` domain in the future.

This directive is currently not being used (at least not until the [docs-ecosystem PR](https://github.com/mongodb/docs-ecosystem/pull/766) goes out), so this change will not have any impact.