### PR TITLE
DOP-3064: Validate relative URLs in card directives

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -515,7 +515,7 @@ class MalformedRelativePath(Diagnostic):
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
-        super().__init__(f"Malformed relative path {str(relative_path)}", start, end)
+        super().__init__(f"Malformed relative path {relative_path}", start, end)
         self.relative_path = relative_path
 
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -505,6 +505,7 @@ class IncorrectLinkSyntax(Diagnostic, MakeCorrectionMixin):
     def did_you_mean(self) -> List[str]:
         return [f"`{self.parts[0]} <{self.parts[1]}>`__"]
 
+
 class MalformedRelativePath(Diagnostic):
     severity = Diagnostic.Level.error
 
@@ -516,6 +517,7 @@ class MalformedRelativePath(Diagnostic):
     ) -> None:
         super().__init__(f"Malformed relative path {str(relative_path)}", start, end)
         self.relative_path = relative_path
+
 
 class MissingTab(Diagnostic):
     severity = Diagnostic.Level.error

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -505,6 +505,17 @@ class IncorrectLinkSyntax(Diagnostic, MakeCorrectionMixin):
     def did_you_mean(self) -> List[str]:
         return [f"`{self.parts[0]} <{self.parts[1]}>`__"]
 
+class MalformedRelativePath(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        relative_path: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(f"Malformed relative path {str(relative_path)}", start, end)
+        self.relative_path = relative_path
 
 class MissingTab(Diagnostic):
     severity = Diagnostic.Level.error

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -952,7 +952,9 @@ class JSONVisitor:
         )
 
         if not target_path.is_file():
-            err_message = f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
+            err_message = (
+                f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
+            )
             self.diagnostics.append(CannotOpenFile(target_path, err_message, line))
         elif re.search(r"([\/])\1", url_argument) is not None:
             self.diagnostics.append(MalformedRelativePath(url_argument, line))

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -945,14 +945,12 @@ class JSONVisitor:
 
     def validate_relative_url(self, url_argument: str, line: int) -> None:
         """Validate relative URL points to page within current docs site"""
-        fullPath = util.filepath_given_relative_url(url_argument, self.project_config.source_path)
-        if not Path(fullPath).is_file():
+        fullPath = Path(
+            util.path_given_relative_url(url_argument, self.project_config.source_path)
+        )
+        if not fullPath.is_file():
             errMessage = f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
-            self.diagnostics.append(
-                CannotOpenFile(
-                    fullPath, errMessage, line
-                )
-            )
+            self.diagnostics.append(CannotOpenFile(fullPath, errMessage, line))
 
     def validate_doc_role(self, node: docutils.nodes.Node) -> None:
         """Validate target for doc role"""

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -944,13 +944,16 @@ class JSONVisitor:
             )
 
     def validate_relative_url(self, url_argument: str, line: int) -> None:
-        """Validate relative URL points to page within current docs site"""
-        fullPath = Path(
-            util.path_given_relative_url(url_argument, self.project_config.source_path)
+        """Validate relative URL points to page within current docs site.
+        URLs can be of the form /foo, foo, /foo/"""
+        relative_txt_path = Path(url_argument).with_suffix(".txt")
+        _, absolute = util.reroot_path(
+            FileId(relative_txt_path), self.docpath, self.project_config.source_path
         )
-        if not fullPath.is_file():
+
+        if not absolute.is_file():
             errMessage = f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
-            self.diagnostics.append(CannotOpenFile(fullPath, errMessage, line))
+            self.diagnostics.append(CannotOpenFile(absolute, errMessage, line))
 
     def validate_doc_role(self, node: docutils.nodes.Node) -> None:
         """Validate target for doc role"""

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -946,14 +946,13 @@ class JSONVisitor:
     def validate_relative_url(self, url_argument: str, line: int) -> None:
         """Validate relative URL points to page within current docs site.
         URLs can be of the form /foo, foo, /foo/"""
-        relative_txt_path = Path(url_argument).with_suffix(".txt")
-        _, absolute = util.reroot_path(
-            FileId(relative_txt_path), self.docpath, self.project_config.source_path
+        target_path = util.add_doc_target_ext(
+            url_argument, self.docpath, self.project_config.source_path
         )
 
-        if not absolute.is_file():
-            errMessage = f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
-            self.diagnostics.append(CannotOpenFile(absolute, errMessage, line))
+        if not target_path.is_file():
+            err_message = f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
+            self.diagnostics.append(CannotOpenFile(target_path, err_message, line))
 
     def validate_doc_role(self, node: docutils.nodes.Node) -> None:
         """Validate target for doc role"""

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -55,6 +55,7 @@ from .diagnostics import (
     InvalidTableStructure,
     InvalidURL,
     MalformedGlossary,
+    MalformedRelativePath,
     MissingChild,
     RemovedLiteralBlockSyntax,
     TabMustBeDirective,
@@ -953,6 +954,8 @@ class JSONVisitor:
         if not target_path.is_file():
             err_message = f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
             self.diagnostics.append(CannotOpenFile(target_path, err_message, line))
+        elif re.search(r"([\/])\1", url_argument) is not None:
+            self.diagnostics.append(MalformedRelativePath(url_argument, line))
 
     def validate_doc_role(self, node: docutils.nodes.Node) -> None:
         """Validate target for doc role"""

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -944,15 +944,13 @@ class JSONVisitor:
             )
 
     def validate_relative_url(self, url_argument: str, line: int) -> None:
-        """Validate URL point to page within docs site"""
-        # import pdb; pdb.set_trace()
-        # TODO: lots of the same code as validate_doc_role. can you DRY it out...
-        filePath = url_argument if url_argument[0] == "/" else f"/{url_argument}"
-        fullPath = f"{self.project_config.source_path}{filePath}.txt" # TODO: what other file types could be here??
+        """Validate relative URL points to page within current docs site"""
+        fullPath = util.filepath_given_relative_url(url_argument, self.project_config.source_path)
         if not Path(fullPath).is_file():
+            errMessage = f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
             self.diagnostics.append(
-                CannotOpenFile( # TODO: maybe a new error that's a subclass of CannotOpenFile?
-                    fullPath, os.strerror(errno.ENOENT), line
+                CannotOpenFile(
+                    fullPath, errMessage, line
                 )
             )
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -74,6 +74,7 @@ from .types import BuildIdentifierSet, ParsedBannerConfig, ProjectConfig, Static
 from .util import RST_EXTENSIONS
 
 NO_CHILDREN = (n.SubstitutionReference,)
+MULTIPLE_FORWARD_SLASHES = re.compile(r"([\/])\1")
 logger = logging.getLogger(__name__)
 
 
@@ -956,7 +957,7 @@ class JSONVisitor:
                 f"{os.strerror(errno.ENOENT)} for relative path {url_argument}"
             )
             self.diagnostics.append(CannotOpenFile(target_path, err_message, line))
-        elif re.search(r"([\/])\1", url_argument) is not None:
+        elif MULTIPLE_FORWARD_SLASHES.search(url_argument) is not None:
             self.diagnostics.append(MalformedRelativePath(url_argument, line))
 
     def validate_doc_role(self, node: docutils.nodes.Node) -> None:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -15,6 +15,7 @@ from .diagnostics import (
     InvalidURL,
     MakeCorrectionMixin,
     MalformedGlossary,
+    MalformedRelativePath,
     TabMustBeDirective,
     UnexpectedIndentation,
     UnknownTabID,
@@ -127,7 +128,7 @@ def test_card() -> None:
 
     SOURCE_DIR = "/test_project/source/"
     VALID_URLS = ["index", "index/"]
-    INVALID_URL = "foo"
+    INVALID_URL = [("foo", CannotOpenFile), ("index//", MalformedRelativePath)]
     CARD_CONTENT = """
 .. card-group::
    :columns: 3
@@ -151,13 +152,14 @@ def test_card() -> None:
         page.finish(diagnostics)
         assert len(diagnostics) == 0
 
-    page, diagnostics = parse_rst(
-        parser,
-        path,
-        CARD_CONTENT % (SOURCE_DIR + INVALID_URL),
-    )
-    assert len(diagnostics) == 1
-    assert isinstance(diagnostics[0], CannotOpenFile)
+    for url, error_type in INVALID_URL:
+        page, diagnostics = parse_rst(
+            parser,
+            path,
+            CARD_CONTENT % (SOURCE_DIR + url),
+        )
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], error_type)
 
 
 def test_tabs() -> None:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -119,6 +119,47 @@ def test_chapter() -> None:
     assert isinstance(diagnostics[0], CannotOpenFile)
 
 
+def test_card() -> None:
+    """Test card directive"""
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    SOURCE_DIR = "/test_project/source/"
+    VALID_URLS = ["index", "index/"]
+    INVALID_URL = "foo"
+    CARD_CONTENT = """
+.. card-group::
+   :columns: 3
+   :layout: carousel
+
+   .. card::
+      :headline: Develop Applications
+      :cta: Test Develop Applications Relative URL Test
+      :url: %s
+
+      This card was built with a relative URL.
+"""
+
+    for url in VALID_URLS:
+        page, diagnostics = parse_rst(
+            parser,
+            path,
+            CARD_CONTENT % (SOURCE_DIR + url),
+        )
+
+        page.finish(diagnostics)
+        assert len(diagnostics) == 0
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        CARD_CONTENT % (SOURCE_DIR + INVALID_URL),
+    )
+    assert len(diagnostics) == 1
+    assert isinstance(diagnostics[0], CannotOpenFile)
+
+
 def test_tabs() -> None:
     tabs_path = ROOT_PATH.joinpath(Path("test_tabs.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")

--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -26,6 +26,11 @@ def test_reroot_path() -> None:
     )
     assert relative.parts == ("test_data", "bar", "baz.rst")
 
+def test_path_given_relative_url() -> None:
+    relative_urls = ["/foo", "foo", "/foo/"]
+    expected_output = [str(Path(".").joinpath("foo.txt").resolve()) for i in range(3)]
+    result = map(lambda url: util.path_given_relative_url(url, Path(".").resolve()), relative_urls)
+    assert list(result) == expected_output
 
 def test_option_string() -> None:
     assert util.option_string("Test") == "Test"

--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -27,16 +27,6 @@ def test_reroot_path() -> None:
     assert relative.parts == ("test_data", "bar", "baz.rst")
 
 
-def test_path_given_relative_url() -> None:
-    relative_urls = ["/foo", "foo", "/foo/"]
-    expected_output = [str(Path(".").joinpath("foo.txt").resolve()) for i in range(3)]
-    result = map(
-        lambda url: util.path_given_relative_url(url, Path(".").resolve()),
-        relative_urls,
-    )
-    assert list(result) == expected_output
-
-
 def test_option_string() -> None:
     assert util.option_string("Test") == "Test"
     # No input or blank input should raise a ValueError

--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -26,11 +26,16 @@ def test_reroot_path() -> None:
     )
     assert relative.parts == ("test_data", "bar", "baz.rst")
 
+
 def test_path_given_relative_url() -> None:
     relative_urls = ["/foo", "foo", "/foo/"]
     expected_output = [str(Path(".").joinpath("foo.txt").resolve()) for i in range(3)]
-    result = map(lambda url: util.path_given_relative_url(url, Path(".").resolve()), relative_urls)
+    result = map(
+        lambda url: util.path_given_relative_url(url, Path(".").resolve()),
+        relative_urls,
+    )
     assert list(result) == expected_output
+
 
 def test_option_string() -> None:
     assert util.option_string("Test") == "Test"

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -84,11 +84,12 @@ def is_relative_to(a: Path, b: Path) -> bool:
 
 
 def path_given_relative_url(relative_url: str, project_root: Path) -> str:
-    """Returns absolute path to file specified by relative URL.
+    """Returns absolute path to txt file specified by relative URL.
     URLs can be of the form /foo, foo, /foo/"""
     relative_url = relative_url[1:] if relative_url.startswith("/") else relative_url
     relative_url = relative_url[:-1] if relative_url.endswith("/") else relative_url
-    return f"{project_root}/{relative_url}.txt" # TODO: what other file types could be here??
+    return f"{project_root}/{relative_url}.txt"
+
 
 def get_files(
     root: Path, extensions: Container[str], must_be_relative_to: Optional[Path] = None

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -83,6 +83,13 @@ def is_relative_to(a: Path, b: Path) -> bool:
         return False
 
 
+def filepath_given_relative_url(relative_url: str, project_root: Path) -> str:
+    """Returns absolute path to file specified by relative URL.
+    URLs can be of the form /foo, foo, /foo/"""
+    relative_url = relative_url[1:] if relative_url.startswith("/") else relative_url
+    relative_url = relative_url[:-1] if relative_url.endswith("/") else relative_url
+    return f"{project_root}/{relative_url}.txt" # TODO: what other file types could be here??
+
 def get_files(
     root: Path, extensions: Container[str], must_be_relative_to: Optional[Path] = None
 ) -> Iterator[Path]:

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -83,14 +83,6 @@ def is_relative_to(a: Path, b: Path) -> bool:
         return False
 
 
-def path_given_relative_url(relative_url: str, project_root: Path) -> str:
-    """Returns absolute path to txt file specified by relative URL.
-    URLs can be of the form /foo, foo, /foo/"""
-    relative_url = relative_url[1:] if relative_url.startswith("/") else relative_url
-    relative_url = relative_url[:-1] if relative_url.endswith("/") else relative_url
-    return f"{project_root}/{relative_url}.txt"
-
-
 def get_files(
     root: Path, extensions: Container[str], must_be_relative_to: Optional[Path] = None
 ) -> Iterator[Path]:

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -83,7 +83,7 @@ def is_relative_to(a: Path, b: Path) -> bool:
         return False
 
 
-def filepath_given_relative_url(relative_url: str, project_root: Path) -> str:
+def path_given_relative_url(relative_url: str, project_root: Path) -> str:
     """Returns absolute path to file specified by relative URL.
     URLs can be of the form /foo, foo, /foo/"""
     relative_url = relative_url[1:] if relative_url.startswith("/") else relative_url

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -169,7 +169,7 @@ def add_doc_target_ext(target: str, docpath: PurePath, project_root: Path) -> Pa
     new_suffix = target_path.suffix + ".txt"
     target_path = target_path.with_suffix(new_suffix)
 
-    fileid, resolved_target_path = reroot_path(target_path, docpath, project_root)
+    _, resolved_target_path = reroot_path(target_path, docpath, project_root)
     return resolved_target_path
 
 


### PR DESCRIPTION
### Ticket

[DOP-3064](https://jira.mongodb.org/browse/DOP-3064)

### Notes

[DOP-3039](https://jira.mongodb.org/browse/DOP-3039) added support for relative URLs in the `Card` component in the frontend. This PR adds validations to the parser to ensure that any relative URL passed as an option to the card directive points to a valid `.txt` file within the docs site being parsed.

The relative URLs can have leading or trailing slashes (or no slashes at all if the referenced file is not nested within the `source` directory). This aligns with the [expectations in the frontend](https://github.com/mongodb/snooty/blob/f57d8464374d62808a822d1cbeab6bb65d538ec9/tests/unit/Card.test.js#L20).

**Current Behavior**:

Running the parser when an invalid relative URL is passed in the card directive does not generate an error.

**New Behavior**: 

Running the parser with an invalid relative URL in the card directive generates an error with an explanation for the user.

Content:
```
   .. card::
      :headline: Launch & Manage MongoDB
      :cta: Launch & Manage MongoDB Relative URL Test
      :url: /launch-manage!!!!
      :icon: /images/icons/atlas.svg
      :icon-alt: MongoDB Atlas icon
```

Build:
```
➜  docs-landing git:(dop-3039-content-test) ✗ python3 -m snooty build .
INFO:snooty.main:Snooty 0.13.5 starting
ERROR(index.txt:47ish): Error opening /Users/drew.beckmen/Development/mongodb/docs-landing/source/launch-manage!!!!.txt: No such file or directory for relative path /launch-manage!!!!
```

Replacing `url: /launch-manage!!!!` with `url: /launch-manage` results in a clean build.

