### PR TITLE
DOP-3502: make associated_product.versions an optional field

### DIFF
--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2535,6 +2535,7 @@ versions = ["v1", "v2"]
         metadata = cast(Dict[str, Any], result.metadata)
         assert len(metadata["associated_products"]) == 1
         assert len(metadata["associated_products"][0]["versions"]) == 2
+        assert metadata["associated_products"][0]["name"] == "test_associated_product"
 
 
 def test_openapi_metadata() -> None:

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -37,6 +37,8 @@ def test_project() -> None:
     assert len(project_config.associated_products) > 0
     assert project_config.associated_products[0].name == "test-name"
     assert project_config.associated_products[0].versions == ["v1.0", "v1.2"]
+    assert project_config.associated_products[1].name == "test-name2"
+    assert project_config.associated_products[1].versions == []
     assert project_config.name == "test_data"
 
 

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -38,7 +38,7 @@ def test_project() -> None:
     assert project_config.associated_products[0].name == "test-name"
     assert project_config.associated_products[0].versions == ["v1.0", "v1.2"]
     assert project_config.associated_products[1].name == "test-name2"
-    assert project_config.associated_products[1].versions == []
+    assert project_config.associated_products[1].versions == None
     assert project_config.name == "test_data"
 
 

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -127,7 +127,7 @@ class BundleConfig:
 @dataclass
 class AssociatedProduct:
     name: str
-    versions: Optional[List[str]] = field(default_factory=list)
+    versions: Optional[List[str]] = field(default=None)
 
     def serialize(self) -> SerializableType:
         return {"name": self.name, "versions": self.versions}

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -127,7 +127,7 @@ class BundleConfig:
 @dataclass
 class AssociatedProduct:
     name: str
-    versions: List[str]
+    versions: Optional[List[str]] = field(default_factory=list)
 
     def serialize(self) -> SerializableType:
         return {"name": self.name, "versions": self.versions}

--- a/test_data/test_postprocessor/snooty.toml
+++ b/test_data/test_postprocessor/snooty.toml
@@ -20,4 +20,3 @@ value = "This product is deprecated"
 
 [[associated_products]]
 name = "test_associated_name"
-versions = ["v1.1", "v1.2"]

--- a/test_data/test_project/snooty.toml
+++ b/test_data/test_project/snooty.toml
@@ -7,3 +7,6 @@ guides = "MongoDB Guides"
 [[associated_products]]
 name = "test-name"
 versions = ["v1.0", "v1.2"]
+
+[[associated_products]]
+name = "test-name2"


### PR DESCRIPTION
In order to remove [this snooty config from cloud docs](https://github.com/10gen/cloud-docs/blob/master/snooty.toml#L1076), this is a pre-req to make versions an optional value.

Currently it serves no purpose. For the initial launch, all versions of the associated product that are active in repo_branches will be included. In the future, associated product version management should also happen within hapley / repo_branches to have a single source of truth, and not leave this "associated versioning" option to snooty configs.

Tested with doc repos with/without version specified, respectively produces:

![image](https://user-images.githubusercontent.com/13054820/219170098-d6a5706f-9d98-4e45-bee3-80f3045644c1.png)

vs
![image](https://user-images.githubusercontent.com/13054820/219174431-1dd61c20-1ceb-495d-b673-c4975198abad.png)

but these versions have no effect on the merged ToC outcome from the persistence module. image below shows resulting document with the versions configured. the persistence module adheres to the existence in repos_branches document (not the snooty.toml configuration)

(bottom is snooty_dev.metadata with _id 63ed517b6b68628ac28006ae)

![image](https://user-images.githubusercontent.com/13054820/219170572-c92997ae-4c67-471b-8875-d289faf980e5.png)
