### PR TITLE
DOP-2754: Add video directive for video embeddings

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -872,6 +872,12 @@ options.title = {required = true, type = "string"}
 options.image = {required = true, type = ["path", "uri"]}
 options.type = "string"
 
+[directive.video]
+help = "Embed a video in your article"
+argument_type = "uri"
+content_type = "block"
+example = """.. video:: ${1: full video url}"""
+
 [directive.youtube]
 help = "Embed a video from YouTube in your article"
 argument_type = "string"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -875,7 +875,6 @@ options.type = "string"
 [directive.video]
 help = "Embed a video in your article"
 argument_type = "uri"
-content_type = "block"
 example = """.. video:: ${1: full video url}"""
 
 [directive.youtube]


### PR DESCRIPTION
This new directive takes in a video URL to be embedded within the docs. 