### PR TITLE
Spelling suggestions for linking targets

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -288,19 +288,24 @@ class UnknownSubstitution(Diagnostic):
     severity = Diagnostic.Level.warning
 
 
-class TargetNotFound(Diagnostic):
+class TargetNotFound(Diagnostic, MakeCorrectionMixin):
     severity = Diagnostic.Level.error
 
     def __init__(
         self,
         name: str,
         target: str,
+        candidates: Sequence[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(f'Target not found: "{name}:{target}"', start, end)
         self.name = name
         self.target = target
+        self.candidates = list(candidates)
+
+    def did_you_mean(self) -> List[str]:
+        return self.candidates
 
 
 class AmbiguousTarget(Diagnostic):

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -108,7 +108,8 @@ class Backend(ProjectBackend):
 
             if isinstance(diagnostic, MakeCorrectionMixin):
                 did_you_mean = diagnostic.did_you_mean()
-                info["did_you_mean"] = did_you_mean
+                if did_you_mean:
+                    info["did_you_mean"] = did_you_mean
 
             if output == "JSON":
                 document: Dict[str, object] = {"diagnostic": info}

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -402,7 +402,7 @@ class NamedReferenceHandlerPass2(Handler):
         if refuri is None:
             line = node.span[0]
             self.context.diagnostics[fileid_stack.current].append(
-                TargetNotFound("extlink", node.refname, line)
+                TargetNotFound("extlink", node.refname, [], line)
             )
             return
 
@@ -1279,8 +1279,11 @@ class RefsHandler(Handler):
             if injection_candidate is not None:
                 injection_candidate.children = [text_node]
 
+            # See if there are any near matches
+            suggestions = self.targets.get_suggestions(key)
+
             self.context.diagnostics[fileid_stack.current].append(
-                TargetNotFound(node.name, node.target, line)
+                TargetNotFound(node.name, node.target, suggestions, line)
             )
             return
 

--- a/snooty/target_database.py
+++ b/snooty/target_database.py
@@ -82,9 +82,9 @@ class TargetDatabase:
                         canonical_target_name,
                         title,
                     )
-                    for canonical_target_name, fileid, title, html5_id in self.local_definitions[
-                        key
-                    ]
+                    for canonical_target_name, fileid, title, html5_id in self.local_definitions.get(
+                        key, []
+                    )
                 )
             except KeyError:
                 pass
@@ -146,8 +146,8 @@ class TargetDatabase:
                 if len(key_definition_parts) != len(key_parts):
                     continue
 
-                # Evaluate each part separately, since the complexity is O(N*M)
-                # If any part is too different, we can abort before evaluating the rest
+                # Evaluate each part separately, since we can abort before evaluating the rest.
+                # Small bonus: complexity is O(N*M)
                 if all(
                     dist <= 2
                     for dist in (

--- a/snooty/target_database.py
+++ b/snooty/target_database.py
@@ -123,6 +123,7 @@ class TargetDatabase:
 
     def get_suggestions(self, key: str) -> Sequence[str]:
         key = normalize_target(key)
+        key = key.split(":", 2)[2]
         candidates: List[str] = []
 
         with self.lock:
@@ -136,7 +137,8 @@ class TargetDatabase:
 
             key_parts = PAT_TARGET_PART_SEPARATOR.split(key)
 
-            for key_definition in all_keys:
+            for original_key_definition in all_keys:
+                key_definition = original_key_definition.split(":", 2)[2]
                 if abs(len(key) - len(key_definition)) > 2:
                     continue
 
@@ -155,7 +157,7 @@ class TargetDatabase:
                         for p1, p2 in zip(key_parts, key_definition_parts)
                     )
                 ):
-                    candidates.append(key_definition)
+                    candidates.append(original_key_definition)
 
             return candidates
 

--- a/snooty/test_intersphinx.py
+++ b/snooty/test_intersphinx.py
@@ -267,4 +267,6 @@ def test_suggestions() -> None:
             ).repeat(number=5)
         )
     )
-    # db.get_suggestions("std:label:a-labal-on-index")
+    assert db.get_suggestions("std:label:a-labal-on-index") == [
+        "std:label:a-label-on-index"
+    ]

--- a/snooty/test_intersphinx.py
+++ b/snooty/test_intersphinx.py
@@ -258,15 +258,6 @@ def test_suggestions() -> None:
         "std-label-a-label-on-index-2",
     )
 
-    import timeit
-
-    print(
-        min(
-            timeit.Timer(
-                'db.get_suggestions("std:label:a-labal-on-index")', globals=locals()
-            ).repeat(number=5)
-        )
-    )
     assert db.get_suggestions("std:label:a-labal-on-index") == [
         "std:label:a-label-on-index"
     ]

--- a/snooty/test_intersphinx.py
+++ b/snooty/test_intersphinx.py
@@ -224,3 +224,47 @@ intersphinx = ["booglygoogly not a real URL"]
         assert [type(diag) for diag in result.diagnostics[FileId("snooty.toml")]] == [
             FetchError
         ]
+
+
+def test_suggestions() -> None:
+    inventory_bytes = Path("test_data/test_intersphinx/manual.inv").read_bytes()
+    inventory = Inventory.parse(INVENTORY_URL, inventory_bytes)
+    db = TargetDatabase(intersphinx_inventories={"manual": inventory})
+
+    db.define_local_target(
+        "std",
+        "option",
+        ["--maxVarcharLength", "mongosqld.--maxVarcharLength"],
+        FileId("reference/mongosqld.txt"),
+        [n.Text(span=(7,), value="mongosqld --maxVarcharLength")],
+        "std-option-mongosqld.--maxVarcharLength",
+    )
+
+    db.define_local_target(
+        "std",
+        "label",
+        ["a-label-on-index"],
+        FileId("index.txt"),
+        [n.Text(span=(7,), value="A Label on Index")],
+        "std-label-a-label-on-index",
+    )
+
+    db.define_local_target(
+        "std",
+        "label",
+        ["a-label-on-index-2"],
+        FileId("reference/index.txt"),
+        [n.Text(span=(7,), value="A Label on Index 2")],
+        "std-label-a-label-on-index-2",
+    )
+
+    import timeit
+
+    print(
+        min(
+            timeit.Timer(
+                'db.get_suggestions("std:label:a-labal-on-index")', globals=locals()
+            ).repeat(number=5)
+        )
+    )
+    # db.get_suggestions("std:label:a-labal-on-index")

--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -183,3 +183,12 @@ def test_worker_that_fails() -> None:
     worker = util.WorkerLauncher("worker-test", start)
     with pytest.raises(SomeException):
         worker.run_and_wait(None)
+
+
+def test_damerau_levenshtein_distance() -> None:
+    assert util.damerau_levenshtein_distance("foo", "foo") == 0
+    assert util.damerau_levenshtein_distance("foo", "f1o") == 1
+    assert util.damerau_levenshtein_distance("foo", "fo") == 1
+    assert util.damerau_levenshtein_distance("foo", "fooa") == 1
+    assert util.damerau_levenshtein_distance("foo", "ofo") == 1
+    assert util.damerau_levenshtein_distance("foo", "xoao") == 2


### PR DESCRIPTION
Implement Damerau-Levenshtein Distance spelling suggestions, with an edit distance of 2. Heuristics are used to severely limit the amount of entries in the target database we actually have to check, so even with large (non-adversarial) target databases this has low overhead.

However, each call is quite slow, so a pathological database could chew up a lot of time. It could be worth terminating if a set amount of time is wasted, and it might behoove us to copy the list of keys to check and release the lock quickly.

Example error:
```
ERROR(includes/steps-change-replica-set-wiredtiger.yaml:0ish): Target not found: "label:4.2-mmapv1-conf-option"
    Did you mean: std:label:4.2-mmapv1-conf-options
```

It would be better if the `did you mean` string were less... implementation-y and gave proper guidance about what should actually be written.