### PR TITLE
DOP-3661: disallow duplicate changelog directives

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -117,7 +117,7 @@ class ExpectedStringArg(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f'"{name}" expected argument: "{expectedArg}" but received "{receivedArg}"',
+            f'"{name}" expected argument "{expectedArg}", but received "{receivedArg}"',
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -105,6 +105,25 @@ class ExpectedPathArg(Diagnostic):
         self.name = name
 
 
+class ExpectedStringArg(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        name: str,
+        expectedArg: str,
+        receivedArg: Union[str, None],
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f'"{name}" expected argument: "{expectedArg}" but received "{receivedArg}"',
+            start,
+            end,
+        )
+        self.name = name
+
+
 class UnnamedPage(Diagnostic):
     severity = Diagnostic.Level.error
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -130,7 +130,7 @@ class ExpectedStringArg(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f'"{name}" expected argument "{expectedArg}",  but received "{receivedArg}"',
+            f'"{name}" expected argument "{expectedArg}", but received "{receivedArg}"',
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -81,6 +81,19 @@ class UnexpectedIndentation(Diagnostic, MakeCorrectionMixin):
         return [".. blockquote::"]
 
 
+class ExpectedOption(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        name: str,
+        option: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(f'"{name}" missing expected option "{option}"', start, end)
+
+
 class InvalidURL(Diagnostic):
     severity = Diagnostic.Level.error
 
@@ -117,7 +130,7 @@ class ExpectedStringArg(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f'"{name}" expected argument "{expectedArg}", but received "{receivedArg}"',
+            f'"{name}" expected argument "{expectedArg}",  but received "{receivedArg}"',
             start,
             end,
         )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -660,6 +660,7 @@ class JSONVisitor:
                     )
 
         elif name == "openapi":
+            print("openapi alone")
             # OpenAPI directive is parsed here and prepped for OAS module within autobuilder
             # the module is responsible for building OpenAPI specs and AST, post parse
             uses_realm = options.get("uses-realm", False)
@@ -710,6 +711,19 @@ class JSONVisitor:
                 self.diagnostics.append(
                     CannotOpenFile(Path(argument_text), err.strerror, line)
                 )
+                return doc
+
+        elif name == "openapi-changelog":
+            print("here??! ")
+            # Version Changelog will be dependent on present api-version option
+            api_version = options.get("api-version", None)
+
+            if not argument_text == "cloud":
+                self.diagnostics.append(ExpectedPathArg(name, line))
+                return doc
+
+            if api_version:
+                doc.options["source_type"] = "atlas"
                 return doc
 
         elif name == "literalinclude" or name == "input" or name == "output":

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -660,7 +660,6 @@ class JSONVisitor:
                     )
 
         elif name == "openapi":
-            print("openapi alone")
             # OpenAPI directive is parsed here and prepped for OAS module within autobuilder
             # the module is responsible for building OpenAPI specs and AST, post parse
             uses_realm = options.get("uses-realm", False)
@@ -714,7 +713,6 @@ class JSONVisitor:
                 return doc
 
         elif name == "openapi-changelog":
-            print("here??! ")
             # Version Changelog will be dependent on present api-version option
             api_version = options.get("api-version", None)
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -46,6 +46,7 @@ from .diagnostics import (
     Diagnostic,
     DocUtilsParseError,
     ExpectedPathArg,
+    ExpectedStringArg,
     FetchError,
     IconMustBeDefined,
     ImageSuggested,
@@ -717,14 +718,16 @@ class JSONVisitor:
             # Version Changelog will be dependent on present api-version option
             api_version = options.get("api-version", None)
 
-            if not argument_text == "cloud":
-                self.diagnostics.append(ExpectedPathArg(name, line))
+            if argument_text != "cloud":
+                self.diagnostics.append(
+                    ExpectedStringArg(name, "cloud", argument_text, line)
+                )
                 return doc
 
             if api_version:
                 return doc
-            else:
-                self.diagnostics.append(MissingOption(name, line))
+
+            self.diagnostics.append(MissingOption(name, line))
 
         elif name == "literalinclude" or name == "input" or name == "output":
             if name == "literalinclude":

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -45,6 +45,7 @@ from .diagnostics import (
     ConfigurationProblem,
     Diagnostic,
     DocUtilsParseError,
+    ExpectedOption,
     ExpectedPathArg,
     ExpectedStringArg,
     FetchError,
@@ -59,7 +60,6 @@ from .diagnostics import (
     MalformedRelativePath,
     MissingAssociatedToc,
     MissingChild,
-    MissingOption,
     RemovedLiteralBlockSyntax,
     TabMustBeDirective,
     TodoInfo,
@@ -727,7 +727,7 @@ class JSONVisitor:
             if api_version:
                 return doc
 
-            self.diagnostics.append(MissingOption(name, line))
+            self.diagnostics.append(ExpectedOption(name, "api-version", line))
 
         elif name == "literalinclude" or name == "input" or name == "output":
             if name == "literalinclude":

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -58,6 +58,7 @@ from .diagnostics import (
     MalformedRelativePath,
     MissingAssociatedToc,
     MissingChild,
+    MissingOption,
     RemovedLiteralBlockSyntax,
     TabMustBeDirective,
     TodoInfo,
@@ -721,8 +722,9 @@ class JSONVisitor:
                 return doc
 
             if api_version:
-                doc.options["source_type"] = "atlas"
                 return doc
+            else:
+                self.diagnostics.append(MissingOption(name, line))
 
         elif name == "literalinclude" or name == "input" or name == "output":
             if name == "literalinclude":

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1054,7 +1054,7 @@ class OpenAPIChangelogHandler(Handler):
         self.has_changelog_directive = False
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        self.has_contents_directive = False
+        self.has_changelog_directive = False
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "openapi-changelog":

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1066,6 +1066,8 @@ class OpenAPIChangelogHandler(Handler):
                     DuplicateDirective(node.name, node.start[0])
                 )
                 return
+            self.has_changelog_directive = True
+            return
 
 
 class IAHandler(Handler):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1046,6 +1046,28 @@ class OpenAPIHandler(Handler):
         )
 
 
+class OpenAPIChangelogHandler(Handler):
+    """Constructs metadata for OpenAPI content pages."""
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self.has_changelog_directive = False
+
+    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
+        self.has_contents_directive = False
+
+    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if not isinstance(node, n.Directive) or node.name != "openapi-changelog":
+            return
+
+        if isinstance(node, n.Directive) and node.name == "openapi-changelog":
+            if self.has_changelog_directive:
+                self.context.diagnostics[fileid_stack.current].append(
+                    DuplicateDirective(node.name, node.start[0])
+                )
+                return
+
+
 class IAHandler(Handler):
     """Identify IA directive on a page and save a list of its entries as a page-level option."""
 
@@ -1577,6 +1599,7 @@ class Postprocessor:
             BannerHandler,
             GuidesHandler,
             OpenAPIHandler,
+            OpenAPIChangelogHandler,
         ],
         [TargetHandler, IAHandler, NamedReferenceHandlerPass1],
         [RefsHandler, NamedReferenceHandlerPass2],

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -7,6 +7,7 @@ from .diagnostics import (
     Diagnostic,
     DocUtilsParseError,
     ErrorParsingYAMLFile,
+    ExpectedOption,
     ExpectedPathArg,
     ExpectedStringArg,
     IconMustBeDefined,
@@ -3548,3 +3549,22 @@ def test_invalid_string_argument() -> None:
     assert len(diagnostics) == 1
     print(diagnostics)
     assert isinstance(diagnostics[0], ExpectedStringArg)
+
+
+def test_missing_expected_option() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        r"""
+.. openapi-changelog:: cloud
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    print(diagnostics)
+    assert isinstance(diagnostics[0], ExpectedOption)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -8,6 +8,7 @@ from .diagnostics import (
     DocUtilsParseError,
     ErrorParsingYAMLFile,
     ExpectedPathArg,
+    ExpectedStringArg,
     IconMustBeDefined,
     IncorrectLinkSyntax,
     IncorrectMonospaceSyntax,
@@ -3527,3 +3528,23 @@ def test_invalid_icon() -> None:
     )
     page.finish(diagnostics)
     assert len(diagnostics) == 0
+
+
+def test_invalid_string_argument() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        r"""
+.. openapi-changelog::
+   :api-version: 2.0
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    print(diagnostics)
+    assert isinstance(diagnostics[0], ExpectedStringArg)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2659,3 +2659,20 @@ def test_openapi_invalid_version() -> None:
         diagnostics = result.diagnostics[FileId("reference/api-resources-spec/v3.txt")]
         assert len(diagnostics) == 1
         assert isinstance(diagnostics[0], InvalidVersion)
+
+
+def test_openapi_changelog_duplicates() -> None:
+    with make_test(
+        {
+            Path(
+                "source/reference/api-changelog.txt"
+            ): """
+.. openapi:: cloud
+
+.. openapi:: cloud
+            """,
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("reference/api-changelog.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], DuplicateDirective)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2667,9 +2667,11 @@ def test_openapi_changelog_duplicates() -> None:
             Path(
                 "source/reference/api-changelog.txt"
             ): """
-.. openapi:: cloud
+.. openapi-changelog:: cloud
+   :api-version: 2.0
 
-.. openapi:: cloud
+.. openapi-changelog:: cloud
+   :api-version: 2.0
             """,
         }
     ) as result:


### PR DESCRIPTION
Emits error on duplicate `openapi_changelog` directives on a page.

Also, does legwork to account for `openapi_changelog` directives in `parser.py` and `postprocess.py`