### PR TITLE
DOP-3663: validate api-version for changelog

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -826,13 +826,14 @@ class InvalidVersion(Diagnostic, MakeCorrectionMixin):
 
     def __init__(
         self,
+        directive: str,
         api_version: str,
         major_versions: Sequence[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"""Invalid OpenAPI Version Option ({api_version}) specified in options""",
+            f"""Invalid OpenAPI Version option ({api_version}) specified for directive {directive}""",
             start,
             end,
         )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -56,7 +56,6 @@ from .diagnostics import (
     InvalidLiteralInclude,
     InvalidTableStructure,
     InvalidURL,
-    InvalidVersion,
     MalformedGlossary,
     MalformedRelativePath,
     MissingAssociatedToc,
@@ -726,10 +725,6 @@ class JSONVisitor:
                 return doc
 
             if api_version:
-                if api_version != "2.0":
-                    self.diagnostics.append(
-                        InvalidVersion("openapi-changelog", api_version, ["2.0"], line)
-                    )
                 return doc
 
             self.diagnostics.append(ExpectedOption(name, "api-version", line))

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -56,6 +56,7 @@ from .diagnostics import (
     InvalidLiteralInclude,
     InvalidTableStructure,
     InvalidURL,
+    InvalidVersion,
     MalformedGlossary,
     MalformedRelativePath,
     MissingAssociatedToc,
@@ -725,6 +726,10 @@ class JSONVisitor:
                 return doc
 
             if api_version:
+                if api_version != "2.0":
+                    self.diagnostics.append(
+                        InvalidVersion("openapi-changelog", api_version, ["2.0"], line)
+                    )
                 return doc
 
             self.diagnostics.append(ExpectedOption(name, "api-version", line))

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1034,7 +1034,9 @@ class OpenAPIHandler(Handler):
                 ):
                     major_versions = []
                 self.context.diagnostics[fileid_stack.current].append(
-                    InvalidVersion(api_version, major_versions, node.start[0])
+                    InvalidVersion(
+                        "openapi", api_version, major_versions, node.start[0]
+                    )
                 )
                 return
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1035,7 +1035,7 @@ class OpenAPIHandler(Handler):
                     major_versions = []
                 self.context.diagnostics[fileid_stack.current].append(
                     InvalidVersion(
-                        "openapi", api_version, major_versions, node.start[0]
+                        node.name, api_version, major_versions, node.start[0]
                     )
                 )
                 return

--- a/snooty/rstspec-consolidated.toml
+++ b/snooty/rstspec-consolidated.toml
@@ -12,7 +12,6 @@ charts_theme = ["light", "dark"]
 devhub_type = ["article", "quickstart", "how-to", "video", "live"]
 guide_categories = ["Getting Started"]
 mws_version = ["3.4", "3.6", "4.0", "4.2", "4.4", "5.0", "latest"]
-output_format = ["html"]
 procedure_styles = ["normal", "connected"]
 user_level = ["beginner", "intermediate", "advanced"]
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -14,9 +14,9 @@ card_group_type = ["default", "drivers"]
 charts_theme = ["light", "dark"]
 guide_categories = ["Getting Started"]
 mws_version = ["3.4", "3.6", "4.0", "4.2", "4.4", "5.0", "latest"]
-output_format = ["html"]
 procedure_styles = ["normal", "connected"]
 user_level = ["beginner", "intermediate", "advanced"]
+changelog_versions = ["2.0"]
 
 [directive.default-domain]
 argument_type = "string"
@@ -715,7 +715,7 @@ options.api-version = "string"
 [directive."mongodb:openapi-changelog"]
 help = """Create OpenAPI changelog page."""
 argument_type = "string"
-options.api-version = "string"
+options.api-version = "changelog_versions"
 
 [directive."mongodb:operation"]
 content_type = "block"

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -18,7 +18,6 @@ from .diagnostics import (
     InvalidLiteralInclude,
     InvalidTableStructure,
     InvalidURL,
-    InvalidVersion,
     MakeCorrectionMixin,
     MalformedGlossary,
     MalformedRelativePath,
@@ -3588,4 +3587,4 @@ def test_invalid_changelog_option() -> None:
     page.finish(diagnostics)
     assert len(diagnostics) == 1
     print(diagnostics)
-    assert isinstance(diagnostics[0], InvalidVersion)
+    assert isinstance(diagnostics[0], DocUtilsParseError)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -18,6 +18,7 @@ from .diagnostics import (
     InvalidLiteralInclude,
     InvalidTableStructure,
     InvalidURL,
+    InvalidVersion,
     MakeCorrectionMixin,
     MalformedGlossary,
     MalformedRelativePath,
@@ -3568,3 +3569,23 @@ def test_missing_expected_option() -> None:
     assert len(diagnostics) == 1
     print(diagnostics)
     assert isinstance(diagnostics[0], ExpectedOption)
+
+
+def test_invalid_changelog_option() -> None:
+    path = ROOT_PATH.joinpath(Path("test.rst"))
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        r"""
+.. openapi-changelog:: cloud
+   :api-version: 1.0
+""",
+    )
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    print(diagnostics)
+    assert isinstance(diagnostics[0], InvalidVersion)


### PR DESCRIPTION
Very simple PR. This validates that the only acceptable value for the `api-version` for the `openapi-changelog` directive is "2.0"

I've only added this to account in the future for when there will be more versions. An additional check. 