### PR TITLE
Add page dependencies

### DIFF
--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -496,7 +496,7 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
 
         item = check_type(TextDocumentItem, textDocument)
         fileid = self.uri_to_fileid(item.uri)
-        page_path = self.project.get_full_path(fileid)
+        page_path = self.project.config.get_full_path(fileid)
         entry = WorkspaceEntry(fileid, item.uri, [])
         self.workspace[item.uri] = entry
         self.update_file(page_path, item.text)
@@ -509,7 +509,9 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             return
 
         identifier = check_type(VersionedTextDocumentIdentifier, textDocument)
-        page_path = self.project.get_full_path(self.uri_to_fileid(identifier.uri))
+        page_path = self.project.config.get_full_path(
+            self.uri_to_fileid(identifier.uri)
+        )
         assert isinstance(contentChanges, list)
         change = next(
             check_type(TextDocumentContentChangeEvent, x) for x in contentChanges
@@ -528,7 +530,9 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             return
 
         identifier = check_type(TextDocumentIdentifier, textDocument)
-        page_path = self.project.get_full_path(self.uri_to_fileid(identifier.uri))
+        page_path = self.project.config.get_full_path(
+            self.uri_to_fileid(identifier.uri)
+        )
         del self.workspace[identifier.uri]
         self.update_file(page_path)
 

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -1,7 +1,7 @@
 import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from . import n
 from .diagnostics import Diagnostic
@@ -32,6 +32,7 @@ class Page:
     source: str
     ast: n.Root
     blake2b: str
+    dependencies: Dict[FileId, Optional[str]] = field(default_factory=dict)
     static_assets: Set[StaticAsset] = field(default_factory=set)
     pending_tasks: List[PendingTask] = field(default_factory=list)
     facets: Optional[SerializedNode] = field(default=None)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -736,6 +736,12 @@ hello world4</code></directive>
     )
     page.finish(diagnostics)
     assert diagnostics == []
+    assert page.dependencies == {
+        FileId(
+            "test_parser/includes/sample_code.py"
+        ): "f6a999ef69965870804279b80ec4e4f2d38c617175435ac68e5558dcf1dc5be3e15cf31217b0c62024eeef2f5ef94c7b575c84b5624abba6d3b4ae5fdbfa30e6"
+    }
+
     check_ast_testing_string(
         page.ast,
         """

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -237,6 +237,9 @@ class ProjectConfig:
 
         return (text, diagnostics)
 
+    def get_full_path(self, fileid: FileId) -> Path:
+        return self.source_path.joinpath(fileid)
+
     @staticmethod
     def _substitute(
         source: str, constants: Dict[str, Union[str, int, float]]


### PR DESCRIPTION
Allows a Page to depend on multiple other paths for the purposes of caching, so that if a `literalinclude` target changes, the page's parsed cache is invalidated.