### PR TITLE
DOP-3669: Add an Atlas UI option to the language selector

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1732,6 +1732,7 @@ platforms = [
 ]
 drivers = [
   {id = "shell", title = "MongoDB Shell"},
+  {id = "atlas-ui", title = "MongoDB Atlas"},
   {id = "compass", title = "Compass"},
   {id = "c", title = "C"},
   {id = "cpp", title = "C++11"},


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOP-3669

This PR adds an Atlas UI option to the tabs-drivers language selector.