### PR TITLE
DOP-3197: persist associated_products from snooty.toml

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1510,6 +1510,8 @@ class Postprocessor:
         document["eol"] = project_config.eol if project_config.eol else False
         if project_config.deprecated_versions:
             document["deprecated_versions"] = project_config.deprecated_versions
+        if project_config.associated_products:
+            document["associated_products"] = project_config.associated_products
         # Update metadata document with key-value pairs defined in event parser
         document["slugToTitle"] = {
             k: [node.serialize() for node in v]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2440,7 +2440,6 @@ This is a test intro
                 "snooty.toml"
             ): """
 name = "test_name"
-intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 title = "MongoDB title"
 
 [[associated_products]]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2422,3 +2422,33 @@ def test_target_quotes() -> None:
     </target>
 </root>""",
         )
+
+
+def test_metadata() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+======
+Test
+======
+
+This is a test intro
+            """,
+            Path(
+                "snooty.toml"
+            ): """
+name = "test_name"
+intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
+title = "MongoDB title"
+
+[[associated_products]]
+name = "test_associated_product"
+versions = ["v1", "v2"]
+            """,
+        }
+    ) as result:
+        metadata = cast(Dict[str, Any], result.metadata)
+        assert len(metadata["associated_products"]) == 1
+        assert len(metadata["associated_products"][0]["versions"]) == 2

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -27,7 +27,17 @@ def test_project() -> None:
     assert project_config.name == "unnamed"
     assert project_config.title == "untitled"
     assert project_config.deprecated_versions == None
+    assert project_config.associated_products == []
     assert len(project_diagnostics) == 0
+
+    # Test valid project
+    path = Path("test_data/test_project")
+    project_config, project_diganostics = ProjectConfig.open(path)
+    assert len(project_diganostics) == 0
+    assert len(project_config.associated_products) > 0
+    assert project_config.associated_products[0]["name"] == "test-name"
+    assert project_config.associated_products[0]["versions"] == ["v1.0", "v1.2"]
+    assert project_config.name == "test_data"
 
 
 def test_static_asset() -> None:

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -148,6 +148,7 @@ class ProjectConfig:
     manpages: Dict[str, ManPageConfig] = field(default_factory=dict)
     bundle: BundleConfig = field(default_factory=BundleConfig)
     data: Dict[str, object] = field(default_factory=dict)
+    associated_products: List[Dict[str, object]] = field(default_factory=list)
 
     @property
     def source_path(self) -> Path:

--- a/test_data/test_postprocessor/snooty.toml
+++ b/test_data/test_postprocessor/snooty.toml
@@ -17,3 +17,7 @@ mms = ["v1.1", "v1.2", "v1.3"]
 targets = ["*/get-started/*.txt"]
 variant = "info"
 value = "This product is deprecated"
+
+[[associated_products]]
+name = "test_associated_name"
+versions = ["v1.1", "v1.2"]

--- a/test_data/test_project/snooty.toml
+++ b/test_data/test_project/snooty.toml
@@ -3,3 +3,7 @@ title = "MongoDB title"
 
 [substitutions]
 guides = "MongoDB Guides"
+
+[[associated_products]]
+name = "test-name"
+versions = ["v1.0", "v1.2"]


### PR DESCRIPTION
See acceptance criteria from [DOP-3197](https://jira.mongodb.org/browse/DOP-3197)

- parser supports associated_products entry in snooty.toml
- persisted into metadata output
- accessible within project_config within parser's lifecycle