### PR TITLE
update atlas admin openapi links to use V2

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1504,10 +1504,10 @@ type = {link = "https://quay.io/mongodb%s"}
 type = {link = "https://quay.io/repository/mongodb%s"}
 
 [role."oas-atlas-tag"]
-type = {link = "https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag%s"}
+type = {link = "https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag%s"}
 
 [role."oas-atlas-op"]
-type = {link = "https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation%s"}
+type = {link = "https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#operation%s"}
 
 [role."atlascli"]
 help = """Link to a page in the Atlas CLI documentation."""


### PR DESCRIPTION
Updated the `oas-atlas-tag` and `oas-atlas-op` roles to point to the new versioned API. This should be merged and cherry-picked after we publish the versioned API docs tomorrow.