### PR TITLE
DOP-2743: Add source option to codeblocks and add tests

### DIFF
--- a/snooty/gizaparser/release.py
+++ b/snooty/gizaparser/release.py
@@ -36,6 +36,7 @@ class ReleaseSpecification(Inheritable):
                     self.code,
                     False,
                     None,
+                    None,
                 )
             )
         return children

--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -52,6 +52,7 @@ class Action(HeadingMixin):
                     self.code,
                     False,
                     None,
+                    None,
                 )
             )
 

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -158,6 +158,7 @@ class Code(Node):
         "value",
         "linenos",
         "lineno_start",
+        "source",
     )
     type = "code"
     lang: Optional[str]
@@ -167,6 +168,7 @@ class Code(Node):
     value: str
     linenos: bool
     lineno_start: Optional[int]
+    source: Optional[str]
 
 
 @dataclass

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -235,6 +235,7 @@ class JSONVisitor:
                 node.astext(),
                 node["linenos"],
                 node["lineno_start"] if "lineno_start" in node else None,
+                node["source"] if "source" in node else None,
             )
             top_of_state = self.state[-1]
             assert isinstance(top_of_state, n.Parent)
@@ -835,6 +836,7 @@ class JSONVisitor:
             lineno_start = (
                 options["lineno-start"] if "lineno-start" in options else None
             )
+            source = options["source"] if "source" in options else None
 
             code = n.Code(
                 span,
@@ -845,6 +847,7 @@ class JSONVisitor:
                 selected_content,
                 linenos,
                 lineno_start,
+                source,
             )
 
             doc.children.append(code)
@@ -1052,6 +1055,9 @@ def _validate_io_code_block_children(node: n.Directive) -> List[Diagnostic]:
                         True
                         if "copyable" in node.options and node.options["copyable"]
                         else False
+                    )
+                    grandchild.source = (
+                        node.options["source"] if "source" in node.options else None
                     )
                     new_grandchildren.append(grandchild)
                 child.children = new_grandchildren

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -804,6 +804,8 @@ class BaseCodeDirective(docutils.parsers.rst.Directive):
         node["copyable"] = copyable
         node["emphasize_lines"] = emphasize_lines
         node["linenos"] = linenos
+        if "source" in self.options:
+            node["source"] = self.options["source"]
         node.document = self.state.document
         node.source, node.line = source, line
         return [node]
@@ -850,6 +852,9 @@ class BaseCodeIODirective(docutils.parsers.rst.Directive):
             child_code["emphasize_lines"] = emphasize_lines
             child_code["linenos"] = linenos
             child_code["copyable"] = copyable
+            child_code["source"] = "test"
+            if "source" in self.options:
+                child_code["source"] = self.options["source"]
 
             child_code.document = self.state.document
             child_code.source, node.line = source, line

--- a/snooty/rstspec-consolidated.toml
+++ b/snooty/rstspec-consolidated.toml
@@ -440,12 +440,14 @@ options.copyable = "boolean"
 options.emphasize-lines = "string"
 options.class = "string"
 options.linenos = "flag"
+options.source = "uri"
 example = """.. code-block:: ${1:language}
    ${2::copyable: (bool)
    :caption: (string)
    :emphasize-lines: (string)
    :class: (string)
-   :linenos: (flag)}
+   :linenos: (flag)
+   :source: ${1: URL to source code}}
 
    ${0:code content}
 """
@@ -458,7 +460,8 @@ example = """.. code:: ${1:language}
    :caption: (string)
    :emphasize-lines: (string)
    :class: (string)
-   :linenos: (flag)}
+   :linenos: (flag)
+   :source: ${1: URL to source code}}
 
    ${0:code content}
 """

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -440,12 +440,14 @@ options.copyable = "boolean"
 options.emphasize-lines = "string"
 options.class = "string"
 options.linenos = "flag"
+options.source = "uri"
 example = """.. code-block:: ${1:language}
    ${2::copyable: (bool)
    :caption: (string)
    :emphasize-lines: (string)
    :class: (string)
-   :linenos: (flag)}
+   :linenos: (flag)
+   :source: ${1: URL to source code}}
 
    ${0:code content}
 """
@@ -458,7 +460,8 @@ example = """.. code:: ${1:language}
    :caption: (string)
    :emphasize-lines: (string)
    :class: (string)
-   :linenos: (flag)}
+   :linenos: (flag)
+   :source: ${1: URL to source code}}
 
    ${0:code content}
 """

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -793,6 +793,41 @@ def test_codeblock() -> None:
     assert len(diagnostics) == 1
     assert isinstance(diagnostics[0], DocUtilsParseError)
 
+    # Test source option
+    page, diagnostics = parse_rst(
+        parser,
+        tabs_path,
+        """
+.. code-block:: java
+   :copyable: false
+   :source: https://www.github.com/mongodb/snooty
+
+   foo""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst">
+        <code lang="java" source="https://www.github.com/mongodb/snooty">foo</code>
+        </root>""",
+    )
+
+    # Test empty source
+    page, diagnostics = parse_rst(
+        parser,
+        tabs_path,
+        """
+.. code-block:: java
+   :copyable: false
+   :source: 
+
+   foo""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    assert isinstance(diagnostics[0], DocUtilsParseError)
+
 
 def test_literalinclude() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))


### PR DESCRIPTION
This PR adds a source option to code-block in addition to io-code-block, so that the option can be passed into the Child Code nodes for input and output. In the frontend, this source URL would be used to redirect the user to an external page. 