### PR TITLE
Adds Rust (Async) and Rust (Sync) to the driver options list

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1631,6 +1631,8 @@ drivers = [
   {id = "python", title = "Python"},
   {id = "ruby", title = "Ruby"},
   {id = "rust", title = "Rust"},
+  {id = "rust-async", title = "Rust (Async)"},
+  {id = "rust-sync", title = "Rust (Sync)"},
   {id = "scala", title = "Scala"},
   {id = "swift-async", title = "Swift (Async)"},
   {id = "swift-sync", title = "Swift (Sync)"},


### PR DESCRIPTION
Since Rust offers Sync and Async code options, we should add these to the drivers list so that they show in the driver tabs menu/drop-down options (as they do for Swift).