### PR TITLE
Rename "Android SDK" tab to "Java SDK"

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1822,7 +1822,7 @@ realm-sdks = [
   {id = "json-expressions", title = "JSON Expressions"},
   {id = "graphql", title = "GraphQL"},
   {id = "ios", title = "Swift SDK"},
-  {id = "android", title = "Android SDK"},
+  {id = "android", title = "Java SDK"},
   {id = "dotnet", title = ".NET SDK"},
   {id = "xamarin", title = "Xamarin SDK"},
   {id = "javascript", title = "JavaScript SDKs"},

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1823,6 +1823,8 @@ realm-sdks = [
   {id = "graphql", title = "GraphQL"},
   {id = "ios", title = "Swift SDK"},
   {id = "android", title = "Java SDK"},
+  {id = "kotlin", title = "Kotlin SDK"},
+  {id = "flutter", title = "Flutter SDK"},
   {id = "dotnet", title = ".NET SDK"},
   {id = "xamarin", title = "Xamarin SDK"},
   {id = "javascript", title = "JavaScript SDKs"},


### PR DESCRIPTION
Already been renamed in the documentation content -- just need to fix it here.