### PR TITLE
DOP-3660: Add openapi-changelog directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -712,6 +712,11 @@ options.uses-realm = "flag"
 options.preview = "flag"
 options.api-version = "string"
 
+[directive."mongodb:openapi-changelog"]
+help = """Create OpenAPI changelog page."""
+argument_type = "string"
+options.api-version = "string"
+
 [directive."mongodb:operation"]
 content_type = "block"
 options.hash = "string"

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3527,3 +3527,28 @@ def test_invalid_icon() -> None:
     )
     page.finish(diagnostics)
     assert len(diagnostics) == 0
+
+
+# def test_openapi_changelog() -> None:
+#     path = ROOT_PATH.joinpath(Path("test.rst"))
+#     project_config = ProjectConfig(ROOT_PATH, "", source="./")
+#     parser = rstparser.Parser(project_config, JSONVisitor)
+
+#     page, diagnostics = parse_rst(
+#         parser,
+#         path,
+#         """
+# .. openapi-changelog::
+#     :api-version: 2.0
+# """,
+#     )
+#     page.finish(diagnostics)
+#     assert diagnostics == []
+#     print(page.ast)
+#     check_ast_testing_string(
+#         page.ast,
+#         """<root fileid="test.rst">
+#         <directive domain="mongodb" name="openapi-changelog" option="2.0">
+#         </directive>
+#         </root>""",
+#     )

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3527,30 +3527,3 @@ def test_invalid_icon() -> None:
     )
     page.finish(diagnostics)
     assert len(diagnostics) == 0
-
-
-def test_openapi_changelog() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
-    project_config = ProjectConfig(ROOT_PATH, "", source="./")
-    parser = rstparser.Parser(project_config, JSONVisitor)
-
-    page, diagnostics = parse_rst(
-        parser,
-        path,
-        """
-.. openapi-changelog::
-    :api-version: 2.0
-""",
-    )
-    page.finish(diagnostics)
-    assert diagnostics == []
-    print(page.ast)
-    check_ast_testing_string(
-        page.ast,
-        """
-<root fileid="test.rst">
-    <directive name="openapi-changelog" domain="mongodb" api-version="2.0">
-    </directive>
-</root>
-""",
-    )

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3529,26 +3529,28 @@ def test_invalid_icon() -> None:
     assert len(diagnostics) == 0
 
 
-# def test_openapi_changelog() -> None:
-#     path = ROOT_PATH.joinpath(Path("test.rst"))
-#     project_config = ProjectConfig(ROOT_PATH, "", source="./")
-#     parser = rstparser.Parser(project_config, JSONVisitor)
+def test_openapi_changelog() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
 
-#     page, diagnostics = parse_rst(
-#         parser,
-#         path,
-#         """
-# .. openapi-changelog::
-#     :api-version: 2.0
-# """,
-#     )
-#     page.finish(diagnostics)
-#     assert diagnostics == []
-#     print(page.ast)
-#     check_ast_testing_string(
-#         page.ast,
-#         """<root fileid="test.rst">
-#         <directive domain="mongodb" name="openapi-changelog" option="2.0">
-#         </directive>
-#         </root>""",
-#     )
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. openapi-changelog::
+    :api-version: 2.0
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    print(page.ast)
+    check_ast_testing_string(
+        page.ast,
+        """
+<root fileid="test.rst">
+    <directive name="openapi-changelog" domain="mongodb" api-version="2.0">
+    </directive>
+</root>
+""",
+    )


### PR DESCRIPTION
### Ticket

DOP-3660

### Notes

Adds openapi-changelog directive and api-version option.