### PR TITLE
DOP-2447: Add icons to chapters

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -903,6 +903,10 @@ class JSONVisitor:
             if image_argument:
                 self.validate_and_add_asset(doc, image_argument, line)
 
+            icon_argument = options.get("icon")
+            if icon_argument:
+                self.validate_and_add_asset(doc, icon_argument, line)
+
         elif name in {"pubdate", "updated-date"}:
             if "date" in node:
                 doc.options["date"] = node["date"]

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -723,6 +723,7 @@ class GuidesHandler(Handler):
         chapter_number: int
         description: Optional[str]
         guides: List[str]
+        icon: Optional[str]
 
     @dataclass
     class GuideData:
@@ -838,8 +839,9 @@ class GuidesHandler(Handler):
             return
 
         if not self.chapters.get(title):
+            icon = chapter.options.get("icon")
             self.chapters[title] = GuidesHandler.ChapterData(
-                len(self.chapters) + 1, description, guides
+                len(self.chapters) + 1, description, guides, icon
             )
         else:
             self.context.diagnostics[current_file].append(

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -688,7 +688,8 @@ example = """.. card-group::
 help = "A container for a group of MongoDB guides."
 example = """.. chapter:: ${1: string}
    :description: ${2: string}
-   :image: ${3: /path/to/image.png}
+   :image: ${3: /path/to/image.png - the chapter card will use this}
+   :icon: ${4: /path/to/icon.png - the guides cards related to the chapter will use this}
 
    ${0: chapter content}
 """
@@ -696,6 +697,7 @@ argument_type = "string"
 content_type = "block"
 options.description = {type = "string", required = true}
 options.image = ["path", "uri"]
+options.icon = ["path", "uri"]
 
 [directive."mongodb:chapters"]
 help = "A container for a group of chapter directives."

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -165,6 +165,7 @@ Guides
 
     .. chapter:: Atlas
         :description: This is the description for the Atlas chapter.
+        :icon: /path/to/icon.png
 
         .. guide:: /path/to/guide1.txt
         .. guide:: /path/to/guide2.txt
@@ -179,6 +180,7 @@ Guides
 
     .. guide:: /path/to/guide3.txt
             """,
+            Path("source/path/to/icon.png"): "",
         }
     ) as result:
         assert not [
@@ -189,33 +191,33 @@ Guides
             page.ast,
             """
 <root fileid="index.txt">
-	<section>
-		<heading id="guides">
-			<text>Guides</text>
-		</heading>
-		<directive domain="mongodb" name="chapters">
-			<directive domain="mongodb" name="chapter" description="This is the description for the Atlas chapter.">
-				<text>Atlas</text>
-				<directive domain="mongodb" name="guide">
-					<text>/path/to/guide1.txt</text>
-				</directive>
-				<directive domain="mongodb" name="guide">
-					<text>/path/to/guide2.txt</text>
-				</directive>
-			</directive>
-			<directive name="include">
-				<text>/chapters/crud.rst</text>
-				<root fileid="chapters/crud.rst">
-					<directive domain="mongodb" name="chapter" description="This is the description for the CRUD chapter.">
-						<text>CRUD</text>
-						<directive domain="mongodb" name="guide">
-							<text>/path/to/guide3.txt</text>
-						</directive>
-					</directive>
-				</root>
-			</directive>
-		</directive>
-	</section>
+    <section>
+        <heading id="guides">
+            <text>Guides</text>
+        </heading>
+        <directive domain="mongodb" name="chapters">
+            <directive domain="mongodb" name="chapter" description="This is the description for the Atlas chapter." icon="/path/to/icon.png" checksum="0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8">
+                <text>Atlas</text>
+                <directive domain="mongodb" name="guide">
+                    <text>/path/to/guide1.txt</text>
+                </directive>
+                <directive domain="mongodb" name="guide">
+                    <text>/path/to/guide2.txt</text>
+                </directive>
+            </directive>
+            <directive name="include">
+                <text>/chapters/crud.rst</text>
+                <root fileid="chapters/crud.rst">
+                    <directive domain="mongodb" name="chapter" description="This is the description for the CRUD chapter.">
+                        <text>CRUD</text>
+                        <directive domain="mongodb" name="guide">
+                            <text>/path/to/guide3.txt</text>
+                        </directive>
+                    </directive>
+                </root>
+            </directive>
+        </directive>
+    </section>
 </root>
             """,
         )
@@ -227,12 +229,14 @@ Guides
         )
         assert chapters["Atlas"]["guides"] == ["path/to/guide1", "path/to/guide2"]
         assert chapters["Atlas"]["chapter_number"] == 1
+        assert chapters["Atlas"]["icon"] == "/path/to/icon.png"
         assert (
             chapters["CRUD"]["description"]
             == "This is the description for the CRUD chapter."
         )
         assert chapters["CRUD"]["guides"] == ["path/to/guide3"]
         assert chapters["CRUD"]["chapter_number"] == 2
+        assert chapters["CRUD"]["icon"] == None
 
     # Guides metadata is added to the project's metadata document
     with make_test(


### PR DESCRIPTION
[Related frontend PR](https://github.com/mongodb/snooty/pull/511)
[Frontend staging link](https://docs-mongodbcom-staging.corp.mongodb.com/test-guides/guides/raymundrodriguez/DOP-2447/)

This PR adds the `icons` option to the `chapter` directive. Each guide of a particular chapter will include that same `icon` in the guides site homepage. An example can be seen on the staging link, under "Gallery View".