### PR TITLE
DOP-3875

### DIFF
--- a/snooty/taxonomy.py
+++ b/snooty/taxonomy.py
@@ -11,13 +11,16 @@ from .flutter import check_type, checked
 @dataclass
 class FacetDefinition:
     name: str
+    display_name: Optional[str]
 
 
 @checked
 @dataclass
 class TargetPlatformDefinition:
     name: str
-    versions: List[FacetDefinition]
+    display_name: Optional[str]
+    sub_platforms: Optional[List[FacetDefinition]]
+    versions: Optional[List[FacetDefinition]]
 
 
 @checked
@@ -26,6 +29,7 @@ class TaxonomySpec:
 
     genres: List[FacetDefinition]
     target_platforms: List[TargetPlatformDefinition]
+    programming_languages: List[FacetDefinition]
 
     TAXONOMY_SPEC: ClassVar[Optional["TaxonomySpec"]] = None
 

--- a/snooty/taxonomy.toml
+++ b/snooty/taxonomy.toml
@@ -181,6 +181,7 @@ name = "kotlin"
 
 [[programming_languages]]
 name = "php"
+display_name = "PHP"
 
 [[programming_languages]]
 name = "python"

--- a/snooty/taxonomy.toml
+++ b/snooty/taxonomy.toml
@@ -56,6 +56,7 @@ display_name = "BI Connector"
 
 [[target_platforms]]
 name = "com"
+display_name = "Cloud Manager"
 
 [[target_platforms]]
 name = "c2c"
@@ -88,10 +89,6 @@ name = "mongocli"
 display_name = "MongoDB CLI"
 
 [[target_platforms]]
-name = "mongocli"
-display_name = "MongoDB CLI"
-
-[[target_platforms]]
 name = "visual-studio-extension"
 display_name = "MongoDB for VS Code"
 
@@ -112,7 +109,7 @@ name = "realm"
 
   # nestled under docs-realm 
   [[target_platforms.sub_platforms]]
-  name = "fluter"
+  name = "flutter"
   display_name = "Dart Flutter SDK"
 
   [[target_platforms.sub_platforms]]

--- a/snooty/taxonomy.toml
+++ b/snooty/taxonomy.toml
@@ -4,55 +4,221 @@ name = "reference"
 [[genres]]
 name = "tutorial"
 
+# trying to map to docs "name" property 
+# for target_platforms and sub_platforms
+# as much as possible
 [[target_platforms]]
 name = "atlas"
-[[target_platforms.versions]]
-name = "v1.2"
-[[target_platforms.versions]]
-name = "master"
+
+  [[target_platforms.sub_platforms]]
+  name = "atlas-app-services"
+  display_name = "App Services"
+
+  [[target_platforms.sub_platforms]]
+  name = "charts"
+  display_name = "Charts"
+
+  [[target_platforms.sub_platforms]]
+  name = "atlas-cli"
+  display_name = "Atlas CLI"
+
+  [[target_platforms.sub_platforms]]
+  name = "data-api"
+  display_name = "Data API"
+
+  [[target_platforms.sub_platforms]]
+  name = "data-federation"
+
+  [[target_platforms.sub_platforms]]
+  name = "data-lake"
+
+  [[target_platforms.sub_platforms]]
+  name = "device-sync" #404
+
+  [[target_platforms.sub_platforms]]
+  name = "kubernetes-operator"
+
+  [[target_platforms.sub_platforms]]
+  name = "online-archive"
+
+  [[target_platforms.sub_platforms]]
+  name = "search"
+
+  [[target_platforms.sub_platforms]]
+  name = "stream-processing"
+
+  [[target_platforms.sub_platforms]]
+  name = "triggers"
 
 [[target_platforms]]
-name = "atlas-cli"
-[[target_platforms.versions]]
-name = "v1.2"
-[[target_platforms.versions]]
-name = "master"
+name = "bi-connector"
+display_name = "BI Connector"
 
 [[target_platforms]]
-name = "manual"
-[[target_platforms.versions]]
-name = "v1.0"
-[[target_platforms.versions]]
-name = "master"
+name = "com"
 
 [[target_platforms]]
-name = "spark-connector"
-[[target_platforms.versions]]
-name = "v2.0"
-[[target_platforms.versions]]
-name = "v2.1"
+name = "c2c"
+display_name = "Cluster-to-Cluster Sync"
 
 [[target_platforms]]
-name = "node"
-[[target_platforms.versions]]
-name = "v4.9"
+name = "community-kubernetes-operator"  # 404
+
+[[target_platforms]]
+name = "compass"
+
+[[target_platforms]]
+name = "database-tools"
+
+[[target_platforms]]
+name = "drivers"
+
+[[target_platforms]]
+name = "enterprise-kubernetes-operator"
+
+[[target_platforms]]
+name = "kafka-connector"
+
+[[target_platforms]]
+name = "mongodb-analyzer" # 404
+display_name = "MongoDB Analyzer"
 
 [[target_platforms]]
 name = "mongocli"
-[[target_platforms.versions]]
-name = "v1.0"
+display_name = "MongoDB CLI"
+
+[[target_platforms]]
+name = "mongocli"
+display_name = "MongoDB CLI"
 
 [[target_platforms]]
 name = "visual-studio-extension"
-[[target_platforms.versions]]
-name = "current"
+display_name = "MongoDB for VS Code"
 
 [[target_platforms]]
-name = "golang"
-[[target_platforms.versions]]
-name = "v1.7"
+name = "mongodb-shell"
+display_name = "MongoDB Shell"
 
 [[target_platforms]]
+name = "onprem" # verify
+display_name = "Ops Manager"
+
+[[target_platforms]]
+name = "realm"
+
+  [[target_platforms.sub_platforms]]
+  name = "cpp"
+  display_name = "C++ SDK"
+
+  # nestled under docs-realm 
+  [[target_platforms.sub_platforms]]
+  name = "fluter"
+  display_name = "Dart Flutter SDK"
+
+  [[target_platforms.sub_platforms]]
+  name = "java"
+  display_name = "Java SDK"
+
+  [[target_platforms.sub_platforms]]
+  name = "kotlin"
+  display_name = "Kotlin SDK"
+
+  [[target_platforms.sub_platforms]]
+  name = "dotnet"
+  display_name = ".NET SDK"
+
+  [[target_platforms.sub_platforms]]
+  name = "react-native"
+  display_name = "React Native SDK"
+
+  [[target_platforms.sub_platforms]]
+  name = "swift"
+  display_name = "Swift SDK"
+
+  [[target_platforms.sub_platforms]]
+  name = "node"
+  display_name = "Node.js SDK"
+
+  [[target_platforms.sub_platforms]]
+  name = "web"
+  display_name = "Web SDK"
+
+[[target_platforms]]
+name = "docs-relational-migrator"
+display_name = "Relational Migrator"
+
+[[target_platforms]]
+name = "docs"  # verify
+display_name = "Server"
+
+[[target_platforms]]
+name = "spark-connector"  # verify
+
+# validated against existing search documents
+[[programming_languages]]
+name = "objective-c"
+display_name = "Objective C"
+
+[[programming_languages]]
+name = "c"
+
+[[programming_languages]]
+name = "csharp"
+display_name = "C#"
+
+[[programming_languages]]
+name = "cpp"
+display_name = "C++"
+
+[[programming_languages]]
+name = "dart"
+
+[[programming_languages]]
+name = "go"
+
+[[programming_languages]]
 name = "java"
-[[target_platforms.versions]]
-name = "v4.3"
+
+[[programming_languages]]
+name = "kotlin"
+
+[[programming_languages]]
+name = "php"
+
+[[programming_languages]]
+name = "python"
+
+[[programming_languages]]
+name = "ruby"
+
+[[programming_languages]]
+name = "rust"
+
+[[programming_languages]]
+name = "scala"
+
+[[programming_languages]]
+name = "swift"
+
+[[programming_languages]]
+name = "javascript/typescript"  # validate
+display_name = "JavaScript/TypeScript"
+
+[[programming_languages]]
+name = "shell"
+
+[[programming_languages]]
+name = "json"
+display_name = "JSON"
+
+[[programming_languages]]
+name = "realmql"
+display_name = "RealmQL"
+
+[[programming_languages]]
+name = "graphql"
+display_name = "GraphQL"
+
+[[programming_languages]]
+name = "mql"
+display_name = "MQL"

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3649,10 +3649,15 @@ def test_invalid_facets() -> None:
         :name: version
         :values: dne
 
+.. facet::
+    :name: target_platforms
+    :values: atlas, dne
+
 """,
     )
     page.finish(diagnostics)
     print(diagnostics)
-    assert len(diagnostics) == 2
+    assert len(diagnostics) == 3
     assert isinstance(diagnostics[0], MissingFacet)
     assert isinstance(diagnostics[1], MissingFacet)
+    assert isinstance(diagnostics[2], MissingFacet)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2764,7 +2764,13 @@ Facets
         assert facets is not None
         assert facets == {
             "genres": [{"name": "reference"}, {"name": "tutorial"}],
-            "target_platforms": [{"name": "atlas", "versions": [{"name": "v1.2"}], "sub_platforms": [{"name": "charts"}]}],
+            "target_platforms": [
+                {
+                    "name": "atlas",
+                    "versions": [{"name": "v1.2"}],
+                    "sub_platforms": [{"name": "charts"}],
+                }
+            ],
         }
         check_ast_testing_string(
             page.ast,

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2748,6 +2748,11 @@ def test_facets() -> None:
       :name: versions
       :values: v1.2
 
+   .. facet::
+      :name: sub_platforms
+      :values: charts
+
+
 ===========================
 Facets
 ===========================
@@ -2759,7 +2764,7 @@ Facets
         assert facets is not None
         assert facets == {
             "genres": [{"name": "reference"}, {"name": "tutorial"}],
-            "target_platforms": [{"name": "atlas", "versions": [{"name": "v1.2"}]}],
+            "target_platforms": [{"name": "atlas", "versions": [{"name": "v1.2"}], "sub_platforms": [{"name": "charts"}]}],
         }
         check_ast_testing_string(
             page.ast,


### PR DESCRIPTION
[JIRA Issue](https://jira.mongodb.org/browse/DOP-3875)

Goal: Convert the [taxonomy doc](https://docs.google.com/document/d/1niV98yR0ZL9Hrdzj2NT7ili4VgAOvpO8kgacLi280-E/edit) to a toml configuration for validation. Each `genre`,  `targetProduct`, and `programmingLanguge` should be represented in taxonomy.toml. **PTAL** at comments in the toml file for names that may have been murky.

Notes:
- "versions" will be handled in a programmatic manner between mut indexing (generate manfest) and search transport server (save documents) to ensure consistency between search documents and `repos_branches` collection
- `programming_languages` have been verified against `search-staging.documents` ( see `unique_code_langs` view under `search-staging` collection)
- Design mockups for front end show different "category names" ie. `target_platforms` becomes `product`. This should be a quick change all references when it is finalized