### PR TITLE
:sparkles: DOP-3865 adds canonical control from the .toml file

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1323,12 +1323,14 @@ class SubstitutionHandler(Handler):
                 current_paragraph.append(element)
             else:
                 if current_paragraph:
-                    output.append(n.Paragraph(node.span, current_paragraph))  # type: ignore
+                    # type: ignore
+                    output.append(n.Paragraph(node.span, current_paragraph))
                     current_paragraph = []
                 output.append(element)
 
         if current_paragraph:
-            output.append(n.Paragraph(node.span, current_paragraph))  # type: ignore
+            # type: ignore
+            output.append(n.Paragraph(node.span, current_paragraph))
 
         return output
 
@@ -1670,6 +1672,9 @@ class Postprocessor:
         document: Dict[str, SerializableType] = {}
         document["title"] = project_config.title
         document["eol"] = project_config.eol if project_config.eol else False
+        document["canonical"] = (
+            project_config.canonical if project_config.canonical else None
+        )
         if project_config.deprecated_versions:
             document["deprecated_versions"] = project_config.deprecated_versions
         if project_config.associated_products:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1323,14 +1323,12 @@ class SubstitutionHandler(Handler):
                 current_paragraph.append(element)
             else:
                 if current_paragraph:
-                    # type: ignore
-                    output.append(n.Paragraph(node.span, current_paragraph))
+                    output.append(n.Paragraph(node.span, current_paragraph))  # type: ignore
                     current_paragraph = []
                 output.append(element)
 
         if current_paragraph:
-            # type: ignore
-            output.append(n.Paragraph(node.span, current_paragraph))
+            output.append(n.Paragraph(node.span, current_paragraph))  # type: ignore
 
         return output
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2509,6 +2509,31 @@ def test_target_quotes() -> None:
         )
 
 
+def test_canonical() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+======
+Test
+======
+
+This is a test intro
+            """,
+            Path(
+                "snooty.toml"
+            ): """
+name = "test_name"
+title = "MongoDB title"
+canonical = "https://mongodb.com/docs/mongocli/install"
+            """,
+        }
+    ) as result:
+        metadata = cast(Dict[str, Any], result.metadata)
+        assert metadata["canonical"] == "https://mongodb.com/docs/mongocli/install"
+
+
 def test_metadata() -> None:
     with make_test(
         {

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -29,6 +29,7 @@ def test_project() -> None:
     assert project_config.deprecated_versions == None
     assert project_config.associated_products == []
     assert len(project_diagnostics) == 0
+    assert project_config.canonical == None
 
     # Test valid project
     path = Path("test_data/test_project")
@@ -40,6 +41,7 @@ def test_project() -> None:
     assert project_config.associated_products[1].name == "test-name2"
     assert project_config.associated_products[1].versions == None
     assert project_config.name == "test_data"
+    assert project_config.canonical == "https://mongodb.com/docs/mongocli/install"
 
 
 def test_static_asset() -> None:

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -142,6 +142,7 @@ class ProjectConfig:
     default_domain: Optional[str] = field(default=None)
     title: str = field(default="untitled")
     eol: bool = field(default=False)
+    canonical: Optional[str] = field(default=None)
     source: str = field(default="source")
     banners: List[BannerConfig] = field(default_factory=list)
     # banner_nodes contains parsed banner nodes with target data

--- a/test_data/test_project/snooty.toml
+++ b/test_data/test_project/snooty.toml
@@ -1,5 +1,6 @@
 name = "test_data"
 title = "MongoDB title"
+canonical = "https://mongodb.com/docs/mongocli/install"
 
 [substitutions]
 guides = "MongoDB Guides"


### PR DESCRIPTION
This adds the `canonical` tag to the `snooty.toml` file for pages that are completely EOL'd. 

In those edge cases, we are not able to programmatically determine the canonical tag or point to their current version as there is none. To solve this we give the writer the ability to provide us the desired location. 

The logic is then handled in Snooty, as it grabs the canonical URL and applies it to the canonical tag. 

More info can be found [here](https://github.com/mongodb/snooty/pull/857).