### PR TITLE
DOP-2636: Temporary workaround for intersphinx escaping issues

### DIFF
--- a/snooty/target_database.py
+++ b/snooty/target_database.py
@@ -81,6 +81,10 @@ class TargetDatabase:
                 if not entry:
                     entry = inventory.get(key.lower())
 
+                # FIXME: temporary until DOP-2345 is complete
+                if not entry and key.startswith("mongodb:php"):
+                    entry = inventory.get(key.replace("\\\\", "\\"))
+
                 if entry:
                     base_url = inventory.base_url
                     url = urllib.parse.urljoin(base_url, entry.uri)


### PR DESCRIPTION
Legacy's intersphinx implementation is doing some escaping in one specific case. We should look into what intersphinx is actually doing, but this solves the immediate resolution problem.