### PR TITLE
DOP-3211:  ref label

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -328,6 +328,7 @@ class AmbiguousTarget(Diagnostic):
         self.target = target
         self.candidates = candidates
 
+
 class ChildlessRef(Diagnostic):
     severity = Diagnostic.Level.error
 
@@ -338,11 +339,12 @@ class ChildlessRef(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"""Ref found without text: "{target}". Be sure to add label text to the ref itself OR place the target ref directly before a heading""",
+            f'Ref found without text: "{target}". Be sure to add label text to the ref itself OR place the target ref directly before a heading',
             start,
             end,
         )
         self.target = target
+
 
 class TodoInfo(Diagnostic):
     severity = Diagnostic.Level.info

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -339,7 +339,7 @@ class ChildlessRef(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f'Reference found without label: "{target}". Be sure to add label text to the ref itself OR place the target ref directly before a heading',
+            f'Reference found without label: "{target}". Be sure to add label text to the :ref: itself OR place the target reference directly before a heading',
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -339,7 +339,7 @@ class ChildlessRef(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f'Ref found without text: "{target}". Be sure to add label text to the ref itself OR place the target ref directly before a heading',
+            f'Reference found without label: "{target}". Be sure to add label text to the ref itself OR place the target ref directly before a heading',
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -328,6 +328,21 @@ class AmbiguousTarget(Diagnostic):
         self.target = target
         self.candidates = candidates
 
+class ChildlessRef(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        target: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"""Ref found without text: "{target}". Be sure to add label text to the ref itself OR place the target ref directly before a heading""",
+            start,
+            end,
+        )
+        self.target = target
 
 class TodoInfo(Diagnostic):
     severity = Diagnostic.Level.info

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -54,6 +54,7 @@ from .diagnostics import (
     TargetNotFound,
     UnnamedPage,
     UnsupportedFormat,
+    ChildlessRef,
 )
 from .eventparser import EventParser, FileIdStack
 from .n import FileId, SerializableType
@@ -1392,6 +1393,12 @@ class RefsHandler(Handler):
                         node_to_abbreviate.value = new_value
 
             injection_candidate.children = cloned_title_nodes
+            
+            if not node.children:
+                line = node.span[0]
+                self.context.diagnostics[fileid_stack.current].append(
+                    ChildlessRef(node.name, node.target, line)
+                )
 
     def attempt_disambugation(
         self, fileid: FileId, candidates: Sequence[TargetDatabase.Result]

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -34,6 +34,7 @@ from .diagnostics import (
     AmbiguousTarget,
     CannotOpenFile,
     ChapterAlreadyExists,
+    ChildlessRef,
     Diagnostic,
     DuplicatedExternalToc,
     DuplicateDirective,
@@ -54,7 +55,6 @@ from .diagnostics import (
     TargetNotFound,
     UnnamedPage,
     UnsupportedFormat,
-    ChildlessRef,
 )
 from .eventparser import EventParser, FileIdStack
 from .n import FileId, SerializableType
@@ -1393,11 +1393,11 @@ class RefsHandler(Handler):
                         node_to_abbreviate.value = new_value
 
             injection_candidate.children = cloned_title_nodes
-            
+
             if not node.children:
                 line = node.span[0]
                 self.context.diagnostics[fileid_stack.current].append(
-                    ChildlessRef(node.name, node.target, line)
+                    ChildlessRef(node.target, line)
                 )
 
     def attempt_disambugation(


### PR DESCRIPTION
### Ticket

[DOP-3211](https://jira.mongodb.org/browse/DOP-3211)

### Notes

Creating a `reference` that doesn't precede a heading and then attempts to `reference` that target without providing a label does not emit an error. It successfully builds, but the `ref` has no children to render, leaving the user with a visually empty spot where a link should be.

Through my investigation I found many instances of this stemming from the one bug report. As many as eleven invisible refs in `docs-mongodb-internal `alone. This error will help content writers to identify before production.

### Examples

[Current site](https://www.mongodb.com/docs/v6.0/reference/)
- Above the text `Documentation of JavaScript methods and helpers in the legacy mongo shell.` there should be a link to the mongo legacy shell. This is one such example of an invisible ref.

[Three in quick succession on current docs site](https://docs-mongodbcom-integration.corp.mongodb.com/master/docs/matt.meigs/master/reference/method/db.collection.mapReduce/)
- Search for the text `A JavaScript function that associates`
- There are three invisible refs in quick succession here
- In the description column of `map`, `reduce`, and `out` - you will see "See  for more information"

The refs without labels that are causing this are seen [here](https://github.com/10gen/docs-mongodb-internal/blob/67937b56bbf4eaf02800d423f040244f97675a57/source/reference/method/db.collection.mapReduce.txt#L78), [here](https://github.com/10gen/docs-mongodb-internal/blob/67937b56bbf4eaf02800d423f040244f97675a57/source/reference/method/db.collection.mapReduce.txt#L91), and [here](https://github.com/10gen/docs-mongodb-internal/blob/67937b56bbf4eaf02800d423f040244f97675a57/source/reference/method/db.collection.mapReduce.txt#L131).

And the target refs they are pointing to (which do not have headers directly below) are seen in a row [here](https://github.com/10gen/docs-mongodb-internal/blob/67937b56bbf4eaf02800d423f040244f97675a57/source/reference/method/db.collection.mapReduce.txt#L260).

They all three point to starting lines in the [same file](https://github.com/10gen/docs-mongodb-internal/blob/master/source/includes/parameters-map-reduce.rst), however none of these directly precede a header.

-------

A/C:
- `:ref:`s that cannot be rendered due to a lack of label emit an error in the parser log