### PR TITLE
DOP-3746: Use Pyston on linux amd64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,24 @@ jobs:
       run: python3 -m poetry install
     - name: Run tests
       run: make test
+  testPackage:
+    strategy:
+      matrix:
+        platform: [ubuntu-20.04, macos-latest]
+        python-version: ['3.11']
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64'
+    - name: Setup poetry
+      run: python3 -m pip install poetry
+    - name: Install dependencies
+      run: python3 -m poetry install
     - name: Build package
       id: build_package
       run: make package

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 dist/
 .docs
 .vscode
+/pyston_2.3.5/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ dist/snooty/.EXISTS: pyproject.toml snooty/*.py snooty/gizaparser/*.py
 	-rm -rf snooty.dist dist
 	mkdir dist
 	echo 'from snooty import main; main.main()' > snootycli.py
-	poetry run python3 -m PyInstaller -n snooty snootycli.py
+
+	if [ "`uname -ms`" = "Linux x86_64" ]; then \
+		poetry env use "`tools/fetch-pyston.sh`/pyston3" && poetry install; \
+	fi; LD_LIBRARY_PATH=pyston_2.3.5/lib/ poetry run python3 -m PyInstaller -n snooty snootycli.py
+
 	rm snootycli.py
 	install -m644 snooty/config.toml snooty/rstspec.toml LICENSE* dist/snooty/
 	touch $@
@@ -44,6 +48,7 @@ clean: ## Remove all build artifacts
 	-rm -r snooty.tar.zip* snootycli.py
 	-rm -rf dist
 	-rm -rf .docs
+	-rm -r pyston_2.3.5
 
 package: dist/${PACKAGE_NAME}
 

--- a/tools/fetch-pyston.sh
+++ b/tools/fetch-pyston.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+VERSION="2.3.5"
+EXTRACTED_PATH="`pwd`/pyston_${VERSION}"
+
+if [ ! -d "${EXTRACTED_PATH}" ]; then
+    curl -OL "https://github.com/pyston/pyston/releases/download/pyston_${VERSION}/pyston_${VERSION}_portable_amd64.tar.gz"
+    tar -xf "pyston_${VERSION}_portable_amd64.tar.gz"
+    rm "pyston_${VERSION}_portable_amd64.tar.gz"
+    ln -s "libpython3.8-pyston2.3.so" "pyston_${VERSION}/lib/libpython3.8.so"
+    ln -s "libpython3.8-pyston2.3.so" "pyston_${VERSION}/lib/libpython3.8.so.1.0"
+fi
+echo "${EXTRACTED_PATH}"


### PR DESCRIPTION
```
CPython 3.11: 51.130s
Pyston:       41.841s
```

Pyston likely isn't a permanent solution, but provides a low-risk free performance bump in the medium-term.