### PR TITLE
DOP-2742: Restore examples for io-code-block, input, and output directives in rstspec.toml

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -471,14 +471,14 @@ options.caption = "string"
 options.copyable = "boolean"
 options.class = "string"
 options.source = "uri"
-# example = """.. io-code-block::
-#    ${2::copyable: (bool)
-#    :caption: (string)
-#    :class: (string)}
-#    :source: ${1: URL to source code}
+example = """.. io-code-block::
+   ${2::copyable: (bool)
+   :caption: (string)
+   :class: (string)}
+   :source: ${1: URL to source code}
 
-#    ${0:code input/code output content}
-# """
+   ${0:code input/code output content}
+"""
 
 [directive.input]
 help = """The code content."""
@@ -487,12 +487,12 @@ content_type = "raw"
 options.language = "string"
 options.emphasize-lines = "linenos"
 options.linenos = "flag"
-# example = """.. io-code-block::
-#    .. input:: ${0:code output or </path/to/file>}
-#       :language: ${1:language}
-#       :emphasize-lines: (string)
-#       :linenos: (flag)
-# """
+example = """.. io-code-block::
+   .. input:: ${0:code output or </path/to/file>}
+      :language: ${1:language}
+      :emphasize-lines: (string)
+      :linenos: (flag)
+"""
 
 [directive.output]
 help = """The code output."""
@@ -502,13 +502,13 @@ options.language = "string"
 options.emphasize-lines = "linenos"
 options.linenos = "flag"
 options.visible = "boolean"
-# example = """.. io-code-block::
-#    .. output:: ${0:code output or </path/to/file>}
-#       :language: ${1:language}
-#       :emphasize-lines: (string)
-#       :linenos: (flag)
-#       :visible: (bool)
-# """
+example = """.. io-code-block::
+   .. output:: ${0:code output or </path/to/file>}
+      :language: ${1:language}
+      :emphasize-lines: (string)
+      :linenos: (flag)
+      :visible: (bool)
+"""
 
 [directive.cssclass]
 help = """Add the given CSS class name to generated HTML of the contained (if content is given) or

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -474,8 +474,8 @@ options.source = "uri"
 example = """.. io-code-block::
    ${2::copyable: (bool)
    :caption: (string)
-   :class: (string)}
-   :source: ${1: URL to source code}
+   :class: (string)
+   :source: ${1: URL to source code}}
 
    .. input:: ${0:code input or </path/to/file>}
       :language: ${1:language}

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -477,7 +477,16 @@ example = """.. io-code-block::
    :class: (string)}
    :source: ${1: URL to source code}
 
-   ${0:code input/code output content}
+   .. input:: ${0:code input or </path/to/file>}
+      :language: ${1:language}
+      :emphasize-lines: (string)
+      :linenos: (flag)
+
+   .. output:: ${0:code output or </path/to/file>}
+      :language: ${1:language}
+      :emphasize-lines: (string)
+      :linenos: (flag)
+      :visible: (bool)
 """
 
 [directive.input]
@@ -487,8 +496,7 @@ content_type = "raw"
 options.language = "string"
 options.emphasize-lines = "linenos"
 options.linenos = "flag"
-example = """.. io-code-block::
-   .. input:: ${0:code output or </path/to/file>}
+example = """.. input:: ${0:code input or </path/to/file>}
       :language: ${1:language}
       :emphasize-lines: (string)
       :linenos: (flag)
@@ -502,8 +510,7 @@ options.language = "string"
 options.emphasize-lines = "linenos"
 options.linenos = "flag"
 options.visible = "boolean"
-example = """.. io-code-block::
-   .. output:: ${0:code output or </path/to/file>}
+example = """.. output:: ${0:code output or </path/to/file>}
       :language: ${1:language}
       :emphasize-lines: (string)
       :linenos: (flag)


### PR DESCRIPTION
[DOP-2742](https://jira.mongodb.org/browse/DOP-2742)