### PR TITLE
Make SerializableType recursive

### DIFF
--- a/snooty/n.py
+++ b/snooty/n.py
@@ -11,6 +11,7 @@ from typing import (
     Generic,
     Iterator,
     List,
+    Mapping,
     MutableSequence,
     NamedTuple,
     Optional,
@@ -39,7 +40,14 @@ __all__ = (
 )
 
 SerializableType = Union[
-    None, bool, str, int, float, Dict[str, Any], List[Any], datetime
+    None,
+    bool,
+    str,
+    int,
+    float,
+    Mapping[str, "SerializableType"],
+    Sequence["SerializableType"],
+    datetime,
 ]
 SerializedNode = Dict[str, SerializableType]
 ListEnumType = Enum(

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -439,7 +439,7 @@ class ContentsHandler(Handler):
             return
 
         if isinstance(page.ast, n.Root):
-            heading_list = [
+            heading_list: SerializableType = [
                 {
                     "depth": h.depth,
                     "id": h.id,

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -3,7 +3,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import pytest
 
@@ -267,7 +267,7 @@ def test_text_doc_get_page_fileid() -> None:
 def test_reporting_config_error() -> None:
     with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:
         server.m_initialize(None, CWD_URL + "/test_data/bad_project")
-        doc = {
+        doc: Dict[str, SerializableType] = {
             "uri": f"{CWD_URL}/test_data/bad_project/snooty.toml",
             "languageId": "",
             "version": 0,


### PR DESCRIPTION
Historically, mypy did not support recursive types. Consequently, our SerializableType definition had to fall back to Any.

Times change. SerializableType can now be defined in terms of itself. No more Any!