### PR TITLE
DOP-3503: Add OpenAPI Versioning support to parser

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -803,4 +803,4 @@ class InvalidVersion(Diagnostic, MakeCorrectionMixin):
         self.major_versions = major_versions
 
     def did_you_mean(self) -> List[str]:
-        return self.major_versions
+        return list(self.major_versions)

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -770,6 +770,21 @@ class IconMustBeDefined(Diagnostic):
         )
 
 
+class InvalidOpenApiResponse(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            "OpenAPI Versioning data is malformed. Please contact DOP team.",
+            start,
+            end,
+        )
+
+
 class InvalidVersion(Diagnostic, MakeCorrectionMixin):
     severity = Diagnostic.Level.error
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -791,7 +791,7 @@ class InvalidVersion(Diagnostic, MakeCorrectionMixin):
     def __init__(
         self,
         api_version: str,
-        major_versions: List[str],
+        major_versions: Sequence[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -780,7 +780,11 @@ class InvalidVersion(Diagnostic, MakeCorrectionMixin):
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
-        super().__init__(f"""Invalid OpenAPI Version Option ({api_version}) specified in options""", start, end)
+        super().__init__(
+            f"""Invalid OpenAPI Version Option ({api_version}) specified in options""",
+            start,
+            end,
+        )
         self.major_versions = major_versions
 
     def did_you_mean(self) -> List[str]:

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -768,3 +768,20 @@ class IconMustBeDefined(Diagnostic):
             start,
             end,
         )
+
+
+class InvalidVersion(Diagnostic, MakeCorrectionMixin):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        api_version: str,
+        major_versions: List[str],
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(f"""Invalid OpenAPI Version Option ({api_version}) specified in options""", start, end)
+        self.major_versions = major_versions
+
+    def did_you_mean(self) -> List[str]:
+        return self.major_versions

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -652,8 +652,7 @@ class JSONVisitor:
             uses_rst = options.get("uses-rst", False)
             # The frontend will grab the file contents from Realm, using the argument as its key
             uses_realm = options.get("uses-realm", False)
-            # Versioning will be dependent on present option(s)
-            versions = options.get("versions", None)
+            # Versioning will be dependent on present api_version option
             api_version = options.get("api-version", None)
 
             if argument_text is None:
@@ -681,7 +680,7 @@ class JSONVisitor:
                     self.diagnostics.append(InvalidURL(line))
                 return doc
 
-            if versions:
+            if api_version:
                 doc.options["source_type"] = "atlas"
                 doc.options["api_version"] = api_version
                 return doc

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -680,12 +680,7 @@ class JSONVisitor:
                     self.diagnostics.append(InvalidURL(line))
                 return doc
 
-            if api_version:
-                doc.options["source_type"] = "atlas"
-                doc.options["api_version"] = api_version
-                return doc
-
-            if uses_realm:
+            if api_version or uses_realm:
                 doc.options["source_type"] = "atlas"
                 return doc
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -652,6 +652,9 @@ class JSONVisitor:
             uses_rst = options.get("uses-rst", False)
             # The frontend will grab the file contents from Realm, using the argument as its key
             uses_realm = options.get("uses-realm", False)
+            # Versioning will be dependent on present option(s)
+            versions = options.get("versions", None)
+            api_version = options.get("api-version", None)
 
             if argument_text is None:
                 if uses_realm or uses_rst:
@@ -676,6 +679,11 @@ class JSONVisitor:
                     self.diagnostics.append(ExpectedPathArg(name, line))
                 elif spec is None:
                     self.diagnostics.append(InvalidURL(line))
+                return doc
+
+            if versions:
+                doc.options["source_type"] = "atlas"
+                doc.options["api_version"] = api_version
                 return doc
 
             if uses_realm:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -62,12 +62,12 @@ from .diagnostics import (
     UnsupportedFormat,
 )
 from .eventparser import EventParser, FileIdStack
+from .flutter import check_type, checked
 from .n import FileId, SerializableType
 from .page import Page
 from .target_database import TargetDatabase
 from .types import ProjectConfig
 from .util import SOURCE_FILE_EXTENSIONS, bundle
-from .flutter import LoadError, check_type, checked
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
@@ -997,6 +997,7 @@ class OpenAPIHandler(Handler):
         if api_version and source == "cloud":
             # Fetch latest git_hash for S3 versioning data
             try:
+                # TODO: Move urls to snooty-toml configurable constants
                 git_hash_url = "https://cloud.mongodb.com/version"
                 git_hash_response = util.HTTPCache.singleton().get(git_hash_url)
                 git_hash = str(git_hash_response, "utf-8")
@@ -1013,16 +1014,15 @@ class OpenAPIHandler(Handler):
                 )
                 return
 
-
             # Malformed Version data
-            if "major" not in data.get("versions"):
+            if "major" not in data.versions:
                 self.context.diagnostics[fileid_stack.current].append(
                     InvalidOpenApiResponse(node.start[0])
                 )
                 return
 
-            version_data = data.get("versions")
-            major_versions = version_data.get("major")
+            version_data = data.versions
+            major_versions = version_data.get("major", [])
             resource_versions = version_data.get(api_version, [])
 
             # Version not present in version data

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -983,7 +983,7 @@ class OpenAPIHandler(Handler):
             assert isinstance(argument, n.Reference)
             source = argument.refuri
 
-        api_version = node.options.get("api_version", None)
+        api_version = node.options.get("api-version", None)
         resource_versions: Optional[List[str]] = None
 
         # Fetch OpenAPI versioning data if options are present

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -704,7 +704,6 @@ argument_type = ["path", "string", "uri"]
 options.uses-rst = "flag"
 options.uses-realm = "flag"
 options.preview = "flag"
-options.versions = "string"
 options.api-version = "string"
 
 [directive."mongodb:operation"]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -704,6 +704,8 @@ argument_type = ["path", "string", "uri"]
 options.uses-rst = "flag"
 options.uses-realm = "flag"
 options.preview = "flag"
+options.versions = "string"
+options.api-version = "string"
 
 [directive."mongodb:operation"]
 content_type = "block"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2599,15 +2599,9 @@ def test_openapi_metadata() -> None:
         assert versioned_page["source_type"] == "atlas"
         assert versioned_page["source"] == "cloud"
         assert versioned_page["api_version"] == "2.0"
-        expected_resource_versions = [
-            "2021-09-09",
-            "2022-10-18",
-            "2023-01-01",
-            "2023-02-01",
-        ]
-        assert len(versioned_page["resource_versions"]) == len(
-            expected_resource_versions
-        )
+        resource_versions = versioned_page["resource_versions"]
+        assert isinstance(resource_versions, list)
+        assert all(isinstance(rv, str) for rv in resource_versions)
 
 
 def test_openapi_preview() -> None:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2570,7 +2570,6 @@ def test_openapi_metadata() -> None:
                 "source/reference/api-resources-spec/v2.txt"
             ): """
 .. openapi:: cloud
-   :versions: https://cloud.mongodb.com/api/openapi/versions
    :api-version: 2.0
             """,
         }
@@ -2652,7 +2651,6 @@ def test_openapi_invalid_version() -> None:
                 "source/reference/api-resources-spec/v3.txt"
             ): """
 .. openapi:: cloud
-   :versions: https://cloud.mongodb.com/api/openapi/versions
    :api-version: 17.5
             """,
         }


### PR DESCRIPTION
### Ticket

[DOP-3503](https://jira.mongodb.org/browse/DOP-3503)

### Notes

Adds support for OpenAPI versions. Version data should be validated and passed as build metadata.

New openapi directive options called `versions` and `api-version` are implemented to allow the parser to source version data from APIx endpoints.

In-depth information on these changes and parameters [here](https://docs.google.com/document/d/1F2tmPnFM1Kj_gFZDAyWJUAO0M5L1Bd6xQ4pHTcmaI9M/edit#heading=h.bt6gg2flm4js).

Three thoughts and questions are provided below! 