### PR TITLE
DOP-3436: associated ToC missing children/slug

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1747,6 +1747,8 @@ class Postprocessor:
                         if entry.title
                         else None,
                         "options": {"project": entry.ref_project},
+                        "children": [],
+                        "slug": entry.ref_project,
                     }
                     ref_project_pair = (entry.title, entry.ref_project)
                     if ref_project_pair in external_nodes:


### PR DESCRIPTION
**Goal**: associated ToC nodes should have `children[]` and `slug` fields for front end consumption, pre-persistence module invocation.

these missing attributes lead to front end bugs, ie. missing children in node, missing slug field for link

tested with [test branch for cloud docs](https://github.com/10gen/cloud-docs/blob/DOP-3382-toc/source/index.txt#L205)

pre change:
```
{
	"title": [
		{
			"type": "text",
			"position": {
				"start": {
					"line": {
						"$numberInt": "0"
					}
				}
			},
			"value": "Atlas CLI"
		}
	],
	"options": {
		"project": "atlas-cli"
	}
}
```

post change:
```
{
	"title": [
		{
			"type": "text",
			"position": {
				"start": {
					"line": {
						"$numberInt": "0"
					}
				}
			},
			"value": "Atlas CLI"
		}
	],
	"options": {
		"project": "atlas-cli"
	},
	"children": [],
	"slug": "atlas-cli"
},
```