### PR TITLE
Embedded Versions: allow slug to match as external toc node

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1783,6 +1783,7 @@ class Postprocessor:
         toc_landing_pages = [
             clean_slug(slug) for slug in context[ProjectConfig].toc_landing_pages
         ]
+        associated_project_names: Set[str] = set([project.name for project in context[ProjectConfig].associated_products])
         ref_project_set: Set[Tuple[Optional[str], Optional[str]]] = set()
         cls.find_toctree_nodes(
             context,
@@ -1790,6 +1791,7 @@ class Postprocessor:
             ast,
             root,
             toc_landing_pages,
+            associated_project_names,
             ref_project_set,
             {starting_fileid},
         )
@@ -1804,6 +1806,7 @@ class Postprocessor:
         ast: n.Node,
         node: Dict[str, Any],
         toc_landing_pages: List[str],
+        associated_project_names: Set[str],
         external_nodes: Set[Tuple[Optional[str], Optional[str]]],
         visited_file_ids: Set[FileId] = set(),
     ) -> None:
@@ -1889,6 +1892,16 @@ class Postprocessor:
                         "options": toctree_node_options,
                     }
 
+                    # Check if the slug corresponds to an associated project name, indicating an external node
+                    if slug in associated_project_names:
+                        toctree_node["project"] = slug
+                        ref_project_pair = (entry.title, entry.ref_project)
+                        if ref_project_pair in external_nodes:
+                            context.diagnostics[fileid].append(
+                                DuplicatedExternalToc(entry.ref_project, ast.span[0])
+                            )
+                        external_nodes.add(ref_project_pair)
+
                     # Don't recurse on the index page
                     if slug_fileid not in visited_file_ids:
                         new_ast = context.pages[slug_fileid].ast
@@ -1898,6 +1911,7 @@ class Postprocessor:
                             new_ast,
                             toctree_node,
                             toc_landing_pages,
+                            associated_project_names,
                             external_nodes,
                             visited_file_ids.union({slug_fileid}),
                         )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1880,6 +1880,16 @@ class Postprocessor:
                         "drawer": slug not in toc_landing_pages
                     }
 
+                    # Check if the cleaned slug corresponds to an associated project name, indicating an external node
+                    if slug in associated_project_names:
+                        toctree_node_options["project"] = slug
+                        ref_project_pair = (entry.title, slug)
+                        if ref_project_pair in external_nodes:
+                            context.diagnostics[fileid].append(
+                                DuplicatedExternalToc(slug, ast.span[0])
+                            )
+                        external_nodes.add(ref_project_pair)
+
                     # Check if tocicon is a page level option
                     if context.pages[FileId(slug_fileid)].ast.options:
                         if "tocicon" in context.pages[FileId(slug_fileid)].ast.options:
@@ -1893,16 +1903,6 @@ class Postprocessor:
                         "children": [],
                         "options": toctree_node_options,
                     }
-
-                    # Check if the cleaned slug corresponds to an associated project name, indicating an external node
-                    if slug in associated_project_names:
-                        toctree_node["options"]["project"] = slug
-                        ref_project_pair = (entry.title, slug)
-                        if ref_project_pair in external_nodes:
-                            context.diagnostics[fileid].append(
-                                DuplicatedExternalToc(slug, ast.span[0])
-                            )
-                        external_nodes.add(ref_project_pair)
 
                     # Don't recurse on the index page
                     if slug_fileid not in visited_file_ids:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1894,13 +1894,13 @@ class Postprocessor:
                         "options": toctree_node_options,
                     }
 
-                    # Check if the slug corresponds to an associated project name, indicating an external node
+                    # Check if the cleaned slug corresponds to an associated project name, indicating an external node
                     if slug in associated_project_names:
                         toctree_node["project"] = slug
-                        ref_project_pair = (entry.title, entry.slug)
+                        ref_project_pair = (entry.title, slug)
                         if ref_project_pair in external_nodes:
                             context.diagnostics[fileid].append(
-                                DuplicatedExternalToc(entry.slug, ast.span[0])
+                                DuplicatedExternalToc(slug, ast.span[0])
                             )
                         external_nodes.add(ref_project_pair)
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1896,7 +1896,7 @@ class Postprocessor:
 
                     # Check if the cleaned slug corresponds to an associated project name, indicating an external node
                     if slug in associated_project_names:
-                        toctree_node["project"] = slug
+                        toctree_node["options"]["project"] = slug
                         ref_project_pair = (entry.title, slug)
                         if ref_project_pair in external_nodes:
                             context.diagnostics[fileid].append(

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1783,7 +1783,9 @@ class Postprocessor:
         toc_landing_pages = [
             clean_slug(slug) for slug in context[ProjectConfig].toc_landing_pages
         ]
-        associated_project_names: Set[str] = set([project.name for project in context[ProjectConfig].associated_products])
+        associated_project_names: Set[str] = set(
+            [project.name for project in context[ProjectConfig].associated_products]
+        )
         ref_project_set: Set[Tuple[Optional[str], Optional[str]]] = set()
         cls.find_toctree_nodes(
             context,
@@ -1895,10 +1897,10 @@ class Postprocessor:
                     # Check if the slug corresponds to an associated project name, indicating an external node
                     if slug in associated_project_names:
                         toctree_node["project"] = slug
-                        ref_project_pair = (entry.title, entry.ref_project)
+                        ref_project_pair = (entry.title, entry.slug)
                         if ref_project_pair in external_nodes:
                             context.diagnostics[fileid].append(
-                                DuplicatedExternalToc(entry.ref_project, ast.span[0])
+                                DuplicatedExternalToc(entry.slug, ast.span[0])
                             )
                         external_nodes.add(ref_project_pair)
 
@@ -1927,6 +1929,7 @@ class Postprocessor:
                 child_ast,
                 node,
                 toc_landing_pages,
+                associated_project_names,
                 external_nodes,
                 visited_file_ids,
             )


### PR DESCRIPTION
Change to enable slugs which directly match a specified `associated-product.name` to be marked as external ref_project entries, to enable the current `atlas-cli` ToC entry within cloud docs to be replaced on release of embedded versions.


This change is required to allow matching for the existing Atlas-CLI entry (see https://mongodbcom-cdn.website.staging.corp.mongodb.com/docs-qa/atlas/cli/stable/) for an example of current behavior. Without this change, we'll have to try to synchronize the content change with the code deploy, which will add some risk to rollout.