### PR TITLE
DOP-3729: Update Page.static_assets set in IncludeHandler

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -329,6 +329,9 @@ class IncludeHandler(Handler):
         include_page = self.pages.get(include_fileid)
         assert include_page is not None
         ast = include_page.ast
+        self.context.pages[fileid_stack.root].static_assets.update(
+            include_page.static_assets
+        )
         assert isinstance(ast, n.Parent)
         deep_copy_children: MutableSequence[n.Node] = [util.fast_deep_copy(ast)]
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2678,3 +2678,24 @@ def test_openapi_changelog_duplicates() -> None:
         diagnostics = result.diagnostics[FileId("reference/api-changelog.txt")]
         assert len(diagnostics) == 1
         assert isinstance(diagnostics[0], DuplicateDirective)
+
+
+def test_static_assets() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. include:: /foo.rst
+            """,
+            Path(
+                "source/foo.rst"
+            ): """
+.. figure:: figure.blob
+            """,
+            Path("source/figure.blob"): r"",
+        }
+    ) as result:
+        assert [x.key for x in result.pages[FileId("index.txt")].static_assets] == [
+            "figure.blob"
+        ]


### PR DESCRIPTION
This makes `static_assets` not a lie when a page includes another.