### PR TITLE
Add openapi option: api-version

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -701,9 +701,9 @@ example = """.. mongo-web-shell::
 [directive."mongodb:openapi"]
 help = """Include a reStructuredText file's contents."""
 argument_type = ["path", "string", "uri"]
-options.uses-rst = "flag"
 options.uses-realm = "flag"
 options.preview = "flag"
+options.api-version = "string"
 
 [directive."mongodb:operation"]
 content_type = "block"


### PR DESCRIPTION
Include `api-version` option for `openapi` directive in rstspec.toml 

Seems like the test failures are normal for `latest`