### PR TITLE
DOP-3353: Change OpenAPI metadata source to be spec string

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -959,18 +959,15 @@ class OpenAPIHandler(Handler):
             return
 
         source = ""
-        argument = node.argument[0]
         # The parser determines the source_type based on the given argument and its
         # node structure. We echo that logic here to grab the source without needing
         # to worry about the argument's node structure.
         # The source_type cannot be manually set in rST as long as the option is not exposed
         # in the rstspec.
-        if source_type == "local" or source_type == "atlas":
-            assert isinstance(argument, n.Text)
-            source = argument.get_text()
+        if source_type == "local" or source_type == "url":
+            source = node.children[0].get_text()
         else:
-            assert isinstance(argument, n.Reference)
-            source = argument.refuri
+            source = node.argument[0].get_text()
 
         self.openapi_pages[current_slug] = self.SourceData(source_type, source)
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2469,7 +2469,14 @@ def test_openapi_metadata() -> None:
 
 .. openapi:: /openapi-admin-v3.yaml
             """,
-            Path("source/openapi-admin-v3.yaml"): "",
+            Path(
+                "source/openapi-admin-v3.yaml"
+            ): """
+openapi: "3.0.1"
+info:
+  description: ""
+  title: MongoDB Realm API
+""",
             Path(
                 "source/admin/api/url.txt"
             ): """
@@ -2487,17 +2494,15 @@ def test_openapi_metadata() -> None:
             diagnostics for diagnostics in result.diagnostics.values() if diagnostics
         ], "Should not raise any diagnostics"
         openapi_pages = cast(Dict[str, Any], result.metadata["openapi_pages"])
+        spec_title = "MongoDB Realm API"
 
         local_file_page = openapi_pages["admin/api/v3"]
         assert local_file_page["source_type"] == "local"
-        assert local_file_page["source"] == "/openapi-admin-v3.yaml"
+        assert spec_title in local_file_page["source"]
 
         url_page = openapi_pages["admin/api/url"]
         assert url_page["source_type"] == "url"
-        assert (
-            url_page["source"]
-            == "https://raw.githubusercontent.com/mongodb/snooty-parser/master/test_data/test_parser/openapi-admin-v3.yaml"
-        )
+        assert spec_title in url_page["source"]
 
         atlas_page = openapi_pages["admin/api/atlas"]
         assert atlas_page["source_type"] == "atlas"
@@ -2531,7 +2536,14 @@ def test_openapi_duplicates() -> None:
 
 .. openapi:: https://raw.githubusercontent.com/mongodb/snooty-parser/master/test_data/test_parser/openapi-admin-v3.yaml
             """,
-            Path("source/openapi-admin-v3.yaml"): "",
+            Path(
+                "source/openapi-admin-v3.yaml"
+            ): """
+openapi: "3.0.1"
+info:
+  description: ""
+  title: MongoDB Realm API
+""",
         }
     ) as result:
         diagnostics = result.diagnostics[FileId("admin/api/v3.txt")]
@@ -2542,4 +2554,4 @@ def test_openapi_duplicates() -> None:
         # First openapi directive should be source of truth
         file_metadata = openapi_pages["admin/api/v3"]
         assert file_metadata["source_type"] == "local"
-        assert file_metadata["source"] == "/openapi-admin-v3.yaml"
+        assert "MongoDB Realm API" in file_metadata["source"]


### PR DESCRIPTION
### Ticket

DOP-3353

### Notes

* It's more convenient to have the spec file's actual content as a string within the metadata. Since the parser layer already handles grabbing the content and turning it into a string, all the postprocessor has to do is grab it. This also avoids having to re-read the spec files across more than one of our tools (limiting it to the parser).