### PR TITLE
Add new Realm SDK roles

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1374,6 +1374,12 @@ type = {link = "https://github.com/mongodb/specifications/blob/master/source%s"}
 [role."js-sdk"]
 type = {link = "https://www.mongodb.com/docs/realm-sdks/js/latest/%s"}
 
+[role."realm-react-sdk"]
+type = {link = "https://www.mongodb.com/docs/realm-sdks/js/realm-react/latest/%s"}
+
+[role."js-web-sdk"]
+type = {link = "https://www.mongodb.com/docs/realm-sdks/js/realm-web/latest/%s"}
+
 [role."facebook"]
 type = {link = "https://developers.facebook.com/%s"}
 


### PR DESCRIPTION
The `@realm/react` package and JS Web SDK both have new standalone reference docs. This PR adds roles for those references docs to make linking to them easier in the Realm docs.