### PR TITLE
DOP-3503: Add OpenAPI Versioning support to parser (#449)

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -682,3 +682,55 @@ class GuideAlreadyHasChapter(Diagnostic):
             start,
             end,
         )
+
+
+class IconMustBeDefined(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        icon_role: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"The Icon {icon_role} does not exist",
+            start,
+            end,
+        )
+
+
+class InvalidOpenApiResponse(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            "OpenAPI Versioning data is malformed. Please contact DOP team.",
+            start,
+            end,
+        )
+
+
+class InvalidVersion(Diagnostic, MakeCorrectionMixin):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        api_version: str,
+        major_versions: Sequence[str],
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"""Invalid OpenAPI Version Option ({api_version}) specified in options""",
+            start,
+            end,
+        )
+        self.major_versions = major_versions
+
+    def did_you_mean(self) -> List[str]:
+        return list(self.major_versions)

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -635,6 +635,8 @@ class JSONVisitor:
             uses_rst = options.get("uses-rst", False)
             # The frontend will grab the file contents from Realm, using the argument as its key
             uses_realm = options.get("uses-realm", False)
+            # Versioning will be dependent on present api_version option
+            api_version = options.get("api-version", None)
 
             if argument_text is None:
                 if uses_realm or uses_rst:
@@ -661,7 +663,7 @@ class JSONVisitor:
                     self.diagnostics.append(InvalidURL(line))
                 return doc
 
-            if uses_realm:
+            if api_version or uses_realm:
                 doc.options["source_type"] = "atlas"
                 return doc
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -704,6 +704,7 @@ argument_type = ["path", "string", "uri"]
 options.uses-rst = "flag"
 options.uses-realm = "flag"
 options.preview = "flag"
+options.api-version = "string"
 
 [directive."mongodb:operation"]
 content_type = "block"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -16,6 +16,7 @@ from .diagnostics import (
     InvalidChild,
     InvalidContextError,
     InvalidIAEntry,
+    InvalidVersion,
     MissingChild,
     MissingTab,
     MissingTocTreeEntry,
@@ -2479,7 +2480,13 @@ def test_openapi_metadata() -> None:
                 "source/admin/api/atlas.txt"
             ): """
 .. openapi:: cloud
-   :uses-realm:
+    :uses-realm:
+            """,
+            Path(
+                "source/reference/api-resources-spec/v2.txt"
+            ): """
+.. openapi:: cloud
+   :api-version: 2.0
             """,
         }
     ) as result:
@@ -2502,6 +2509,14 @@ def test_openapi_metadata() -> None:
         atlas_page = openapi_pages["admin/api/atlas"]
         assert atlas_page["source_type"] == "atlas"
         assert atlas_page["source"] == "cloud"
+
+        versioned_page = openapi_pages["reference/api-resources-spec/v2"]
+        assert versioned_page["source_type"] == "atlas"
+        assert versioned_page["source"] == "cloud"
+        assert versioned_page["api_version"] == "2.0"
+        resource_versions = versioned_page["resource_versions"]
+        assert isinstance(resource_versions, list)
+        assert all(isinstance(rv, str) for rv in resource_versions)
 
 
 def test_openapi_preview() -> None:
@@ -2543,3 +2558,19 @@ def test_openapi_duplicates() -> None:
         file_metadata = openapi_pages["admin/api/v3"]
         assert file_metadata["source_type"] == "local"
         assert file_metadata["source"] == "/openapi-admin-v3.yaml"
+
+
+def test_openapi_invalid_version() -> None:
+    with make_test(
+        {
+            Path(
+                "source/reference/api-resources-spec/v3.txt"
+            ): """
+.. openapi:: cloud
+   :api-version: 17.5
+            """,
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("reference/api-resources-spec/v3.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], InvalidVersion)


### PR DESCRIPTION
* accessed version data, fetch apix data, added complete data to openapi_pages

* created diagnostic InvalidVersion, implemented in postprocess

* added two tests for openapi versioning

* remove hardcoded test data

* reorganized openapi postprocess, added InvalidOpenApiResponse diagnostic error

* clean

* PR feedback

* Further PR feedback

* PR feedback: flutter type check, deletion of other checks

* fixed Sequence error, added todo

Add openapi option api-version to rstspec.toml