### PR TITLE
DOP-2719: Generalize cta-banner icon option

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -646,8 +646,10 @@ example = """.. banner::
 [directive."mongodb:cta-banner"]
 content_type = "block"
 options.url = { type = "uri", required = true }
+options.icon = "string"
 example = """.. cta-banner::
    :url: https://university.mongodb.com/
+   :icon: ${1:Leafygreen icon}
 
    ${2:Banner Text content}
 """

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -898,7 +898,7 @@ def test_cta_banner() -> None:
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
-    # Test valid cta-banner
+    # Test valid cta-banner with specified icon
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -917,6 +917,32 @@ def test_cta_banner() -> None:
         page.ast,
         """<root fileid="test.rst">
         <directive domain="mongodb" name="cta-banner" url="https://university.mongodb.com/" icon="University">
+            <paragraph>
+                <text>If you prefer learning through videos, try this lesson on </text>
+                <reference refuri="https://university.mongodb.com/"><text>MongoDB University</text></reference>
+                <named_reference refname="MongoDB University" refuri="https://university.mongodb.com/"></named_reference>
+            </paragraph>
+        </directive></root>""",
+    )
+
+    # Test valid cta-banner with no specified icon
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. cta-banner::
+   :url: https://university.mongodb.com/
+
+   If you prefer learning through videos, try this lesson on `MongoDB University 
+   <https://university.mongodb.com/>`_
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst">
+        <directive domain="mongodb" name="cta-banner" url="https://university.mongodb.com/">
             <paragraph>
                 <text>If you prefer learning through videos, try this lesson on </text>
                 <reference refuri="https://university.mongodb.com/"><text>MongoDB University</text></reference>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -898,7 +898,7 @@ def test_cta_banner() -> None:
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
-    # Test valid cta-banner with specified icon
+    # Test valid cta-banner
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -917,32 +917,6 @@ def test_cta_banner() -> None:
         page.ast,
         """<root fileid="test.rst">
         <directive domain="mongodb" name="cta-banner" url="https://university.mongodb.com/" icon="University">
-            <paragraph>
-                <text>If you prefer learning through videos, try this lesson on </text>
-                <reference refuri="https://university.mongodb.com/"><text>MongoDB University</text></reference>
-                <named_reference refname="MongoDB University" refuri="https://university.mongodb.com/"></named_reference>
-            </paragraph>
-        </directive></root>""",
-    )
-
-    # Test valid cta-banner with no specified icon
-    page, diagnostics = parse_rst(
-        parser,
-        path,
-        """
-.. cta-banner::
-   :url: https://university.mongodb.com/
-
-   If you prefer learning through videos, try this lesson on `MongoDB University 
-   <https://university.mongodb.com/>`_
-""",
-    )
-    page.finish(diagnostics)
-    assert diagnostics == []
-    check_ast_testing_string(
-        page.ast,
-        """<root fileid="test.rst">
-        <directive domain="mongodb" name="cta-banner" url="https://university.mongodb.com/">
             <paragraph>
                 <text>If you prefer learning through videos, try this lesson on </text>
                 <reference refuri="https://university.mongodb.com/"><text>MongoDB University</text></reference>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -905,6 +905,7 @@ def test_cta_banner() -> None:
         """
 .. cta-banner::
    :url: https://university.mongodb.com/
+   :icon: University
 
    If you prefer learning through videos, try this lesson on `MongoDB University 
    <https://university.mongodb.com/>`_
@@ -915,10 +916,11 @@ def test_cta_banner() -> None:
     check_ast_testing_string(
         page.ast,
         """<root fileid="test.rst">
-        <directive domain="mongodb" name="cta-banner" url="https://university.mongodb.com/">
-            <paragraph><text>If you prefer learning through videos, try this lesson on </text>
-            <reference refuri="https://university.mongodb.com/"><text>MongoDB University</text></reference>
-            <named_reference refname="MongoDB University" refuri="https://university.mongodb.com/"></named_reference>
+        <directive domain="mongodb" name="cta-banner" url="https://university.mongodb.com/" icon="University">
+            <paragraph>
+                <text>If you prefer learning through videos, try this lesson on </text>
+                <reference refuri="https://university.mongodb.com/"><text>MongoDB University</text></reference>
+                <named_reference refname="MongoDB University" refuri="https://university.mongodb.com/"></named_reference>
             </paragraph>
         </directive></root>""",
     )


### PR DESCRIPTION
This change modifies the `cta-banner` directive to allow it to take an LG icon as an option, so that other LG icons can be used if needed. The default icon if none is specified is the "Play" icon. 

[DOP-2719 JIRA Ticket](https://jira.mongodb.org/browse/DOP-2719)