### PR TITLE
Have a separate Named Reference mapping for each .txt context

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -374,13 +374,13 @@ class NamedReferenceHandlerPass1(Handler):
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.named_references: Dict[str, str] = {}
+        self.named_references: Dict[FileId, Dict[str, str]] = defaultdict(dict)
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.NamedReference):
             return
 
-        self.named_references[node.refname] = node.refuri
+        self.named_references[fileid_stack.root][node.refname] = node.refuri
 
 
 class NamedReferenceHandlerPass2(Handler):
@@ -396,8 +396,10 @@ class NamedReferenceHandlerPass2(Handler):
             # Node is already populated with url; nothing to do
             return
 
-        refuri = self.context[NamedReferenceHandlerPass1].named_references.get(
-            node.refname
+        refuri = (
+            self.context[NamedReferenceHandlerPass1]
+            .named_references[fileid_stack.root]
+            .get(node.refname)
         )
         if refuri is None:
             line = node.span[0]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -1774,6 +1774,15 @@ This is not `GitHub <https://twitter.com>`_
 
 Reference `GitHub`_
 """,
+            # Should not be able to link to a named reference from another .txt
+            Path(
+                "source/foo.txt"
+            ): """
+.. include:: /fact-reference.rst
+
+`docs link`_
+""",
+            Path("source/fact-reference.rst"): "`docs link`_",
         },
     ) as result:
 
@@ -1855,6 +1864,14 @@ Reference `GitHub`_
 </root>
 """,
         )
+
+        # Should not be able to link to a named reference from another .txt
+        active_file = "foo.txt"
+        diagnostics = result.diagnostics[FileId(active_file)]
+        assert len(diagnostics) == 1
+        active_file = "fact-reference.rst"
+        diagnostics = result.diagnostics[FileId(active_file)]
+        assert len(diagnostics) == 1
 
 
 def test_contents_directive() -> None:


### PR DESCRIPTION
Named references should be scoped to a single .txt file to prevent namespace collisions and general undefined behavior.

This will require a fix in the [server manual](https://github.com/10gen/docs-mongodb-internal/blob/a4a305fd467fe00ace6e2ffd4ac266109a0e7055/source/release-notes/5.1-compatibility.txt) for the `MongoDB Enterprise` named reference