### PR TITLE
Revert "DOP-3353: Change OpenAPI metadata source to be spec string (#…

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -962,15 +962,18 @@ class OpenAPIHandler(Handler):
             return
 
         source = ""
+        argument = node.argument[0]
         # The parser determines the source_type based on the given argument and its
         # node structure. We echo that logic here to grab the source without needing
         # to worry about the argument's node structure.
         # The source_type cannot be manually set in rST as long as the option is not exposed
         # in the rstspec.
-        if source_type == "local" or source_type == "url":
-            source = node.children[0].get_text()
+        if source_type == "local" or source_type == "atlas":
+            assert isinstance(argument, n.Text)
+            source = argument.get_text()
         else:
-            source = node.argument[0].get_text()
+            assert isinstance(argument, n.Reference)
+            source = argument.refuri
 
         self.openapi_pages[current_slug] = self.SourceData(source_type, source)
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2526,14 +2526,7 @@ def test_openapi_metadata() -> None:
 
 .. openapi:: /openapi-admin-v3.yaml
             """,
-            Path(
-                "source/openapi-admin-v3.yaml"
-            ): """
-openapi: "3.0.1"
-info:
-  description: ""
-  title: MongoDB Realm API
-""",
+            Path("source/openapi-admin-v3.yaml"): "",
             Path(
                 "source/admin/api/url.txt"
             ): """
@@ -2551,15 +2544,17 @@ info:
             diagnostics for diagnostics in result.diagnostics.values() if diagnostics
         ], "Should not raise any diagnostics"
         openapi_pages = cast(Dict[str, Any], result.metadata["openapi_pages"])
-        spec_title = "MongoDB Realm API"
 
         local_file_page = openapi_pages["admin/api/v3"]
         assert local_file_page["source_type"] == "local"
-        assert spec_title in local_file_page["source"]
+        assert local_file_page["source"] == "/openapi-admin-v3.yaml"
 
         url_page = openapi_pages["admin/api/url"]
         assert url_page["source_type"] == "url"
-        assert spec_title in url_page["source"]
+        assert (
+            url_page["source"]
+            == "https://raw.githubusercontent.com/mongodb/snooty-parser/master/test_data/test_parser/openapi-admin-v3.yaml"
+        )
 
         atlas_page = openapi_pages["admin/api/atlas"]
         assert atlas_page["source_type"] == "atlas"
@@ -2593,14 +2588,7 @@ def test_openapi_duplicates() -> None:
 
 .. openapi:: https://raw.githubusercontent.com/mongodb/snooty-parser/master/test_data/test_parser/openapi-admin-v3.yaml
             """,
-            Path(
-                "source/openapi-admin-v3.yaml"
-            ): """
-openapi: "3.0.1"
-info:
-  description: ""
-  title: MongoDB Realm API
-""",
+            Path("source/openapi-admin-v3.yaml"): "",
         }
     ) as result:
         diagnostics = result.diagnostics[FileId("admin/api/v3.txt")]
@@ -2611,4 +2599,4 @@ info:
         # First openapi directive should be source of truth
         file_metadata = openapi_pages["admin/api/v3"]
         assert file_metadata["source_type"] == "local"
-        assert "MongoDB Realm API" in file_metadata["source"]
+        assert file_metadata["source"] == "/openapi-admin-v3.yaml"


### PR DESCRIPTION
…428)"

This reverts commit 5fdbdd379d95fe3615bdfe2607efe9cf8c75a47f.

### Notes

* Reverting the work for DOP-3353 because the autobuilder module uses paths/urls to OpenAPI specs instead of using stringified JSON.
* If stringified JSON is needed to be supported again, we can update the metadata schema to include both the path and the stringified JSON as separate fields for flexibility (and to avoid needing to flip-flop between the two).
* This PR should not break anything in production since neither the frontend nor autobuilder currently use this metadata. (It's been primarily used for testing purposes locally and through the autobuilder's pre-prd environment)