### PR TITLE
DOP-3298: Upgrade release Python to 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v[0-9]*'
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        platform: [ubuntu-20.04, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        architecture: 'x64'
+    - name: Run tests
+      run: make test
+      env:
+        FLIT_ROOT_INSTALL: "1"
+    - name: Build package
+      id: build_package
+      run: make package
+    - name: Upload package
+      uses: actions/upload-artifact@v3
+      with:
+        name: packages
+        path: dist/${{ steps.build_package.outputs.package_filename }}
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v1
+        with:
+          name: packages
+      - name: Get environment
+        id: environment
+        run: |
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+          echo "tag_name=$(echo ${{ github.ref }} | cut -d / -f 3)" >> $GITHUB_OUTPUT
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@4874428bc07f8473128b16dfb628a0bcfb6ca10d
+        with:
+          tag: ${{ steps.environment.outputs.tag_name }}
+          name: "Release: [${{ steps.environment.outputs.tag_name }}] - ${{ steps.environment.outputs.date }}"
+          artifacts: "packages/*.zip"
+          artifactContentType: "application/zip"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          prerelease: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
     - master
     - 'v[0-9]*'
-    tags:
-    - 'v[0-9]*'
   pull_request:
 
 jobs:
@@ -14,6 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-20.04, macos-latest]
+        python-version: ['3.8', '3.11']
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v3
@@ -21,7 +20,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.python-version }}
         architecture: 'x64'
     - name: Run tests
       run: make test
@@ -30,34 +29,3 @@ jobs:
     - name: Build package
       id: build_package
       run: make package
-    - name: Upload package
-      uses: actions/upload-artifact@v3
-      with:
-        name: packages
-        path: dist/${{ steps.build_package.outputs.package_filename }}
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download
-        uses: actions/download-artifact@v1
-        with:
-          name: packages
-      - name: Get environment
-        id: environment
-        run: |
-          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          echo "tag_name=$(echo ${{ github.ref }} | cut -d / -f 3)" >> $GITHUB_OUTPUT
-      - name: Create Release
-        id: create_release
-        uses: ncipollo/release-action@4874428bc07f8473128b16dfb628a0bcfb6ca10d
-        with:
-          tag: ${{ steps.environment.outputs.tag_name }}
-          name: "Release: [${{ steps.environment.outputs.tag_name }}] - ${{ steps.environment.outputs.date }}"
-          artifacts: "packages/*.zip"
-          artifactContentType: "application/zip"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
-          prerelease: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
     "black ~= 22.3.0",
     "pyflakes ~= 2.4",
     "mypy == 0.960",
-    "pyinstaller ~= 4.10",
+    "pyinstaller ~= 5.6",
     "isort ~= 5.10.1",
     "types-requests ~= 2.26.1"
 ]


### PR DESCRIPTION
This PR splits the CI and Release tasks into two different actions: `CI` runs on `(macOS-x86-64,Linux-x86-64) X py3.8,py3.11)`, while `Release` runs on `(macOS-x86-64,Linux-x86-64) X py3.11)`

On my laptop (i7-1065G7, 4 cores), this results in a 14% reduction in time building 10gen/docs-mongodb-internal#888fad61c726440d07de6f399cec6da925156c75: 41.263s down to 35.496s, lowest time of 3 runs