### PR TITLE
DOP-3739: Implement simple PageData persistance and unpersistence

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -63,6 +63,18 @@ class Diagnostic:
         diag["message"] = self.message
         return diag
 
+    def __eq__(self, other: object) -> bool:
+        if type(self) != type(other):
+            return False
+
+        assert isinstance(other, Diagnostic)
+
+        return (
+            self.message == other.message
+            and self.start == other.start
+            and self.end == other.end
+        )
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({repr(self.message)}, {repr(self.start)})"
 

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -30,10 +30,10 @@ class Page:
     output_filename: str
     source: str
     ast: n.Root
-    facets: Optional[SerializedNode] = field(default=None)
-    category: Optional[str] = field(default=None)
     static_assets: Set[StaticAsset] = field(default_factory=set)
     pending_tasks: List[PendingTask] = field(default_factory=list)
+    facets: Optional[SerializedNode] = field(default=None)
+    category: Optional[str] = field(default=None)
 
     @classmethod
     def create(

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -30,10 +30,10 @@ class Page:
     output_filename: str
     source: str
     ast: n.Root
+    facets: Optional[SerializedNode] = field(default=None)
+    category: Optional[str] = field(default=None)
     static_assets: Set[StaticAsset] = field(default_factory=set)
     pending_tasks: List[PendingTask] = field(default_factory=list)
-    facets: Optional[SerializedNode] = None
-    category: Optional[str] = None
 
     @classmethod
     def create(

--- a/snooty/page_database.py
+++ b/snooty/page_database.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import pickle
+import pickletools
+import queue
+import threading
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+from . import util
+from .diagnostics import Diagnostic
+from .n import FileId
+from .page import Page
+from .postprocess import Postprocessor, PostprocessorResult
+from .target_database import TargetDatabase
+
+
+@dataclass
+class SerializedPageData:
+    parsed: Dict[FileId, Tuple[Page, FileId, List[Diagnostic]]]
+    orphan_diagnostics: Dict[FileId, List[Diagnostic]]
+
+
+class PageDatabase:
+    """A database of FileId->Page mappings that ensures the postprocessing pipeline
+    is run correctly. Raw parsed pages are added, flush() is called, then postprocessed
+    pages can be accessed.
+
+    All methods are thread-safe, but data returned should not be mutated by more than one
+    thread."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+        self._parsed: Dict[FileId, Tuple[Page, FileId, List[Diagnostic]]] = {}
+        self._orphan_diagnostics: Dict[FileId, List[Diagnostic]] = {}
+        self.__cached = PostprocessorResult({}, {}, {}, TargetDatabase())
+        self.__changed_pages: Set[FileId] = set()
+
+        def start(
+            cancellation_token: threading.Event,
+            args: Postprocessor,
+        ) -> PostprocessorResult:
+            with self._lock:
+                if not self.__changed_pages:
+                    return self.__cached
+
+                with util.PerformanceLogger.singleton().start("copy"):
+                    copied_pages = {}
+                    for k, v in self._parsed.items():
+                        if cancellation_token.is_set():
+                            raise util.CancelledException()
+
+                        copied_pages[k] = util.fast_deep_copy(v[0])
+
+            with util.PerformanceLogger.singleton().start("postprocessing"):
+                result = args.run(copied_pages, cancellation_token)
+
+            with self._lock:
+                self.__cached = result
+                self.__changed_pages.clear()
+
+            return result
+
+        self.worker: util.WorkerLauncher[
+            Postprocessor, PostprocessorResult
+        ] = util.WorkerLauncher("postprocessor", start)
+
+    def set_orphan_diagnostics(self, key: FileId, value: List[Diagnostic]) -> None:
+        """Some diagnostics can't be associated with a parsed Page because of underlying
+        problems like invalid YAML syntax. These are orphan diagnostics, and we need
+        to track them too."""
+        with self._lock:
+            self._orphan_diagnostics[key] = value
+
+    def __setitem__(
+        self, key: FileId, value: Tuple[Page, FileId, List[Diagnostic]]
+    ) -> None:
+        """Set a raw parsed page."""
+        with self._lock:
+            self._parsed[key] = value
+            self.__changed_pages.add(key)
+
+    def get(self, key: FileId) -> Optional[Page]:
+        try:
+            return self[key]
+        except KeyError:
+            return None
+
+    def __getitem__(self, key: FileId) -> Page:
+        """If the postprocessor has been run since modifications were made, fetch a postprocessed page."""
+        with self._lock:
+            assert not self.__changed_pages
+            return self.__cached.pages[key]
+
+    def __contains__(self, key: FileId) -> bool:
+        """Check if a given page exists in the parsed set."""
+        with self._lock:
+            return key in self._parsed
+
+    def __delitem__(self, key: FileId) -> None:
+        with self._lock:
+            try:
+                del self._parsed[key]
+            except KeyError:
+                pass
+
+            try:
+                del self._orphan_diagnostics[key]
+            except KeyError:
+                pass
+
+    def __eq__(self, other: object) -> bool:
+        if type(self) != type(other):
+            return False
+
+        assert isinstance(other, PageDatabase)
+
+        with self._lock:
+            with other._lock:
+                print("Foo1")
+                if self._parsed != other._parsed:
+                    return False
+
+                print("Foo1")
+                return self._orphan_diagnostics == other._orphan_diagnostics
+
+    def merge_diagnostics(
+        self, *others: Dict[FileId, List[Diagnostic]]
+    ) -> Dict[FileId, List[Diagnostic]]:
+        with self._lock:
+            result: Dict[FileId, List[Diagnostic]] = {
+                v[1]: list(v[2]) for v in self._parsed.values()
+            }
+
+            for key, diagnostics in self._orphan_diagnostics.items():
+                if key in result:
+                    result[key].extend(diagnostics)
+                else:
+                    result[key] = list(diagnostics)
+
+        all_keys: Set[FileId] = set()
+        for other in others:
+            all_keys.update(other.keys())
+
+        for key in all_keys:
+            try:
+                lst = result[key]
+            except KeyError:
+                lst = []
+                result[key] = lst
+            for other in others:
+                try:
+                    lst.extend(other[key])
+                except KeyError:
+                    pass
+
+        return result
+
+    def flush(
+        self, postprocessor_factory: Callable[[], Postprocessor]
+    ) -> queue.Queue[Tuple[Optional[PostprocessorResult], Optional[Exception]]]:
+        """Run the postprocessor if and only if any pages have changed, and return postprocessing results."""
+        postprocessor = postprocessor_factory()
+        return self.worker.run(postprocessor)
+
+    def flush_and_wait(
+        self, postprocessor_factory: Callable[[], Postprocessor]
+    ) -> PostprocessorResult:
+        result, exception = self.flush(postprocessor_factory).get()
+        if exception:
+            raise exception
+        assert result is not None
+        return result
+
+    def cancel(self) -> None:
+        self.worker.cancel()
+
+    def persist(self) -> bytes:
+        with self._lock:
+            pickled = pickle.dumps(
+                SerializedPageData(self._parsed, self._orphan_diagnostics)
+            )
+
+        return pickletools.optimize(pickled)
+
+    @classmethod
+    def from_persisted(cls, pickled: bytes) -> PageDatabase:
+        unpickled = pickle.loads(pickled)
+        assert isinstance(unpickled, SerializedPageData)
+
+        db = PageDatabase()
+        db._parsed = unpickled.parsed
+        db._orphan_diagnostics = unpickled.orphan_diagnostics
+        db.__changed_pages = set(db._parsed.keys())
+        return db

--- a/snooty/page_database.py
+++ b/snooty/page_database.py
@@ -118,12 +118,10 @@ class PageDatabase:
 
         with self._lock:
             with other._lock:
-                print("Foo1")
-                if self._parsed != other._parsed:
-                    return False
-
-                print("Foo1")
-                return self._orphan_diagnostics == other._orphan_diagnostics
+                return (
+                    self._parsed == other._parsed
+                    and self._orphan_diagnostics == other._orphan_diagnostics
+                )
 
     def merge_diagnostics(
         self, *others: Dict[FileId, List[Diagnostic]]

--- a/snooty/test_page_data.py
+++ b/snooty/test_page_data.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from .n import FileId
+from .page_database import PageDatabase
+from .parser import Project
+from .test_project import Backend
+
+
+def test_persistance() -> None:
+    backend = Backend()
+    with Project(
+        Path("test_data/test_project_embedding_includes/"), backend, {}
+    ) as project:
+        project.build()
+
+        with project._lock:
+            persisted = project._project.pages.persist()
+            loaded = PageDatabase.from_persisted(persisted)
+            assert loaded == project._project.pages
+
+            loaded._parsed[FileId("index.txt")][0].ast.children[0].span = (2,)
+            assert loaded != project._project.pages

--- a/snooty/test_page_database.py
+++ b/snooty/test_page_database.py
@@ -6,7 +6,7 @@ from .parser import Project
 from .test_project import Backend
 
 
-def test_persistance() -> None:
+def test_persistence() -> None:
     backend = Backend()
     with Project(
         Path("test_data/test_project_embedding_includes/"), backend, {}


### PR DESCRIPTION
This approach uses `pickletools.optimize()`: while increasing persistence times dramatically (2.5s to 15.4s), it decreases load times from 4.0s to 1.8s using CPython 3.11.

Is this a worthwhile tradeoff? If cached builds are generated as a one-off batch-job, probably yes. If caching is generated on each build, absolutely not. Optimization can additionally be run offline as a separate job.

How we handle this and fine-tune what we persist and unpersist can be handled in the subsequent task.

# Laptop Timings

## CPython 3.11
Persist: 15.4s
Unpersist: 1.8s

## Pyston 3.8
Persist: 10.3s
Unpersist: 1.7s