### PR TITLE
DOP-3924: Cache assets including source constant substitutions

### DIFF
--- a/snooty/parse_cache.py
+++ b/snooty/parse_cache.py
@@ -47,7 +47,8 @@ class CacheData:
         """Get a specific page from the cached data with the specified blake2b hash. Raises KeyError
         if the page is not found or the checksum does not match."""
 
-        file_hash = hashlib.blake2b(path.read_bytes()).hexdigest()
+        text, _ = config.read(path)
+        file_hash = hashlib.blake2b(bytes(text, "utf-8")).hexdigest()
 
         try:
             page, diagnostics = pickle.loads(


### PR DESCRIPTION
With this change, with a no-op build of the server manual, we go from 285 misses to 0 misses, and the single-process `parse rst` time goes from 6.50s to 2.43s (as usual, minimum of three runs on the reference metric unit My Laptop).

![image](https://github.com/mongodb/snooty-parser/assets/334192/242a4abe-8756-4f73-8e48-c27a7d5e9c36)
