### PR TITLE
DOP-3932: convert target platforms to target products

### DIFF
--- a/snooty/taxonomy.py
+++ b/snooty/taxonomy.py
@@ -16,10 +16,10 @@ class FacetDefinition:
 
 @checked
 @dataclass
-class TargetPlatformDefinition:
+class TargetProductDefinition:
     name: str
     display_name: Optional[str]
-    sub_platforms: Optional[List[FacetDefinition]]
+    sub_products: Optional[List[FacetDefinition]]
     versions: Optional[List[FacetDefinition]]
 
 
@@ -28,7 +28,7 @@ class TargetPlatformDefinition:
 class TaxonomySpec:
 
     genres: List[FacetDefinition]
-    target_platforms: List[TargetPlatformDefinition]
+    target_products: List[TargetProductDefinition]
     programming_languages: List[FacetDefinition]
 
     TAXONOMY_SPEC: ClassVar[Optional["TaxonomySpec"]] = None

--- a/snooty/taxonomy.toml
+++ b/snooty/taxonomy.toml
@@ -5,150 +5,150 @@ name = "reference"
 name = "tutorial"
 
 # trying to map to docs "name" property 
-# for target_platforms and sub_platforms
+# for target_products and sub_products
 # as much as possible
-[[target_platforms]]
+[[target_products]]
 name = "atlas"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "atlas-app-services"
   display_name = "App Services"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "charts"
   display_name = "Charts"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "atlas-cli"
   display_name = "Atlas CLI"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "data-api"
   display_name = "Data API"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "data-federation"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "data-lake"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "device-sync" #404
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "kubernetes-operator"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "online-archive"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "search"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "stream-processing"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "triggers"
 
-[[target_platforms]]
+[[target_products]]
 name = "bi-connector"
 display_name = "BI Connector"
 
-[[target_platforms]]
+[[target_products]]
 name = "com"
 display_name = "Cloud Manager"
 
-[[target_platforms]]
+[[target_products]]
 name = "c2c"
 display_name = "Cluster-to-Cluster Sync"
 
-[[target_platforms]]
+[[target_products]]
 name = "community-kubernetes-operator"  # 404
 
-[[target_platforms]]
+[[target_products]]
 name = "compass"
 
-[[target_platforms]]
+[[target_products]]
 name = "database-tools"
 
-[[target_platforms]]
+[[target_products]]
 name = "drivers"
 
-[[target_platforms]]
+[[target_products]]
 name = "enterprise-kubernetes-operator"
 
-[[target_platforms]]
+[[target_products]]
 name = "kafka-connector"
 
-[[target_platforms]]
+[[target_products]]
 name = "mongodb-analyzer" # 404
 display_name = "MongoDB Analyzer"
 
-[[target_platforms]]
+[[target_products]]
 name = "mongocli"
 display_name = "MongoDB CLI"
 
-[[target_platforms]]
+[[target_products]]
 name = "visual-studio-extension"
 display_name = "MongoDB for VS Code"
 
-[[target_platforms]]
+[[target_products]]
 name = "mongodb-shell"
 display_name = "MongoDB Shell"
 
-[[target_platforms]]
+[[target_products]]
 name = "onprem" # verify
 display_name = "Ops Manager"
 
-[[target_platforms]]
+[[target_products]]
 name = "realm"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "cpp"
   display_name = "C++ SDK"
 
   # nestled under docs-realm 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "flutter"
   display_name = "Dart Flutter SDK"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "java"
   display_name = "Java SDK"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "kotlin"
   display_name = "Kotlin SDK"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "dotnet"
   display_name = ".NET SDK"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "react-native"
   display_name = "React Native SDK"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "swift"
   display_name = "Swift SDK"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "node"
   display_name = "Node.js SDK"
 
-  [[target_platforms.sub_platforms]]
+  [[target_products.sub_products]]
   name = "web"
   display_name = "Web SDK"
 
-[[target_platforms]]
+[[target_products]]
 name = "docs-relational-migrator"
 display_name = "Relational Migrator"
 
-[[target_platforms]]
+[[target_products]]
 name = "docs"  # verify
 display_name = "Server"
 
-[[target_platforms]]
+[[target_products]]
 name = "spark-connector"  # verify
 
 # validated against existing search documents

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3650,7 +3650,7 @@ def test_invalid_facets() -> None:
         :values: dne
 
 .. facet::
-    :name: target_platforms
+    :name: target_products
     :values: atlas, dne
 
 """,

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2741,7 +2741,7 @@ def test_facets() -> None:
    :values: tutorial
 
 .. facet::
-   :name: target_platforms
+   :name: target_products
    :values: atlas
 
    .. facet::
@@ -2749,7 +2749,7 @@ def test_facets() -> None:
       :values: v1.2
 
    .. facet::
-      :name: sub_platforms
+      :name: sub_products
       :values: charts
 
 
@@ -2764,11 +2764,11 @@ Facets
         assert facets is not None
         assert facets == {
             "genres": [{"name": "reference"}, {"name": "tutorial"}],
-            "target_platforms": [
+            "target_products": [
                 {
                     "name": "atlas",
                     "versions": [{"name": "v1.2"}],
-                    "sub_platforms": [{"name": "charts"}],
+                    "sub_products": [{"name": "charts"}],
                 }
             ],
         }


### PR DESCRIPTION
[DOP-3932](https://jira.mongodb.org/browse/DOP-3932)

We should convert these in the parser, so that the facets.toml seed files that are generated as part of [DOP-3851](https://jira.mongodb.org/browse/DOP-3851) do not emit warnings for invalid fields. See issue description for schema definitions for reason for change

[Schema definition for targetPlatform](https://schema.org/targetPlatform)

[Schema definition for targetProduct](https://schema.org/targetProduct)