### PR TITLE
Make repeated bundle builds bit-identical

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -1,6 +1,6 @@
 import enum
 from pathlib import Path, PurePath
-from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import AbstractSet, Dict, List, Optional, Sequence, Tuple, Union
 
 from . import n
 from .n import SerializableType
@@ -662,16 +662,17 @@ class MissingTab(Diagnostic):
 
     def __init__(
         self,
-        tabs: Set[str],
+        tabs: AbstractSet[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
+        sorted_tabs = sorted(tabs)
         super().__init__(
-            f"One or more set of tabs on this page was missing the following tab(s): {tabs}",
+            f"One or more set of tabs on this page was missing the following tab(s): {sorted_tabs}",
             start,
             end,
         )
-        self.tabs = tabs
+        self.tabs = sorted_tabs
 
 
 class ExpectedTabs(Diagnostic):

--- a/snooty/page_database.py
+++ b/snooty/page_database.py
@@ -47,7 +47,8 @@ class PageDatabase:
 
                 with util.PerformanceLogger.singleton().start("copy"):
                     copied_pages = {}
-                    for k, v in self._parsed.items():
+                    for k in sorted(self._parsed.keys()):
+                        v = self._parsed[k]
                         if cancellation_token.is_set():
                             raise util.CancelledException()
 


### PR DESCRIPTION
Two categories of change are afoot here to ensure repeatable builds:
* Sorting data
* Removing timestamps