### PR TITLE
Add kotlin drivers to rst spec

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1833,6 +1833,8 @@ drivers = [
   {id = "go", title = "Go"},
   {id = "java-async", title = "Java (Async)"},
   {id = "java-sync", title = "Java (Sync)"},
+  {id = "kotlin-coroutine", title = "Kotlin (Coroutine)"},
+  {id = "kotlin-sync", title = "Kotlin (Sync)"},
   {id = "motor", title = "Motor"},
   {id = "nodejs", title = "Node.js"},
   {id = "perl", title = "Perl"},


### PR DESCRIPTION
question to reviewers: is there anywhere else in the snooty repo(s) that we should add the kotlin driver? 