### PR TITLE
DOP-2939: Add rstobjects for Data Lake config

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1743,6 +1743,22 @@ help = """Stitch Function Context"""
 help = """Data Lake Configuration Object"""
 prefix = "datalakeconf"
 
+[rstobject."mongodb:datalakeconf-adl"]
+help = """Data Lake ADL Configuration Object"""
+prefix = "datalakeconf-adl"
+
+[rstobject."mongodb:datalakeconf-atlas"]
+help = """Data Lake Atlas Configuration Object"""
+prefix = "datalakeconf-atlas"
+
+[rstobject."mongodb:datalakeconf-aws"]
+help = """Data Lake AWS Configuration Object"""
+prefix = "datalakeconf-aws"
+
+[rstobject."mongodb:datalakeconf-http"]
+help = """Data Lake HTTP Configuration Object"""
+prefix = "datalakeconf-http"
+
 [rstobject."mongodb:opsmgrkube"]
 help = """Kubernetes Operator Ops Manager Resource Setting"""
 prefix = "opsmgrkube"


### PR DESCRIPTION
Ticket: DOP-2939
[Staging link](https://docs-mongodbcom-integration.corp.mongodb.com/DOP-2939/datalake/raymundrodriguez/master/reference/cli/collections/create-collections-views/) - see list of `store` examples at the top of the page