### PR TITLE
Fix an intermittent test failure

### DIFF
--- a/snooty/util_test.py
+++ b/snooty/util_test.py
@@ -225,8 +225,8 @@ def make_test(
 
         backend = BackendTestResults()
 
-        project = Project(root, backend, {})
-        project.build()
+        with Project(root, backend, {}, watch=False) as project:
+            project.build()
 
     yield backend
 


### PR DESCRIPTION
It seemed to be caused by issues around our observer API, so we make the
following changes:

* Disable filesystem watching in tests
* Open the project in a context manager as intended, although this has
  no real effect due to the previous change
* Add a big lock to the FileWatcher, just to be safe