### PR TITLE
DOP-2504: Add style option for procedure and step directives

### DIFF
--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -108,7 +108,7 @@ class Step(Inheritable, HeadingMixin):
 
 def step_to_page(page: Page, step: Step, rst_parser: EmbeddedRstParser) -> n.Directive:
     rendered = step.render(page, rst_parser)
-    directive = n.Directive((step.line,), [], "", "step-yaml", [], {})
+    directive = n.Directive((step.line,), [], "", "step", [], {})
     directive.children = [rendered]
     return directive
 
@@ -130,10 +130,11 @@ class GizaStepsCategory(GizaCategory[Step]):
         page, rst_parser = page_factory(output_filename)
         page.category = "steps"
         source_fileid = self.project_config.get_fileid(source_path)
-        steps_directive = n.Directive((0,), [], "", "steps-yaml", [], {})
+        steps_directive = n.Directive((0,), [], "", "procedure", [], {})
         steps_directive.children = [
             step_to_page(page, step, rst_parser) for step in steps
         ]
+        steps_directive.options["style"] = "normal"
         page.ast = n.Root((0,), [], source_fileid, {})
         page.ast.children.append(steps_directive)
         return [page]

--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -47,8 +47,8 @@ def test_step() -> None:
         pages[0].ast,
         """
 <root fileid="includes/steps-test.yaml">
-<directive name="steps-yaml">
-<directive name="step-yaml">
+<directive name="procedure" style="normal">
+<directive name="step">
     <section>
     <heading id="import-the-public-key-used-by-the-package-management-system">
         <text>Import the </text>
@@ -65,7 +65,7 @@ def test_step() -> None:
         <text>MongoDB public GPG Key</text></reference>
         <named_reference refname="MongoDB public GPG Key" refuri="https://www.mongodb.org/static/pgp/server-3.4.asc" />
     </paragraph></section></directive>
-<directive name="step-yaml">
+<directive name="step">
     <section>
     <heading id="create-a-etc-apt-sources-list-d-mongodb-org-3-4-list-file-for-mongodb">
         <text>Create a </text><literal><text>
@@ -81,7 +81,7 @@ def test_step() -> None:
         <paragraph><text>action-content</text></paragraph>
         <paragraph><text>action-post</text></paragraph>
     </section></section></directive>
-<directive name="step-yaml"><section>
+<directive name="step"><section>
     <heading id="reload-local-package-database">
         <text>Reload local package database.</text>
     </heading>
@@ -90,7 +90,7 @@ def test_step() -> None:
     </paragraph>
     <code copyable="True" lang="sh">sudo apt-get update\n</code>
     </section></directive>
-<directive name="step-yaml"><section>
+<directive name="step"><section>
     <heading id="install-the-mongodb-packages">
         <text>Install the MongoDB packages.</text>
     </heading>
@@ -142,8 +142,8 @@ replacement:
         page.ast,
         """
 <root fileid="includes/steps-configure-mcli-cm.yaml">
-    <directive name="steps-yaml">
-        <directive name="step-yaml">
+    <directive name="procedure" style="normal">
+        <directive name="step">
             <section>
                 <heading id="create-a-profile"><text>Create a profile.</text></heading>
                 <paragraph><text>foobar</text></paragraph>

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -484,6 +484,9 @@ class JSONVisitor:
                 target.children = [identifier]
                 item.term.append(target)
 
+        elif isinstance(popped, n.Directive) and popped.name == "step":
+            popped.children = [n.Section((util.get_line(node),), popped.children)]  # type: ignore
+
     def handle_tabset(self, node: n.Directive) -> None:
         tabset = node.options["tabset"]
         line = node.start[0]
@@ -867,6 +870,16 @@ class JSONVisitor:
             new_fileid = FileId("sharedinclude").joinpath(argument_text)
             doc.argument = [n.Text((line,), new_fileid.as_posix())]
             self.synthetic_pages[new_fileid] = str(response, "utf-8")
+
+        elif name == "step":
+            # Create heading for the step's argument, similar to titles of Giza/YAML steps
+            if argument:
+                argument_text = "".join(node.get_text() for node in argument)
+                heading_id = util.make_html5_id(argument_text.strip()).lower()
+
+                heading = n.Heading((line,), [], heading_id)
+                heading.children = argument
+                doc.children.insert(0, heading)
 
         elif name == "chapter":
             image_argument = options.get("image")

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -13,6 +13,7 @@ devhub_type = ["article", "quickstart", "how-to", "video", "live"]
 guide_categories = ["Getting Started"]
 mws_version = ["3.4", "3.6", "4.0", "4.2", "4.4", "5.0", "latest"]
 output_format = ["html"]
+procedure_styles = ["normal", "connected"]
 user_level = ["beginner", "intermediate", "advanced"]
 
 [directive.default-domain]
@@ -759,8 +760,11 @@ options.path = "string"
 [directive."mongodb:procedure"]
 help = "Make a set of numbered steps."
 example = """.. procedure::
-${0: Steps content}"""
+   :style: ${0: string}
+
+${1: Steps content}"""
 content_type = "block"
+options.style = "procedure_styles"
 
 [directive."mongodb:quiz"]
 content_type = "block"

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -178,12 +178,12 @@ def test_text_doc_get_page_ast() -> None:
 
             <directive name="include"><text>/includes/steps/migrate-compose-pr.rst</text>
             <root fileid="includes/steps-migrate-compose-pr.yaml">
-            <directive name="steps-yaml">
-            <directive name="step-yaml"><section><heading id="mongodb-atlas-account"><text>MongoDB Atlas account</text>
+            <directive name="procedure" style="normal">
+            <directive name="step"><section><heading id="mongodb-atlas-account"><text>MongoDB Atlas account</text>
             </heading><paragraph><text>If you don't have an Atlas account, </text>
             <ref_role domain="std" name="doc" fileid="['/cloud/atlas', '']"><text>create one</text></ref_role>
             <text> now.</text></paragraph></section></directive>
-            <directive name="step-yaml"><section><heading id="compose-mongodb-deployment">
+            <directive name="step"><section><heading id="compose-mongodb-deployment">
             <text>Compose MongoDB deployment</text></heading>
             </section></directive></directive>
             </root></directive></section></root>"""

--- a/snooty/test_mongodb_domain.py
+++ b/snooty/test_mongodb_domain.py
@@ -79,21 +79,27 @@ def test_mongodb_directives(backend: Backend) -> None:
         <directive domain="mongodb" name="procedure">
             <directive domain="mongodb" name="step">
                 <text>Connect to Your Deployment</text>
-                <paragraph><text>Paragraph.</text></paragraph>
-                <paragraph>
-                    <ref_role domain="std" name="label" target="Connect to MongoDB">
-                        <text>To learn more, see Connect to MongoDB</text>
-                    </ref_role>
-                </paragraph>
+                <section>
+                    <heading id="connect-to-your-deployment"><text>Connect to Your Deployment</text></heading>
+                    <paragraph><text>Paragraph.</text></paragraph>
+                    <paragraph>
+                        <ref_role domain="std" name="label" target="Connect to MongoDB">
+                            <text>To learn more, see Connect to MongoDB</text>
+                        </ref_role>
+                    </paragraph>
+                </section>
             </directive>
             <directive domain="mongodb" name="step">
                 <text>Import Your Data</text>
-                <paragraph><text>Paragraph.</text></paragraph>
-                <paragraph>
-                    <ref_role domain="std" name="label" target="Import and Export Data">
-                        <text>To learn more, see Import and Export Data</text>
-                    </ref_role>
-                </paragraph>
+                <section>
+                    <heading id="import-your-data"><text>Import Your Data</text></heading>
+                    <paragraph><text>Paragraph.</text></paragraph>
+                    <paragraph>
+                        <ref_role domain="std" name="label" target="Import and Export Data">
+                            <text>To learn more, see Import and Export Data</text>
+                        </ref_role>
+                    </paragraph>
+                </section>
             </directive>
         </directive>""",
     )

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -185,7 +185,7 @@ def test_get_ast() -> None:
         <paragraph><text>Test.</text></paragraph>
         <directive name="include"><text>/includes/steps/test.rst</text>
             <root fileid="includes/steps-test.yaml">
-            <directive name="steps-yaml"><directive name="step-yaml"><section><heading id="identify-the-privileges-granted-by-a-role">
+            <directive name="procedure" style="normal"><directive name="step"><section><heading id="identify-the-privileges-granted-by-a-role">
             <text>Identify the privileges granted by a role.</text></heading>
             <paragraph><text>this is a test step.</text></paragraph></section></directive></directive>
             </root>


### PR DESCRIPTION
This hopefully bridges the gap between the way PLP procedure/steps and YAML steps are parsed a little.
* [Related frontend PR](https://github.com/mongodb/snooty/pull/525)