### PR TITLE
Make bump_version.py also bump the version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snooty"
-version = "0.13.12.dev"
+version = "0.13.16.dev"
 description = ""
 authors = ["MongoDB, inc. <andrew.aldridge@mongodb.com>"]
 license = "Apache-2.0"

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -8,6 +8,9 @@ from typing import Match
 CHANGELOG_PATH = Path("CHANGELOG.md")
 INCOMING_VERISON_PAT = re.compile(r"\d+\.\d+\.\d+")
 PAT = re.compile(r'"(\d+\.\d+\.\S+)"')
+PYPROJECT_VERSION_PAT = re.compile(
+    r"(?<=^version = )\"(\d+\.\d+\.\S+)\"$", re.MULTILINE
+)
 CHANGELOG_UNRELEASED_PAT = re.compile(
     r"\n## \[Unreleased\](?P<unreleased>.*)(?=\n## )", re.DOTALL
 )
@@ -84,6 +87,19 @@ def main() -> None:
         if n_replaced != 1:
             print(
                 "Error bumping version: expected 1 version string in __init__.py",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        f.seek(0)
+        f.truncate(0)
+        f.write(data)
+
+    with Path("pyproject.toml").open("r+") as f:
+        data = f.read()
+        data, n_replaced = PYPROJECT_VERSION_PAT.subn(f'"{version_to_bump_to}"', data)
+        if n_replaced != 1:
+            print(
+                "Error bumping version: expected 1 version string in pyproject.toml",
                 file=sys.stderr,
             )
             sys.exit(1)


### PR DESCRIPTION
The "right" solution to this is to make the pyproject.toml version canonical, and use `importlib.metadata` (1), but let's do that once we bump our supported floor to python 3.8 as a separate decision.

(1): https://github.com/python-poetry/poetry/pull/2366#issuecomment-652418094