### PR TITLE
Do not swallow OSError when adding file watches

### DIFF
--- a/snooty/page.py
+++ b/snooty/page.py
@@ -3,25 +3,46 @@ from pathlib import Path, PurePath
 from typing import List, Optional, Set
 
 from . import n
-from .diagnostics import Diagnostic
+from .diagnostics import CannotOpenFile, Diagnostic
 from .n import FileId
 from .target_database import EmptyProjectInterface, ProjectInterface
 from .types import StaticAsset
 
 
-class PendingTask:
-    """A thunk which will be executed in the main process after the full tree is
-    constructed. This should primarily be used to execute tasks which may need
-    to mutate state from the main process (e.g. caches or dependency graphs)."""
+class PendingFigure:
+    """Add an image's checksum."""
 
-    def __init__(self, node: n.Node) -> None:
-        self.node = node
+    def __init__(self, node: n.Directive, asset: StaticAsset) -> None:
+        self.node: n.Directive = node
+        self.asset = asset
 
     def __call__(
-        self, diagnostics: List[Diagnostic], project: ProjectInterface
+        self, diagnostics: List[Diagnostic], project: ProjectInterface, page: "Page"
     ) -> None:
-        """Perform an action in the main process once the tree has been built."""
-        pass
+        """Compute this figure's checksum and store it in our node."""
+        cache = project.expensive_operation_cache
+
+        # Use the cached checksum if possible. Note that this does not currently
+        # update the underlying asset: if the asset is used by the current backend,
+        # the image will still have to be read.
+        if self.node.options is None:
+            self.node.options = {}
+        options = self.node.options
+        entry = cache[(self.asset.fileid, 0)]
+        if entry is not None:
+            assert isinstance(entry, str)
+            options["checksum"] = entry
+            return
+
+        try:
+            checksum = self.asset.get_checksum()
+            options["checksum"] = checksum
+            cache[(self.asset.fileid, 0)] = checksum
+        except OSError as err:
+            diagnostics.append(
+                CannotOpenFile(self.asset.path, err.strerror, self.node.start[0])
+            )
+            page.static_assets.remove(self.asset)
 
 
 @dataclass
@@ -31,7 +52,7 @@ class Page:
     source: str
     ast: n.Root
     static_assets: Set[StaticAsset] = field(default_factory=set)
-    pending_tasks: List[PendingTask] = field(default_factory=list)
+    pending_tasks: List[PendingFigure] = field(default_factory=list)
     category: Optional[str] = None
 
     @classmethod
@@ -66,7 +87,9 @@ class Page:
         """Finish all pending tasks for this page. This should be run in the main process."""
         for task in self.pending_tasks:
             task(
-                diagnostics, project if project is not None else EmptyProjectInterface()
+                diagnostics,
+                project if project is not None else EmptyProjectInterface(),
+                self,
             )
 
         self.pending_tasks.clear()


### PR DESCRIPTION
I found that tests were suddenly failing for no apparent reason. After investigation, it turns out that vscode had exhausted my system's inotify quota, but we were eating the relevant exception.

The exception handler in question was really only targeted at the "cannot open file" case, which was already handled elsewhere, but was acting as a very delayed "remove the file we can't read from our list of files" action.

I hate our PendingTasks system anyway, so I've made PendingFigure immediately handle removing the StaticAsset from the Page if it can't open the referenced file, and gotten rid of the now-pointless base class PendingTask.