### PR TITLE
DOP-3740: Data cache layer

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -3,6 +3,7 @@
 Usage:
   snooty build [--no-caching] <source-path> [--output=<path>] [options]
   snooty watch [--no-caching] <source-path>
+  snooty create-cache         <source-path>
   snooty [--no-caching] language-server
 
 Options:
@@ -292,6 +293,10 @@ def main() -> None:
 
     try:
         project.build()
+
+        if args["create-cache"]:
+            with PerformanceLogger.singleton().start("persist cache"):
+                project.update_cache()
 
         if os.environ.get("SNOOTY_PERF_SUMMARY", "0") == "1":
             PerformanceLogger.singleton().print(sys.stderr)

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -1,3 +1,4 @@
+import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
 from typing import List, Optional, Set
@@ -30,6 +31,7 @@ class Page:
     output_filename: str
     source: str
     ast: n.Root
+    blake2b: str
     static_assets: Set[StaticAsset] = field(default_factory=set)
     pending_tasks: List[PendingTask] = field(default_factory=list)
     facets: Optional[SerializedNode] = field(default=None)
@@ -49,7 +51,13 @@ class Page:
         if ast is None:
             ast = n.Root((0,), [], FileId(source_path), {})
 
-        return Page(source_path, output_filename, source, ast)
+        return Page(
+            source_path,
+            output_filename,
+            source,
+            ast,
+            hashlib.blake2b(bytes(source, "utf-8")).hexdigest(),
+        )
 
     def fake_full_path(self) -> PurePath:
         """Return a fictitious path (hopefully) uniquely identifying this output artifact."""

--- a/snooty/page_database.py
+++ b/snooty/page_database.py
@@ -7,7 +7,7 @@ import threading
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from . import util
+from . import parse_cache, util
 from .diagnostics import Diagnostic
 from .n import FileId
 from .page import Page
@@ -109,6 +109,15 @@ class PageDatabase:
                 del self._orphan_diagnostics[key]
             except KeyError:
                 pass
+
+    def add_to_cache(self, cache: parse_cache.CacheData) -> None:
+        with self._lock:
+            for data in self._parsed.values():
+                page, fileid, diagnostics = data
+                cache.set_page(page, diagnostics)
+
+            for fileid, diagnostics in self._orphan_diagnostics.items():
+                cache.set_orphan_diagnostics(fileid, diagnostics)
 
     def __eq__(self, other: object) -> bool:
         if type(self) != type(other):

--- a/snooty/parse_cache.py
+++ b/snooty/parse_cache.py
@@ -1,0 +1,108 @@
+import hashlib
+import logging
+import pickle
+import pickletools
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from . import __version__, diagnostics, specparser, util
+from .diagnostics import Diagnostic
+from .n import FileId
+from .page import Page
+from .types import ProjectConfig
+
+logger = logging.getLogger(__name__)
+
+# Specify protocol 5 since it's supported by Python 3.8+, our supported
+# versions of Python.
+PROTOCOL = 5
+
+
+@dataclass
+class CacheData:
+    specifier: Tuple[str, ...]
+    pages: Dict[Tuple[str, str], bytes] = field(default_factory=dict)
+    orphan_diagnostics: Dict[str, bytes] = field(default_factory=dict)
+
+    def set_page(self, obj: Page, diagnostics: List[Diagnostic]) -> None:
+        self.pages[(obj.ast.fileid.as_posix(), obj.blake2b)] = pickle.dumps(
+            (obj, diagnostics), protocol=PROTOCOL
+        )
+
+    def set_orphan_diagnostics(
+        self, fileid: FileId, orphan_diagnostics: List[Diagnostic]
+    ) -> None:
+        self.orphan_diagnostics[fileid.as_posix()] = pickle.dumps(
+            orphan_diagnostics, protocol=PROTOCOL
+        )
+
+    def get(
+        self, config: ProjectConfig, path: Path
+    ) -> Tuple[Page, Sequence[diagnostics.Diagnostic]]:
+        """Get a specific page from the cached data with the specified blake2b hash. Raises KeyError
+        if the page is not found or the checksum does not match."""
+
+        file_hash = hashlib.blake2b(path.read_bytes()).hexdigest()
+
+        page, diagnostics = pickle.loads(
+            self.pages[(config.get_fileid(path).as_posix(), file_hash)]
+        )
+        assert isinstance(page, Page)
+        assert all(isinstance(x, diagnostics.Diagnostic) for x in diagnostics)
+
+        return page, diagnostics
+
+    def __len__(self) -> int:
+        return len(self.pages)
+
+
+class ParseCache:
+    def __init__(self, project_config: ProjectConfig) -> None:
+        self.project_config = project_config
+
+    def read(self, path: Optional[Path] = None) -> CacheData:
+        path = self.path if path is None else path
+
+        self_specifier = self.generate_specifier()
+
+        try:
+            with path.open("rb") as f:
+                data = pickle.load(f)
+        except Exception as err:
+            logger.debug("Error loading cache file: %s", err)
+            return CacheData(self_specifier)
+
+        if data.specifier != self_specifier:
+            logger.info(
+                "Cache file specifier incompatible: %s != %s",
+                data.specifier,
+                self_specifier,
+            )
+            return CacheData(self_specifier)
+
+        assert isinstance(data, CacheData)
+        return data
+
+    @property
+    def path(self) -> Path:
+        return self.project_config.root / ".parsercache"
+
+    def persist(
+        self, data: CacheData, path: Optional[Path] = None, optimize: bool = False
+    ) -> None:
+        path = self.path if path is None else path
+        # Specify protocol 5 since it's supported by Python 3.8+, our supported
+        # versions of Python.
+        pickled = pickle.dumps(data, protocol=PROTOCOL)
+        if optimize:
+            pickled = pickletools.optimize(pickled)
+
+        util.atomic_write(path, pickled, path.parent)
+
+    def generate_specifier(self) -> Tuple[str, ...]:
+        return (
+            __version__,
+            util.structural_hash(self.project_config).hex(),
+            util.structural_hash(specparser.Spec.get()).hex(),
+        )

--- a/snooty/parse_cache.py
+++ b/snooty/parse_cache.py
@@ -49,7 +49,7 @@ class CacheData:
             self.pages[(config.get_fileid(path).as_posix(), file_hash)]
         )
         assert isinstance(page, Page)
-        assert all(isinstance(x, diagnostics.Diagnostic) for x in diagnostics)
+        assert all(isinstance(x, Diagnostic) for x in diagnostics)
 
         return page, diagnostics
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1738,7 +1738,8 @@ class _Project:
     def _page_updated(self, page: Page, diagnostics: Sequence[Diagnostic]) -> None:
         """Update any state associated with a parsed page."""
         # Finish any pending tasks
-        page.finish(list(diagnostics), self)
+        diagnostics_copy = list(diagnostics)
+        page.finish(diagnostics_copy, self)
 
         # Synchronize our asset watching
         old_assets: Set[StaticAsset] = set()
@@ -1778,7 +1779,6 @@ class _Project:
         )
 
         # Report to our backend
-        diagnostics_copy = list(diagnostics)
         self.pages[fileid] = (
             page,
             self.config.get_fileid(page.source_path),

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -144,21 +144,27 @@ class ProjectConfig:
     eol: bool = field(default=False)
     source: str = field(default="source")
     banners: List[BannerConfig] = field(default_factory=list)
-    # banner_nodes contains parsed banner nodes with target data
-    banner_nodes: List[ParsedBannerConfig] = field(default_factory=list)
     constants: Dict[str, Union[str, int, float]] = field(default_factory=dict)
     deprecated_versions: Optional[Dict[str, List[str]]] = field(default=None)
     intersphinx: List[str] = field(default_factory=list)
     sharedinclude_root: Optional[str] = field(default=None)
     substitutions: Dict[str, str] = field(default_factory=dict)
-    # substitution_nodes contains a parsed representation of the substitutions member, and is populated on Project initialization.
-    substitution_nodes: Dict[str, List[n.InlineNode]] = field(default_factory=dict)
     toc_landing_pages: List[str] = field(default_factory=list)
     page_groups: Dict[str, List[str]] = field(default_factory=dict)
     manpages: Dict[str, ManPageConfig] = field(default_factory=dict)
     bundle: BundleConfig = field(default_factory=BundleConfig)
     data: Dict[str, object] = field(default_factory=dict)
     associated_products: List[AssociatedProduct] = field(default_factory=list)
+
+    # banner_nodes contains parsed banner nodes with target data
+    banner_nodes: List[ParsedBannerConfig] = field(
+        default_factory=list, metadata={"nohash": True}
+    )
+
+    # substitution_nodes contains a parsed representation of the substitutions member, and is populated on Project initialization.
+    substitution_nodes: Dict[str, List[n.InlineNode]] = field(
+        default_factory=dict, metadata={"nohash": True}
+    )
 
     @property
     def source_path(self) -> Path:

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import collections.abc
+import dataclasses
 import datetime
+import enum
+import hashlib
 import io
 import logging
 import os
@@ -53,6 +57,7 @@ PAT_INVALID_ID_CHARACTERS = re.compile(r"[^\w_\.\-]")
 PAT_URI = re.compile(r"^(?P<schema>[a-z]+)://")
 SOURCE_FILE_EXTENSIONS = {".txt", ".rst", ".yaml"}
 RST_EXTENSIONS = {".txt", ".rst"}
+EMPTY_BLAKE2B = hashlib.blake2b(b"").hexdigest()
 
 PACKAGE_ROOT_STRING = sys.modules["snooty"].__file__
 assert PACKAGE_ROOT_STRING is not None
@@ -418,18 +423,22 @@ class HTTPCache:
         if res.status_code == 304:
             return inventory_path.read_bytes()
 
-        # Atomically (re)write the cache file entry
-        try:
-            tempf = tempfile.NamedTemporaryFile(dir=self.cache_dir)
-            tempf.write(res.content)
-            os.replace(tempf.name, inventory_path)
-        finally:
-            try:
-                tempf.close()
-            except FileNotFoundError:
-                pass
+        atomic_write(inventory_path, res.content, self.cache_dir)
 
         return res.content
+
+
+def atomic_write(path: Path, data: bytes, temp_dir: Path) -> None:
+    """Atomically write a file."""
+    try:
+        tempf = tempfile.NamedTemporaryFile(dir=temp_dir)
+        tempf.write(data)
+        os.replace(tempf.name, path)
+    finally:
+        try:
+            tempf.close()
+        except FileNotFoundError:
+            pass
 
 
 class CancelledException(Exception):
@@ -623,3 +632,43 @@ def lines_contain(haystack: Iterable[str], needle: str) -> Iterator[int]:
     of the line where the match succeeded. Repeat for each line."""
     pat = re.compile(rf"^\W*{re.escape(needle)}\W*$")
     yield from (idx for idx, line in enumerate(haystack) if pat.match(line))
+
+
+def structural_hash(obj: object) -> bytes:
+    """Compute a hash of a nested set of dataclasses and primitive types. We form a kind of simple
+    serialization format in the process -- it's just here to prevent ambiguity. Structural hashes
+    are subject to change and are not stable across releases.
+
+    Fields in dataclasses with ma metadata value of "nohash" are skipped."""
+    hasher = hashlib.blake2b()
+    if isinstance(obj, (int, str, float, PurePath)):
+        hasher.update(bytes("P" + str(obj), "utf-8"))
+    elif dataclasses.is_dataclass(obj):
+        fields = dataclasses.fields(obj)
+        hasher.update(bytes(f"O{len(fields)}\x20", "utf-8"))
+        for field in sorted(fields, key=lambda x: x.name):
+            if not field.metadata.get("nohash"):
+                hasher.update(bytes(f"F{len(field.name)}\x20{field.name}", "utf-8"))
+                hasher.update(structural_hash(getattr(obj, field.name)))
+    elif isinstance(obj, (collections.abc.Sequence, collections.abc.Set)):
+        hasher.update(bytes(f"L{len(obj)}\x20", "utf-8"))
+        for member in obj:
+            child_hash = structural_hash(member)
+            hasher.update(bytes(f"E{len(child_hash)}\x20", "utf-8"))
+            hasher.update(child_hash)
+    elif isinstance(obj, collections.abc.Mapping):
+        hasher.update(bytes(f"M{len(obj)}\x20", "utf-8"))
+        for key, member in obj.items():
+            child_hash = structural_hash(member)
+            hasher.update(
+                bytes(f"E{len(key)}\x20{key}\x20{len(child_hash)}\x20", "utf-8")
+            )
+            hasher.update(child_hash)
+    elif isinstance(obj, enum.Enum):
+        hasher.update(bytes(str(obj), "utf-8"))
+    elif obj is None:
+        hasher.update(b"N")
+    else:
+        raise TypeError("Unhashable type", obj)
+
+    return hasher.digest()

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -639,7 +639,7 @@ def structural_hash(obj: object) -> bytes:
     serialization format in the process -- it's just here to prevent ambiguity. Structural hashes
     are subject to change and are not stable across releases.
 
-    Fields in dataclasses with ma metadata value of "nohash" are skipped."""
+    Fields in dataclasses with metadata value of "nohash" are skipped."""
     hasher = hashlib.blake2b()
     if isinstance(obj, (int, str, float, PurePath)):
         hasher.update(bytes("P" + str(obj), "utf-8"))


### PR DESCRIPTION
# Overview
The ergonomics are open to change, but this PR does two things:
* It adds a new `create-cache` command that builds a parse cache in `<source-root>/.parsercache`
* If a `.parsercache` file is found in the source root, and if the *satisfaction conditions* defined below are met, then the cache is used to skip parsing files where possible. 

# Satisfaction Conditions

1. The cache file must be able to be unpickled into the expected classes without errors
2. The parser version string given in the cache file must match the version string in the running parser
3. The `rstspec.toml` and `pyproject.toml` files must match the cache file. The implementation of this check is a little overkill, and hashes the data rather than the plain text of these files, so comments and formatting can change without invalidating the cache. Like I said: overkill.

# Performance Analysis

There's a significant trade-off in this implementation: if a cache file and its data is optimized with `pickletools.optimize()`, loading time is significantly lower, at the cost of making the cache file creation vastly slower.

What I've opted to do for this PR is to not do the optimization. We may want to revisit this decision, but it's not a massive difference.

All times are plain rst parse times, min of three runs over the server manual on the official metric standard My Laptop:

```
No Cache:       9.47s
Unoptimized:    3.22s
Optimized:      2.76s

Cache Creation (No optimize):   0.88s
Cache Creation (Optimize):      12.33s
```

# Known Deficiencies

Currently source files that contain source constants always end up being a cache miss. This can be dealt with in a followup ticket. On the server manual, we have 2581 hits and 238 misses.

The gains at this point are modest, but the real magic will happen when we add support for caching YAML pages in DOP-3742.

Invalidation right now is very aggressive. With a little work, many kinds of changes could be made to a `snooty.toml` file without requiring invalidation.

There is a soundness issue surrounding literalincludes: changes to a literalinclude will not be picked up. There's two possible solutions to this pickle: the better solution is to have a proper dependency graph.