### PR TITLE
DOP-3200

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ mypy_path = "stubs"
 strict_equality = true
 
 [tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "DEBUG"
 testpaths = [
     "snooty",
     "tools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,6 @@ mypy_path = "stubs"
 strict_equality = true
 
 [tool.pytest.ini_options]
-log_cli = true
-log_cli_level = "DEBUG"
 testpaths = [
     "snooty",
     "tools",

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -421,7 +421,9 @@ class MissingAssociatedToc(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"The toctree entry {expected_project} does not exist in project config associated projects. Removing this toctree entry",
+            f"""Detected an associated toctree entry at {expected_project} 
+            which does not exist in an associated_products entry within the snooty.toml. 
+            Removing this toctree entry.""",
             start,
             end,
         )
@@ -437,7 +439,7 @@ class DuplicatedExternalToc(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"The external toctree entry {duplicated_toc} is duplicated",
+            f"Detected a duplicated associated toctree entry at {duplicated_toc}. Removing this toctree entry.",
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -410,6 +410,7 @@ class InvalidTocTree(Diagnostic, MakeCorrectionMixin):
     def did_you_mean(self) -> List[str]:
         return [".. ia::"]
 
+
 class MissingAssociatedToc(Diagnostic):
     severity = Diagnostic.Level.warning
 
@@ -425,6 +426,7 @@ class MissingAssociatedToc(Diagnostic):
             end,
         )
 
+
 class DuplicatedExternalToc(Diagnostic):
     severity = Diagnostic.Level.error
 
@@ -439,6 +441,7 @@ class DuplicatedExternalToc(Diagnostic):
             start,
             end,
         )
+
 
 class InvalidIAEntry(Diagnostic):
     severity = Diagnostic.Level.error

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -425,6 +425,21 @@ class MissingAssociatedToc(Diagnostic):
             end,
         )
 
+class DuplicatedExternalToc(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        duplicated_toc: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"The external toctree entry {duplicated_toc} is duplicated",
+            start,
+            end,
+        )
+
 class InvalidIAEntry(Diagnostic):
     severity = Diagnostic.Level.error
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -410,6 +410,20 @@ class InvalidTocTree(Diagnostic, MakeCorrectionMixin):
     def did_you_mean(self) -> List[str]:
         return [".. ia::"]
 
+class MissingAssociatedToc(Diagnostic):
+    severity = Diagnostic.Level.warning
+
+    def __init__(
+        self,
+        expected_project: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"The toctree entry {expected_project} does not exist in project config associated projects. Removing this toctree entry",
+            start,
+            end,
+        )
 
 class InvalidIAEntry(Diagnostic):
     severity = Diagnostic.Level.error

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -359,6 +359,7 @@ class TocTreeDirectiveEntry(NamedTuple):
     title: Optional[str]
     url: Optional[str]
     slug: Optional[str]
+    ref_project: Optional[str]
 
     def serialize(self) -> SerializedNode:
         result: SerializedNode = {}
@@ -368,6 +369,8 @@ class TocTreeDirectiveEntry(NamedTuple):
             result["url"] = self.url
         if self.slug:
             result["slug"] = self.slug
+        if self.ref_project:
+            result["ref_project"] = self.ref_project
         return result
 
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -577,11 +577,11 @@ class JSONVisitor:
         options = node["options"] or {}
 
         if name == "toctree":
-            self.diagnostics.extend(validate_toc_entries(
-                node["entries"],
-                self.project_config.associated_products,
-                line
-            ))
+            self.diagnostics.extend(
+                validate_toc_entries(
+                    node["entries"], self.project_config.associated_products, line
+                )
+            )
             doc: n.Directive = n.TocTreeDirective(
                 (line,), [], domain, name, [], options, node["entries"]
             )
@@ -1072,8 +1072,11 @@ class JSONVisitor:
         visitor.pending = self.pending
         return visitor
 
+
 def validate_toc_entries(
-    node_entries: List[TocTreeDirectiveEntry], associated_products: ProjectConfig.associated_products, line: int
+    node_entries: List[TocTreeDirectiveEntry],
+    associated_products: List[Dict[str, object]],
+    line: int,
 ) -> List[Diagnostic]:
     """
     validates that external toc node exists as one of the associated products
@@ -1081,15 +1084,16 @@ def validate_toc_entries(
     associated_products come in form of {name: str, versions: List[str]}
     """
     diagnostics: List[Diagnostic] = []
-    associated_product_names = [product['name'] for product in associated_products]
+    associated_product_names = [product["name"] for product in associated_products]
     for toc_entry in node_entries:
-        if toc_entry.ref_project and toc_entry.ref_project not in associated_product_names:
-            diagnostics.append(MissingAssociatedToc(
-                toc_entry.ref_project, 
-                line
-            ))
+        if (
+            toc_entry.ref_project
+            and toc_entry.ref_project not in associated_product_names
+        ):
+            diagnostics.append(MissingAssociatedToc(toc_entry.ref_project, line))
             node_entries.remove(toc_entry)
     return diagnostics
+
 
 def _validate_io_code_block_children(node: n.Directive) -> List[Diagnostic]:
     """Validates that a given io-code-block directive has 1 input and 1 output

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pdb
 import collections
 import errno
 import getpass

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -35,8 +35,8 @@ from .diagnostics import (
     CannotOpenFile,
     ChapterAlreadyExists,
     Diagnostic,
-    DuplicateDirective,
     DuplicatedExternalToc,
+    DuplicateDirective,
     ExpectedPathArg,
     ExpectedTabs,
     GuideAlreadyHasChapter,
@@ -1659,7 +1659,7 @@ class Postprocessor:
         node: Dict[str, Any],
         toc_landing_pages: List[str],
         visited_file_ids: Set[FileId] = set(),
-        external_nodes: List[str] = []
+        external_nodes: List[object] = [],
     ) -> None:
         """Iterate over AST to find toctree directives and construct their nodes for the unified toctree"""
 
@@ -1676,12 +1676,12 @@ class Postprocessor:
                         "title": [n.Text((0,), entry.title).serialize()]
                         if entry.title
                         else None,
-                        "options": {
-                            "project": entry.ref_project
-                        }
+                        "options": {"project": entry.ref_project},
                     }
                     if toctree_node in external_nodes:
-                        context.diagnostics[fileid].append(DuplicatedExternalToc(entry.ref_project, ast.span[0]))
+                        context.diagnostics[fileid].append(
+                            DuplicatedExternalToc(entry.ref_project, ast.span[0])
+                        )
                     external_nodes.append(toctree_node)
                 if entry.url:
                     toctree_node = {
@@ -1750,7 +1750,7 @@ class Postprocessor:
                             toctree_node,
                             toc_landing_pages,
                             visited_file_ids.union({slug_fileid}),
-                            external_nodes
+                            external_nodes,
                         )
 
                 if toctree_node:
@@ -1759,7 +1759,13 @@ class Postprocessor:
         # Locate the correct directive object containing the toctree within this AST
         for child_ast in ast.children:
             cls.find_toctree_nodes(
-                context, fileid, child_ast, node, toc_landing_pages, visited_file_ids, external_nodes
+                context,
+                fileid,
+                child_ast,
+                node,
+                toc_landing_pages,
+                visited_file_ids,
+                external_nodes,
             )
 
     @staticmethod

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1669,6 +1669,15 @@ class Postprocessor:
             # Recursively build the tree for each toctree node in this entries list
             for entry in ast.entries:
                 toctree_node: Dict[str, object] = {}
+                if entry.ref_project:
+                    toctree_node = {
+                        "title": [n.Text((0,), entry.title).serialize()]
+                        if entry.title
+                        else None,
+                        "options": {
+                            "project": entry.ref_project
+                        }
+                    }
                 if entry.url:
                     toctree_node = {
                         "title": [n.Text((0,), entry.title).serialize()]

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -929,7 +929,6 @@ class BaseTocTreeDirective(docutils.parsers.rst.Directive):
         errors: List[docutils.nodes.Node] = []
         for child in self.content:
             entry, err = self.make_toc_entry(source, child)
-            # TODO: check for duplicates within existing entries
             errors.extend(err)
             if entry:
                 entries.append(entry)

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -948,7 +948,7 @@ class BaseTocTreeDirective(docutils.parsers.rst.Directive):
         if match:
             title, target = match["label"], match["target"]
             # pipelines denote project reference
-            if target.startswith('|') and target.endswith('|'):
+            if target.startswith("|") and target.endswith("|"):
                 ref_project = target[1:-1]
                 target = None
         else:

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -927,7 +927,6 @@ class BaseTocTreeDirective(docutils.parsers.rst.Directive):
 
         entries: List[n.TocTreeDirectiveEntry] = []
         errors: List[docutils.nodes.Node] = []
-        print('BaseTocTreeDirective(docutils.parsers.rst.Directive) run')
         for child in self.content:
             entry, err = self.make_toc_entry(source, child)
             # TODO: check for duplicates within existing entries
@@ -1243,8 +1242,6 @@ class Parser(Generic[_V]):
         self.visitor_class = visitor_class
 
     def parse(self, path: Path, text: Optional[str]) -> Tuple[_V, str]:
-        print('parse')
-        # print(self)
         Registry.get(self.project_config.default_domain).activate()
 
         diagnostics: List[Diagnostic] = []
@@ -1262,6 +1259,5 @@ class Parser(Generic[_V]):
 
         visitor = self.visitor_class(self.project_config, path, document)
         visitor.add_diagnostics(diagnostics)
-        print('1272 document.walkabout')
         document.walkabout(visitor)
         return visitor, text

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -954,7 +954,7 @@ class BaseTocTreeDirective(docutils.parsers.rst.Directive):
         else:
             target = child
 
-        if not title and util.PAT_URI.match(target):
+        if not title and (util.PAT_URI.match(target) or ref_project):
             # If entry is surrounded by <> tags, assume it is a URL and log an error.
             err = "toctree nodes with URLs or project references must include titles"
             error_node = self.state.document.reporter.error(err, line=self.lineno)

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -39,9 +39,6 @@ from .flutter import LoadError, check_type, checked
 from .gizaparser import nodes
 from .gizaparser.parse import load_yaml
 from .types import ProjectConfig
-import logging
-
-LOGGER = logging.getLogger(__name__)
 
 RoleHandlerType = Callable[
     [
@@ -930,6 +927,7 @@ class BaseTocTreeDirective(docutils.parsers.rst.Directive):
 
         entries: List[n.TocTreeDirectiveEntry] = []
         errors: List[docutils.nodes.Node] = []
+        print('BaseTocTreeDirective(docutils.parsers.rst.Directive) run')
         for child in self.content:
             entry, err = self.make_toc_entry(source, child)
             # TODO: check for duplicates within existing entries
@@ -945,15 +943,14 @@ class BaseTocTreeDirective(docutils.parsers.rst.Directive):
     ) -> Tuple[Optional[n.TocTreeDirectiveEntry], List[docutils.nodes.Node]]:
         """Parse entry for either url or slug and optional title"""
         match = PAT_EXPLICIT_TITLE.match(child)
-        LOGGER.info(self.state_machine)
         title: Optional[str] = None
         url: Optional[str] = None
         slug: Optional[str] = None
         ref_project: Optional[str] = None
         if match:
             title, target = match["label"], match["target"]
+            # pipelines denote project reference
             if target.startswith('|') and target.endswith('|'):
-                # CHECK PROJECT CONFIG FOR ASSOCIATED PROJECTS
                 ref_project = target[1:-1]
                 target = None
         else:
@@ -1246,6 +1243,8 @@ class Parser(Generic[_V]):
         self.visitor_class = visitor_class
 
     def parse(self, path: Path, text: Optional[str]) -> Tuple[_V, str]:
+        print('parse')
+        # print(self)
         Registry.get(self.project_config.default_domain).activate()
 
         diagnostics: List[Diagnostic] = []
@@ -1263,5 +1262,6 @@ class Parser(Generic[_V]):
 
         visitor = self.visitor_class(self.project_config, path, document)
         visitor.add_diagnostics(diagnostics)
+        print('1272 document.walkabout')
         document.walkabout(visitor)
         return visitor, text

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import logging
+
 from . import rstparser
 from .diagnostics import (
     CannotOpenFile,
@@ -2628,6 +2630,10 @@ def test_toctree() -> None:
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
+    # TODO. add test for associated product
+    LOGGER = logging.getLogger(__name__)
+    LOGGER.info(path)
+
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -2638,19 +2644,23 @@ def test_toctree() -> None:
    Title here </test1>
    /test2/faq
    URL with title <https://www.mongodb.com/docs/atlas>
+   Associated Product <|atlas-cli|>
    <https://www.mongodb.com/docs/stitch>
 """,
     )
     page.finish(diagnostics)
+    LOGGER.info('test here')
+    LOGGER.info(page.ast)
+    LOGGER.info(diagnostics)
 
     # MESSAGE need to create a toctree diagnostic
     assert len(diagnostics) == 1 and "toctree" in diagnostics[0].message
-    check_ast_testing_string(
-        page.ast,
-        """<root fileid="test.rst">
-        <directive name="toctree" titlesonly="True" entries="[{'title': 'Title here', 'slug': '/test1'}, {'slug': '/test2/faq'}, {'title': 'URL with title', 'url': 'https://www.mongodb.com/docs/atlas'}]" />
-        </root>""",
-    )
+    # check_ast_testing_string(
+    #     page.ast,
+    #     """<root fileid="test.rst">
+    #     <directive name="toctree" titlesonly="True" entries="[{'title': 'Title here', 'slug': '/test1'}, {'slug': '/test2/faq'}, {'title': 'URL with title', 'url': 'https://www.mongodb.com/docs/atlas'}, {'title': 'Associated Product', 'options': {'project': 'atlas-cli'}}]" />
+    #     </root>""",
+    # )
 
 
 def test_mongo_web_shell() -> None:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import logging
-
 from . import rstparser
 from .diagnostics import (
     CannotOpenFile,
@@ -2647,7 +2645,11 @@ def test_toctree() -> None:
 """,
     )
     page.finish(diagnostics)
-    assert len(diagnostics) == 2 and "toctree" in diagnostics[0].message and "toctree" in diagnostics[1].message
+    assert (
+        len(diagnostics) == 2
+        and "toctree" in diagnostics[0].message
+        and "toctree" in diagnostics[1].message
+    )
     check_ast_testing_string(
         page.ast,
         """<root fileid="test.rst">

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -8,8 +8,8 @@ from . import diagnostics
 from .diagnostics import (
     ChapterAlreadyExists,
     DocUtilsParseError,
-    DuplicateDirective,
     DuplicatedExternalToc,
+    DuplicateDirective,
     ExpectedPathArg,
     ExpectedTabs,
     GuideAlreadyHasChapter,
@@ -559,6 +559,7 @@ def test_toctree_self_add() -> None:
 """,
         )
 
+
 def test_toctree_duplicate_node() -> None:
     with make_test(
         {
@@ -580,7 +581,9 @@ versions = ["v1", "v2"]
     /page1
     Duplicate Toc <|test_associated_product|>
             """,
-            Path("source/page1.txt"): """
+            Path(
+                "source/page1.txt"
+            ): """
 ==================
 Page 1
 ==================


### PR DESCRIPTION
[DOP-3200](https://jira.mongodb.org/browse/DOP-3200)

**status**: ready for review

changes include:
- parser takes in an external toc node marked with `${label} <|${project-name}|>` within a toc tree directive ie 
```
... toctree::

    /getting-started
    Atlas CLI <|atlas-cli|>                        <-- net new format for external node
    Inner Page Toc </inner-page>
```
- parser emits a warning when a external toc node is not listed under snooty.toml .associated_products
- parser emits an error when an external toc node is repeated within the doc repo