### PR TITLE
DOP-2760: Add visibility option to output directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -496,7 +496,8 @@ options.linenos = "flag"
 
 [directive.output]
 help = """The code output."""
-inherit = "input"
+argument_type = ["path", "raw"]
+content_type = "raw"
 options.language = "string"
 options.emphasize-lines = "linenos"
 options.linenos = "flag"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -475,6 +475,7 @@ options.source = "uri"
 #    ${2::copyable: (bool)
 #    :caption: (string)
 #    :class: (string)}
+#    :source: ${1: URL to source code}
 
 #    ${0:code input/code output content}
 # """
@@ -496,11 +497,16 @@ options.linenos = "flag"
 [directive.output]
 help = """The code output."""
 inherit = "input"
+options.language = "string"
+options.emphasize-lines = "linenos"
+options.linenos = "flag"
+options.visible = "boolean"
 # example = """.. io-code-block::
 #    .. output:: ${0:code output or </path/to/file>}
 #       :language: ${1:language}
 #       :emphasize-lines: (string)
 #       :linenos: (flag)
+#       :visible: (bool)
 # """
 
 [directive.cssclass]


### PR DESCRIPTION
This change adds a visibility option to the output directive, which allows writers to specify whether or not they would like the output code snippet to be visible or hidden on default. 