### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,10 @@ jobs:
         platform: [ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
         architecture: 'x64'
@@ -29,7 +31,7 @@ jobs:
       id: build_package
       run: make package
     - name: Upload package
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: packages
         path: dist/${{ steps.build_package.outputs.package_filename }}
@@ -46,8 +48,8 @@ jobs:
       - name: Get environment
         id: environment
         run: |
-          echo "::set-output name=date::$(date +%Y-%m-%d)"
-          echo "::set-output name=tag_name::$(echo ${{ github.ref }} | cut -d / -f 3)"
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+          echo "tag_name=$(echo ${{ github.ref }} | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@4874428bc07f8473128b16dfb628a0bcfb6ca10d

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ dist/${PACKAGE_NAME}: snooty/rstspec.toml snooty/config.toml dist/snooty/.EXISTS
 	cd dist && find snooty -print | sort | zip -X ../$@ -@
 	# Ensure that the generated binary runs
 	./dist/snooty/snooty --help >/dev/null
-	echo "::set-output name=package_filename::${PACKAGE_NAME}"
+	if [ -n "${GITHUB_OUTPUT}" ]; then echo "package_filename=${PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"; fi
 
 dist/${PACKAGE_NAME}.asc: dist/snooty-${VERSION}-${PLATFORM}.zip ## Build and sign a binary tarball
 	gpg --armor --detach-sig $^


### PR DESCRIPTION
* [set-output is now deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* actions/setup-python@v2 is using a deprecated version of node, and is now v4
* actions/upload-artifact@v1 uses the deprecated set-output stanza
* actions/checkout is now v3