### PR TITLE
Unravel reexporting spaghetti

### DIFF
--- a/snooty/builders/man.py
+++ b/snooty/builders/man.py
@@ -5,8 +5,8 @@ from enum import Enum, auto
 from typing import Dict, Iterable, List, Union, cast
 
 from .. import n
+from ..n import FileId
 from ..page import Page
-from ..types import FileId
 
 logger = logging.getLogger(__name__)
 

--- a/snooty/builders/test_man.py
+++ b/snooty/builders/test_man.py
@@ -9,7 +9,7 @@ from typing import Dict, Union, cast
 import pytest
 
 from ..diagnostics import CannotOpenFile, UnsupportedFormat
-from ..types import FileId
+from ..n import FileId
 from ..util_test import make_test
 
 PAGE_TEXT = """

--- a/snooty/eventparser.py
+++ b/snooty/eventparser.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from . import n
+from .n import FileId
 from .page import Page
-from .types import FileId
 from .util import CancelledException
 
 

--- a/snooty/gizaparser/parse.py
+++ b/snooty/gizaparser/parse.py
@@ -9,7 +9,8 @@ from yaml.composer import Composer
 
 from ..diagnostics import Diagnostic, ErrorParsingYAMLFile, UnmarshallingError
 from ..flutter import LoadError, check_type, mapping_dict
-from ..types import ProjectConfig, SerializableType
+from ..n import SerializableType
+from ..types import ProjectConfig
 
 _T = TypeVar("_T")
 logger = logging.getLogger(__name__)

--- a/snooty/gizaparser/test_extracts.py
+++ b/snooty/gizaparser/test_extracts.py
@@ -7,9 +7,10 @@ from ..diagnostics import (
     FailedToInheritRef,
     UnmarshallingError,
 )
+from ..n import FileId
 from ..page import Page
 from ..parser import EmbeddedRstParser
-from ..types import FileId, ProjectConfig
+from ..types import ProjectConfig
 from ..util_test import check_ast_testing_string, make_test
 from .extracts import GizaExtractsCategory
 

--- a/snooty/gizaparser/test_steps.py
+++ b/snooty/gizaparser/test_steps.py
@@ -2,9 +2,10 @@ from pathlib import Path, PurePath
 from typing import Dict, List, Optional, Tuple
 
 from ..diagnostics import Diagnostic
+from ..n import FileId
 from ..page import Page
 from ..parser import EmbeddedRstParser
-from ..types import FileId, ProjectConfig
+from ..types import ProjectConfig
 from ..util_test import ast_to_testing_string, check_ast_testing_string, make_test
 from .steps import GizaStepsCategory
 

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -28,9 +28,10 @@ import pyls_jsonrpc.streams
 from . import n, util
 from .diagnostics import Diagnostic
 from .flutter import check_type, checked
+from .n import FileId, SerializableType
 from .page import Page
 from .parser import Project, ProjectBackend
-from .types import BuildIdentifierSet, FileId, SerializableType
+from .types import BuildIdentifierSet
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 Uri = str

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -37,9 +37,10 @@ from docopt import docopt
 
 from . import __version__, language_server, specparser
 from .diagnostics import Diagnostic, MakeCorrectionMixin
+from .n import FileId, SerializableType
 from .page import Page
 from .parser import Project, ProjectBackend
-from .types import BuildIdentifierSet, FileId, SerializableType
+from .types import BuildIdentifierSet
 from .util import PACKAGE_ROOT, SOURCE_FILE_EXTENSIONS, HTTPCache, PerformanceLogger
 
 PARANOID_MODE = os.environ.get("SNOOTY_PARANOID", "0") == "1"

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -4,8 +4,9 @@ from typing import Dict, List, Optional, Set
 
 from . import n
 from .diagnostics import Diagnostic
+from .n import FileId
 from .target_database import EmptyProjectInterface, ProjectInterface
-from .types import FileId, StaticAsset
+from .types import StaticAsset
 
 
 class PendingTask:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -64,18 +64,12 @@ from .diagnostics import (
     UnknownTabset,
 )
 from .gizaparser.nodes import GizaCategory
+from .n import FileId, SerializableType
 from .openapi import OpenAPI
 from .page import Page, PendingTask
 from .postprocess import DevhubPostprocessor, Postprocessor, PostprocessorResult
 from .target_database import ProjectInterface, TargetDatabase
-from .types import (
-    BuildIdentifierSet,
-    FileId,
-    ParsedBannerConfig,
-    ProjectConfig,
-    SerializableType,
-    StaticAsset,
-)
+from .types import BuildIdentifierSet, ParsedBannerConfig, ProjectConfig, StaticAsset
 from .util import RST_EXTENSIONS
 
 NO_CHILDREN = (n.SubstitutionReference,)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -55,9 +55,10 @@ from .diagnostics import (
     UnsupportedFormat,
 )
 from .eventparser import EventParser, FileIdStack
+from .n import FileId, SerializableType
 from .page import Page
 from .target_database import TargetDatabase
-from .types import FileId, ProjectConfig, SerializableType
+from .types import ProjectConfig
 from .util import SOURCE_FILE_EXTENSIONS, bundle
 
 logger = logging.getLogger(__name__)

--- a/snooty/target_database.py
+++ b/snooty/target_database.py
@@ -12,7 +12,8 @@ from typing_extensions import Protocol
 
 from . import intersphinx, n, specparser
 from .cache import Cache
-from .types import FileId, ProjectConfig, normalize_target
+from .n import FileId
+from .types import ProjectConfig, normalize_target
 
 logger = logging.getLogger(__name__)
 

--- a/snooty/test_devhub.py
+++ b/snooty/test_devhub.py
@@ -3,9 +3,10 @@ from typing import Any, Dict, List, cast
 
 import pytest
 
+from .n import FileId, SerializableType
 from .parser import Project
 from .test_project import Backend
-from .types import BuildIdentifierSet, FileId, SerializableType
+from .types import BuildIdentifierSet
 from .util_test import ast_to_testing_string, check_ast_testing_string
 
 

--- a/snooty/test_intersphinx.py
+++ b/snooty/test_intersphinx.py
@@ -8,10 +8,10 @@ from pytest import raises
 from . import n
 from .diagnostics import FetchError
 from .intersphinx import Inventory, TargetDefinition, fetch_inventory
+from .n import FileId
 from .parser import Project
 from .target_database import TargetDatabase
 from .test_project import Backend
-from .types import FileId
 from .util_test import make_test
 
 TESTING_CACHE_DIR = Path(f".intersphinx_cache-{os.getpid()}")

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -10,7 +10,7 @@ import pytest
 from . import language_server
 from .diagnostics import DocUtilsParseError, InvalidTableStructure
 from .flutter import check_type, checked
-from .types import FileId, SerializableType
+from .n import FileId, SerializableType
 from .util_test import ast_to_testing_string, check_ast_testing_string
 
 CWD_URL = "file://" + Path().resolve().as_posix()

--- a/snooty/test_main.py
+++ b/snooty/test_main.py
@@ -7,7 +7,7 @@ from typing import Any, List
 
 from . import main
 from .diagnostics import InvalidLiteralInclude, InvalidURL, UnknownSubstitution
-from .types import FileId
+from .n import FileId
 
 
 def test_backend() -> None:

--- a/snooty/test_mongodb_domain.py
+++ b/snooty/test_mongodb_domain.py
@@ -3,9 +3,10 @@ from pathlib import Path
 import pytest
 
 from . import n
+from .n import FileId
 from .parser import Project
 from .test_project import Backend
-from .types import BuildIdentifierSet, FileId
+from .types import BuildIdentifierSet
 from .util_test import check_ast_testing_string
 
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -23,7 +23,7 @@ from .diagnostics import (
     TabMustBeDirective,
     TargetNotFound,
 )
-from .types import FileId
+from .n import FileId
 from .util_test import (
     ast_to_testing_string,
     check_ast_testing_string,

--- a/snooty/test_postprocess_old_and_monolithic.py
+++ b/snooty/test_postprocess_old_and_monolithic.py
@@ -5,9 +5,10 @@ import pytest
 
 from . import n
 from .diagnostics import AmbiguousTarget, MissingTocTreeEntry, TargetNotFound
+from .n import FileId
 from .parser import Project
 from .test_project import Backend
-from .types import BuildIdentifierSet, FileId
+from .types import BuildIdentifierSet
 from .util_test import (
     ast_to_testing_string,
     check_ast_testing_string,

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -8,10 +8,11 @@ from typing import DefaultDict, Dict, List
 
 from . import n
 from .diagnostics import ConstantNotDeclared, Diagnostic, GitMergeConflictArtifactFound
+from .n import FileId, SerializableType
 from .page import Page
 from .parser import Project, ProjectBackend
 from .target_database import TargetDatabase
-from .types import BuildIdentifierSet, FileId, ProjectConfig, SerializableType
+from .types import BuildIdentifierSet, ProjectConfig
 from .util import ast_dive
 from .util_test import check_ast_testing_string, make_test
 

--- a/snooty/test_sharedinclude.py
+++ b/snooty/test_sharedinclude.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from .diagnostics import CannotOpenFile, ConfigurationProblem, SubstitutionRefError
-from .types import FileId
+from .n import FileId
 from .util_test import check_ast_testing_string, make_test
 
 

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -1,7 +1,8 @@
 from pathlib import Path, PurePath
 
+from .n import FileId
 from .page import Page
-from .types import FileId, ProjectConfig, StaticAsset
+from .types import ProjectConfig, StaticAsset
 
 
 def test_project() -> None:

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -17,11 +17,8 @@ from .diagnostics import (
     UnmarshallingError,
 )
 from .flutter import LoadError, check_type, checked
-from .n import FileId as FD
-from .n import SerializableType as ST
+from .n import FileId
 
-SerializableType = ST
-FileId = FD
 FileSource = Union[Path, str]
 PAT_VARIABLE = re.compile(r"{\+([\w-]+)\+}")
 PAT_GIT_MARKER = re.compile(r"^<<<<<<< .*?^=======\n.*?^>>>>>>>", re.M | re.S)

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -46,7 +46,6 @@ import watchdog.observers
 import watchdog.observers.api
 
 from . import n
-from .types import FileId
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
@@ -66,13 +65,13 @@ if PACKAGE_ROOT.is_file():
 
 def reroot_path(
     filename: PurePosixPath, docpath: PurePath, project_root: Path
-) -> Tuple[FileId, Path]:
+) -> Tuple[n.FileId, Path]:
     """Files within a project may refer to other files. Return a canonical path
     relative to the project root."""
     if filename.is_absolute():
-        rel_fn = FileId(*filename.parts[1:])
+        rel_fn = n.FileId(*filename.parts[1:])
     else:
-        rel_fn = FileId(*docpath.parent.joinpath(filename).parts).collapse_dots()
+        rel_fn = n.FileId(*docpath.parent.joinpath(filename).parts).collapse_dots()
     return rel_fn, project_root.joinpath(rel_fn).resolve()
 
 

--- a/snooty/util_test.py
+++ b/snooty/util_test.py
@@ -12,10 +12,11 @@ from xml.sax.saxutils import escape
 
 from . import n, rstparser
 from .diagnostics import Diagnostic
+from .n import FileId, SerializableType
 from .page import Page
 from .parser import JSONVisitor, Project, ProjectBackend
 from .parser import parse_rst as parse_rst_multi
-from .types import BuildIdentifierSet, FileId, SerializableType
+from .types import BuildIdentifierSet
 
 __all__ = ("eprint", "ast_to_testing_string", "assert_etree_equals")
 


### PR DESCRIPTION
A Long Time Ago we moved where FileId and SerializableType lived to avoid a cyclic import. Let's tidy up the compatibility re-exporting to avoid *another* cyclic import.