### PR TITLE
DOP-2657: Add data_fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
     "docutils >= 0.16, < 0.18",
     "watchdog ~= 1.0",
     "requests ~= 2.24",
-    "toml ~= 0.10",
+    "tomli ~= 2.0",
     "pyyaml ~= 5.3",
     "typing-extensions >= 3.7",
     "python-jsonrpc-server ~= 0.3.4",
@@ -30,8 +30,7 @@ dev = [
     "mypy == 0.942",
     "pyinstaller ~= 4.10",
     "isort ~= 5.10.1",
-    "types-requests ~= 2.26.1",
-    "types-toml ~= 0.10.1"
+    "types-requests ~= 2.26.1"
 ]
 test = [
     "pytest ~= 7.1.1",

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -30,7 +30,7 @@ from pathlib import Path, PurePath
 from typing import Any, Dict, List, Optional, Union
 
 import pymongo
-import toml
+import tomli
 import watchdog.events
 import watchdog.observers
 from docopt import docopt
@@ -165,8 +165,8 @@ class MongoBackend(Backend):
         ] = defaultdict(list)
 
     def _config_db(self) -> str:
-        with PACKAGE_ROOT.joinpath("config.toml").open(encoding="utf-8") as f:
-            config = toml.load(f)
+        with PACKAGE_ROOT.joinpath("config.toml").open("rb") as f:
+            config = tomli.load(f)
             db_name = config["environments"][SNOOTY_ENV]["db"]
             assert isinstance(db_name, str)
             return db_name

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1,3 +1,5 @@
+data_fields = ["source_page_template", "assets"]
+
 [meta]
 version = 0
 

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -25,7 +25,7 @@ from typing import (
 import docutils.nodes
 import docutils.parsers.rst
 import docutils.parsers.rst.directives
-import toml
+import tomli
 from typing_extensions import Protocol
 
 from . import util
@@ -280,7 +280,7 @@ class Spec:
     @classmethod
     def loads(cls, data: str) -> "Spec":
         """Load a spec from a string."""
-        root = check_type(cls, toml.loads(data))
+        root = check_type(cls, tomli.loads(data))
         if root.meta.version != SPEC_VERSION:
             raise ValueError(f"Unknown spec version: {root.meta.version}")
 

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -273,6 +273,7 @@ class Spec:
     role: Dict[str, Role] = field(default_factory=dict)
     rstobject: Dict[str, RstObject] = field(default_factory=dict)
     tabs: Dict[str, List[TabDefinition]] = field(default_factory=dict)
+    data_fields: List[str] = field(default_factory=list)
 
     SPEC: ClassVar[Optional[Spec]] = None
 

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -267,7 +267,7 @@ name = "invalid_data"
 
 [data]
 source_page_template = "https://github.com/mongodb/docs/blob/master/source/%s.txt"
-invalid = "gooblygoobly"
+invalid = {foo = "bar"}
 """,
             Path("source/index.txt"): r"",
         }

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -7,7 +7,12 @@ from pathlib import Path, PurePath
 from typing import DefaultDict, Dict, List
 
 from . import n
-from .diagnostics import ConstantNotDeclared, Diagnostic, GitMergeConflictArtifactFound
+from .diagnostics import (
+    ConstantNotDeclared,
+    Diagnostic,
+    GitMergeConflictArtifactFound,
+    UnmarshallingError,
+)
 from .n import FileId, SerializableType
 from .page import Page
 from .parser import Project, ProjectBackend
@@ -250,3 +255,23 @@ def test_target_wipe() -> None:
             query_result = project._project.targets["std:label:gooblygooblygoo"][0]
             assert isinstance(query_result, TargetDatabase.InternalResult)
             assert query_result.result[0] == "index"
+
+
+def test_invalid_data() -> None:
+    with make_test(
+        {
+            Path(
+                "snooty.toml"
+            ): r"""
+name = "invalid_data"
+
+[data]
+source_page_template = "https://github.com/mongodb/docs/blob/master/source/%s.txt"
+invalid = "gooblygoobly"
+""",
+            Path("source/index.txt"): r"",
+        }
+    ) as result:
+        assert [type(d) for d in result.diagnostics[FileId("snooty.toml")]] == [
+            UnmarshallingError
+        ]

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePath
 from typing import Dict, List, Match, MutableSequence, Optional, Tuple, Union
 
-import toml
+import tomli
 from typing_extensions import Protocol
 
 from . import n, specparser
@@ -167,8 +167,8 @@ class ProjectConfig:
         diagnostics: List[Diagnostic] = []
         while path.parent != path:
             try:
-                with path.joinpath("snooty.toml").open(encoding="utf-8") as f:
-                    data = toml.load(f)
+                with path.joinpath("snooty.toml").open("rb") as f:
+                    data = tomli.load(f)
                     data["root"] = path
                     result, parsed_diagnostics = check_type(
                         ProjectConfig, data


### PR DESCRIPTION
This permits `rstspec.toml` to list fields that may be included in `snooty.toml` under the `data` namespace. This is to be used for Nathan's asset fetching script.