### PR TITLE
DOP-2446: Validate and save chapter image asset

### DIFF
--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -2743,3 +2743,64 @@ Prerequisites
     page.finish(diagnostics)
     assert len(diagnostics) == 1
     assert diagnostics[0].start[0] == 13
+
+
+def test_chapter() -> None:
+    """Test chapter directive"""
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    # Test good chapter with image
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. chapters::
+
+   .. chapter:: Atlas
+      :description: Chapter description.
+      :image: /test_parser/sample.png
+
+      .. guide:: /test_parser/includes/sample_rst.rst
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+    # Test good chapter without image
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. chapters::
+
+   .. chapter:: Atlas
+      :description: Chapter description.
+
+      .. guide:: /test_parser/includes/sample_rst.rst
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+    # Test chapter with incorrect image
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. chapters::
+
+   .. chapter:: Atlas
+      :description: Chapter description.
+      :image: /fake-image.png
+
+      .. guide:: /test_parser/includes/sample_rst.rst
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    assert isinstance(diagnostics[0], CannotOpenFile)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -57,6 +57,67 @@ def test_quiz() -> None:
     )
 
 
+def test_chapter() -> None:
+    """Test chapter directive"""
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    # Test good chapter with image
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. chapters::
+
+   .. chapter:: Atlas
+      :description: Chapter description.
+      :image: /test_parser/sample.png
+
+      .. guide:: /test_parser/includes/sample_rst.rst
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+    # Test good chapter without image
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. chapters::
+
+   .. chapter:: Atlas
+      :description: Chapter description.
+
+      .. guide:: /test_parser/includes/sample_rst.rst
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+    # Test chapter with incorrect image
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. chapters::
+
+   .. chapter:: Atlas
+      :description: Chapter description.
+      :image: /fake-image.png
+
+      .. guide:: /test_parser/includes/sample_rst.rst
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    assert isinstance(diagnostics[0], CannotOpenFile)
+
+
 def test_tabs() -> None:
     tabs_path = ROOT_PATH.joinpath(Path("test_tabs.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
@@ -2743,64 +2804,3 @@ Prerequisites
     page.finish(diagnostics)
     assert len(diagnostics) == 1
     assert diagnostics[0].start[0] == 13
-
-
-def test_chapter() -> None:
-    """Test chapter directive"""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
-    project_config = ProjectConfig(ROOT_PATH, "", source="./")
-    parser = rstparser.Parser(project_config, JSONVisitor)
-
-    # Test good chapter with image
-    page, diagnostics = parse_rst(
-        parser,
-        path,
-        """
-.. chapters::
-
-   .. chapter:: Atlas
-      :description: Chapter description.
-      :image: /test_parser/sample.png
-
-      .. guide:: /test_parser/includes/sample_rst.rst
-""",
-    )
-
-    page.finish(diagnostics)
-    assert len(diagnostics) == 0
-
-    # Test good chapter without image
-    page, diagnostics = parse_rst(
-        parser,
-        path,
-        """
-.. chapters::
-
-   .. chapter:: Atlas
-      :description: Chapter description.
-
-      .. guide:: /test_parser/includes/sample_rst.rst
-""",
-    )
-
-    page.finish(diagnostics)
-    assert len(diagnostics) == 0
-
-    # Test chapter with incorrect image
-    page, diagnostics = parse_rst(
-        parser,
-        path,
-        """
-.. chapters::
-
-   .. chapter:: Atlas
-      :description: Chapter description.
-      :image: /fake-image.png
-
-      .. guide:: /test_parser/includes/sample_rst.rst
-""",
-    )
-
-    page.finish(diagnostics)
-    assert len(diagnostics) == 1
-    assert isinstance(diagnostics[0], CannotOpenFile)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -165,7 +165,6 @@ Guides
 
     .. chapter:: Atlas
         :description: This is the description for the Atlas chapter.
-        :image: /images/atlas.png
 
         .. guide:: /path/to/guide1.txt
         .. guide:: /path/to/guide2.txt
@@ -177,7 +176,6 @@ Guides
             ): """
 .. chapter:: CRUD
     :description: This is the description for the CRUD chapter.
-    :image: /images/crud.png
 
     .. guide:: /path/to/guide3.txt
             """,
@@ -196,7 +194,7 @@ Guides
 			<text>Guides</text>
 		</heading>
 		<directive domain="mongodb" name="chapters">
-			<directive domain="mongodb" name="chapter" description="This is the description for the Atlas chapter." image="/images/atlas.png">
+			<directive domain="mongodb" name="chapter" description="This is the description for the Atlas chapter.">
 				<text>Atlas</text>
 				<directive domain="mongodb" name="guide">
 					<text>/path/to/guide1.txt</text>
@@ -208,7 +206,7 @@ Guides
 			<directive name="include">
 				<text>/chapters/crud.rst</text>
 				<root fileid="chapters/crud.rst">
-					<directive domain="mongodb" name="chapter" description="This is the description for the CRUD chapter." image="/images/crud.png">
+					<directive domain="mongodb" name="chapter" description="This is the description for the CRUD chapter.">
 						<text>CRUD</text>
 						<directive domain="mongodb" name="guide">
 							<text>/path/to/guide3.txt</text>
@@ -250,7 +248,6 @@ Guides
 
     .. chapter:: Atlas
         :description: This is the description for the Atlas chapter.
-        :image: /images/atlas.png
 
         .. guide:: /path/to/guide1.txt
             """,
@@ -294,13 +291,11 @@ Guides
 .. chapters::
 
    .. chapter:: Missing Description
-      :image: /images/atlas.png
 
       .. guide:: /path/to/guide1.txt
 
    .. chapter:: Good Chapter Here
       :description: The description exists! No errors
-      :image: /images/description.png
 
       .. guide:: /path/to/guide2.txt
    


### PR DESCRIPTION
While working on DOP-2446 on the frontend ([PR](https://github.com/mongodb/snooty/pull/508)), I realized that the chapter's image wasn't being saved/uploaded onto the database. This PR fixes this issue while also consolidating the same logic for validating images into a reusable function.

Here is a staging link to confirm that the images are validated and parsed properly:
[Guides Staging](https://docs-mongodborg-staging.corp.mongodb.com/test-guides/guides/raymundrodriguez/DOP-2446/)