### PR TITLE
DOP-3386: fix literalinclude copyable option

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -847,7 +847,7 @@ class JSONVisitor:
             span = (line,)
             language = options["language"] if "language" in options else ""
             caption = options["caption"] if "caption" in options else None
-            copyable = "copyable" not in options or options["copyable"] == "True"
+            copyable = "copyable" not in options or options["copyable"] != False
             selected_content = "\n".join(lines)
             linenos = "linenos" in options
             lineno_start = (

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -953,6 +953,33 @@ for (i = 0; i &lt; 10; i++) {
     </root>""",
     )
 
+    # Test a literally-included code block with copyable option specified
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. literalinclude:: /test_parser/includes/sample_code.js
+    :language: json
+    :copyable: true
+    :emphasize-lines: 5
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst">
+  <directive name="literalinclude" language="json" emphasize-lines="5" copyable="True">
+  <text>/test_parser/includes/sample_code.js</text>
+  <code lang="json" emphasize_lines="[(5, 5)]" copyable="True">var str = "sample code";
+var i = 0;
+for (i = 0; i &lt; 10; i++) {
+  str += i;
+}</code>
+    </directive>
+    </root>""",
+    )
+
     # Test a literally-included code block with fully specified options
     page, diagnostics = parse_rst(
         parser,


### PR DESCRIPTION
### Ticket

[DOP-3386](https://jira.mongodb.org/browse/DOP-3386)

----

The `copyable` option for code blocks is not being set when used as an option on a `literalinclude`. The conditional check for this option was based off of a string value rather than a boolean.

A/C: 
`Code` blocks will have the copyable option propagated on `literalinclude` by default, but also when:
- docs writers set `:copyable: true` as an option on the `literalinclude`
- as a fallback, when docs writers set `:copyable:` without a boolean

This PR also adds a test to ensure future adherence to this ability.

----
**Example from parser run:**

When parsing this rst:

```
.. literalinclude:: /includes/tutorials/change-streams/output/change.json
   :language: json
   :copyable: true
   :emphasize-lines: 5
```


----
The master branch allows the options in the `literalinclude`, but does not pass copyable correctly to `code`

```
{
	"type": "directive",
	"position": {
		"start": {
			"line": {
				"$numberInt": "15"
			}
		}
	},
	"children": [
		{
			"type": "code",
			"position": {
				"start": {
					"line": {
						"$numberInt": "15"
					}
				}
			},
			"lang": "json",
			"copyable": false,
			"emphasize_lines": [
				[
					{
						"$numberInt": "5"
					},
					{
						"$numberInt": "5"
					}
				]
			],
			"value": "{\n  \"_id\": {\n    \"_data\": \"826264...\"\n  },\n  \"operationType\": \"insert\",\n  \"clusterTime\": {\n    \"$timestamp\": {\n      \"t\": 1650754657,\n      \"i\": 1\n    }\n  },\n  \"wallTime\": {\n    \"$date\": \"2022-10-13T17:06:23.409Z\"\n  },\n  \"fullDocument\": {\n    \"_id\": {\n      \"$oid\": \"<_id value of document>\"\n    },\n    \"test\": 1\n  },\n  \"ns\": {\n    \"db\": \"Tutorial1\",\n    \"coll\": \"orders\"\n  },\n  \"documentKey\": {\n    \"_id\": {\n      \"$oid\": \"<_id value of document>\"\n    }\n  }\n}\n",
			"linenos": false
		}
	],
	"domain": "",
	"name": "literalinclude",
	"argument": [
		{
			"type": "text",
			"position": {
				"start": {
					"line": {
						"$numberInt": "15"
					}
				}
			},
			"value": "/includes/tutorials/change-streams/output/change.json"
		}
	],
	"options": {
		"language": "json",
		"copyable": true,
		"emphasize-lines": "5"
	}
},
```

----
The new branch passes copyable correctly to `code`

```
{
	"type": "directive",
	"position": {
		"start": {
			"line": {
				"$numberInt": "15"
			}
		}
	},
	"children": [
		{
			"type": "code",
			"position": {
				"start": {
					"line": {
						"$numberInt": "15"
					}
				}
			},
			"lang": "json",
			"copyable": true,
			"emphasize_lines": [
				[
					{
						"$numberInt": "5"
					},
					{
						"$numberInt": "5"
					}
				]
			],
			"value": "{\n  \"_id\": {\n    \"_data\": \"826264...\"\n  },\n  \"operationType\": \"insert\",\n  \"clusterTime\": {\n    \"$timestamp\": {\n      \"t\": 1650754657,\n      \"i\": 1\n    }\n  },\n  \"wallTime\": {\n    \"$date\": \"2022-10-13T17:06:23.409Z\"\n  },\n  \"fullDocument\": {\n    \"_id\": {\n      \"$oid\": \"<_id value of document>\"\n    },\n    \"test\": 1\n  },\n  \"ns\": {\n    \"db\": \"Tutorial1\",\n    \"coll\": \"orders\"\n  },\n  \"documentKey\": {\n    \"_id\": {\n      \"$oid\": \"<_id value of document>\"\n    }\n  }\n}\n",
			"linenos": false
		}
	],
	"domain": "",
	"name": "literalinclude",
	"argument": [
		{
			"type": "text",
			"position": {
				"start": {
					"line": {
						"$numberInt": "15"
					}
				}
			},
			"value": "/includes/tutorials/change-streams/output/change.json"
		}
	],
	"options": {
		"language": "json",
		"copyable": true,
		"emphasize-lines": "5"
	}
}
```