### PR TITLE
DOP-1166: include all icon roles. parse icon classname from role + target

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -292,7 +292,7 @@ class JSONVisitor:
                 self.state.append(role)
                 return
 
-            elif role_name.startswith('icon'):
+            elif role_name.startswith("icon"):
                 self.validate_icon_role(node)
 
             role = n.Role((line,), [], node["domain"], role_name, target, flag)
@@ -1031,19 +1031,21 @@ class JSONVisitor:
             return
         # construct icon class name based off node
         classname_prefix = {
-            'icon-fa5': 'fa',
-            'icon': 'fa',
-            'icon-fa5-brands': 'fa',
-            'iconb': 'fa',
-            'icon-mms': 'mms',
-            'icon-mms-org': 'mms-org',
-            'icon-charts': 'charts-icon',
-            'icon-fa4': 'fa4'
+            "icon-fa5": "fa",
+            "icon": "fa",
+            "icon-fa5-brands": "fa",
+            "iconb": "fa",
+            "icon-mms": "mms",
+            "icon-mms-org": "mms-org",
+            "icon-charts": "charts-icon",
+            "icon-fa4": "fa4",
         }
         icon_name = node["target"]
         target_icon_classname = f"{classname_prefix[node['name']]}-{icon_name}"
         if target_icon_classname not in ICON_SET:
-            self.diagnostics.append(IconMustBeDefined(target_icon_classname, util.get_line(node)))
+            self.diagnostics.append(
+                IconMustBeDefined(target_icon_classname, util.get_line(node))
+            )
         return
 
     def add_static_asset(self, raw_path: str, upload: bool) -> StaticAsset:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -292,7 +292,7 @@ class JSONVisitor:
                 self.state.append(role)
                 return
 
-            elif role_name == "icon":
+            elif role_name.startswith('icon'):
                 self.validate_icon_role(node)
 
             role = n.Role((line,), [], node["domain"], role_name, target, flag)
@@ -1029,16 +1029,21 @@ class JSONVisitor:
         """
         if not ICON_SET:
             return
-        icon_name = node["target"]
-        icon_name_formats = {
-            icon_name,
-            f"fa-{icon_name}",
-            f"fa4-{icon_name}",
-            f"mms-icon-{icon_name}",
-            f"charts-icon-{icon_name}",
+        # construct icon class name based off node
+        classname_prefix = {
+            'icon-fa5': 'fa',
+            'icon': 'fa',
+            'icon-fa5-brands': 'fa',
+            'iconb': 'fa',
+            'icon-mms': 'mms',
+            'icon-mms-org': 'mms-org',
+            'icon-charts': 'charts-icon',
+            'icon-fa4': 'fa4'
         }
-        if not icon_name_formats.intersection(ICON_SET):
-            self.diagnostics.append(IconMustBeDefined(icon_name, util.get_line(node)))
+        icon_name = node["target"]
+        target_icon_classname = f"{classname_prefix[node['name']]}-{icon_name}"
+        if target_icon_classname not in ICON_SET:
+            self.diagnostics.append(IconMustBeDefined(target_icon_classname, util.get_line(node)))
         return
 
     def add_static_asset(self, raw_path: str, upload: bool) -> StaticAsset:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3417,6 +3417,7 @@ def test_valid_icon() -> None:
 </root>""",
     )
 
+
 def test_invalid_icon() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3376,7 +3376,7 @@ here is an invalid character sequence\x80 oh noooo
         assert [(type(d), d.start[0]) for d in diagnostics] == [(CannotOpenFile, 2)]
 
 
-def test_icon() -> None:
+def test_valid_icon() -> None:
     path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
@@ -3403,7 +3403,41 @@ def test_icon() -> None:
         parser,
         path,
         """
+:icon-fa5-brands:`Windows logo <windows>`
+""",
+    )
+    page.finish(diagnostics)
+    check_ast_testing_string(
+        page.ast,
+        """
+<root fileid="test.rst">
+    <paragraph>
+        <role name="icon-fa5-brands" target="windows"><text>Windows logo</text></role>
+    </paragraph>
+</root>""",
+    )
+
+def test_invalid_icon() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
 :icon:`ICON-DNE`
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    assert isinstance(diagnostics[0], IconMustBeDefined)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+:icon-fa4:`shunned`
 """,
     )
     page.finish(diagnostics)


### PR DESCRIPTION
[improvements to icon validation](https://jira.mongodb.org/browse/DOP-1166)

previous solution: only checking :icon: role, and also has possibility of letting non existent icon targets to slip by since we are constructing a set of possible classnames

update: explicitly come up with icon classname from role name and target name, and validate this icon classname in set of valid icon classnames