### PR TITLE
DOP-3932 follow up: un pluralize taxonomy

### DIFF
--- a/snooty/taxonomy.py
+++ b/snooty/taxonomy.py
@@ -19,16 +19,16 @@ class FacetDefinition:
 class TargetProductDefinition:
     name: str
     display_name: Optional[str]
-    sub_products: Optional[List[FacetDefinition]]
-    versions: Optional[List[FacetDefinition]]
+    sub_product: Optional[List[FacetDefinition]]
+    version: Optional[List[FacetDefinition]]
 
 
 @checked
 @dataclass
 class TaxonomySpec:
-    genres: List[FacetDefinition]
-    target_products: List[TargetProductDefinition]
-    programming_languages: List[FacetDefinition]
+    genre: List[FacetDefinition]
+    target_product: List[TargetProductDefinition]
+    programming_language: List[FacetDefinition]
 
     TAXONOMY_SPEC: ClassVar[Optional["TaxonomySpec"]] = None
 

--- a/snooty/taxonomy.toml
+++ b/snooty/taxonomy.toml
@@ -1,222 +1,222 @@
-[[genres]]
+[[genre]]
 name = "reference"
 
-[[genres]]
+[[genre]]
 name = "tutorial"
 
 # trying to map to docs "name" property 
-# for target_products and sub_products
+# for target_product and sub_product
 # as much as possible
-[[target_products]]
+[[target_product]]
 name = "atlas"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "atlas-app-services"
   display_name = "App Services"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "charts"
   display_name = "Charts"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "atlas-cli"
   display_name = "Atlas CLI"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "data-api"
   display_name = "Data API"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "data-federation"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "data-lake"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "device-sync" #404
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "kubernetes-operator"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "online-archive"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "search"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "stream-processing"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "triggers"
 
-[[target_products]]
+[[target_product]]
 name = "bi-connector"
 display_name = "BI Connector"
 
-[[target_products]]
+[[target_product]]
 name = "com"
 display_name = "Cloud Manager"
 
-[[target_products]]
+[[target_product]]
 name = "c2c"
 display_name = "Cluster-to-Cluster Sync"
 
-[[target_products]]
+[[target_product]]
 name = "community-kubernetes-operator"  # 404
 
-[[target_products]]
+[[target_product]]
 name = "compass"
 
-[[target_products]]
+[[target_product]]
 name = "database-tools"
 
-[[target_products]]
+[[target_product]]
 name = "drivers"
 
-[[target_products]]
+[[target_product]]
 name = "enterprise-kubernetes-operator"
 
-[[target_products]]
+[[target_product]]
 name = "kafka-connector"
 
-[[target_products]]
+[[target_product]]
 name = "mongodb-analyzer" # 404
 display_name = "MongoDB Analyzer"
 
-[[target_products]]
+[[target_product]]
 name = "mongocli"
 display_name = "MongoDB CLI"
 
-[[target_products]]
+[[target_product]]
 name = "visual-studio-extension"
 display_name = "MongoDB for VS Code"
 
-[[target_products]]
+[[target_product]]
 name = "mongodb-shell"
 display_name = "MongoDB Shell"
 
-[[target_products]]
+[[target_product]]
 name = "onprem" # verify
 display_name = "Ops Manager"
 
-[[target_products]]
+[[target_product]]
 name = "realm"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "cpp"
   display_name = "C++ SDK"
 
   # nestled under docs-realm 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "flutter"
   display_name = "Dart Flutter SDK"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "java"
   display_name = "Java SDK"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "kotlin"
   display_name = "Kotlin SDK"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "dotnet"
   display_name = ".NET SDK"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "react-native"
   display_name = "React Native SDK"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "swift"
   display_name = "Swift SDK"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "node"
   display_name = "Node.js SDK"
 
-  [[target_products.sub_products]]
+  [[target_product.sub_product]]
   name = "web"
   display_name = "Web SDK"
 
-[[target_products]]
+[[target_product]]
 name = "docs-relational-migrator"
 display_name = "Relational Migrator"
 
-[[target_products]]
+[[target_product]]
 name = "docs"  # verify
 display_name = "Server"
 
-[[target_products]]
+[[target_product]]
 name = "spark-connector"  # verify
 
 # validated against existing search documents
-[[programming_languages]]
+[[programming_language]]
 name = "objective-c"
 display_name = "Objective C"
 
-[[programming_languages]]
+[[programming_language]]
 name = "c"
 
-[[programming_languages]]
+[[programming_language]]
 name = "csharp"
 display_name = "C#"
 
-[[programming_languages]]
+[[programming_language]]
 name = "cpp"
 display_name = "C++"
 
-[[programming_languages]]
+[[programming_language]]
 name = "dart"
 
-[[programming_languages]]
+[[programming_language]]
 name = "go"
 
-[[programming_languages]]
+[[programming_language]]
 name = "java"
 
-[[programming_languages]]
+[[programming_language]]
 name = "kotlin"
 
-[[programming_languages]]
+[[programming_language]]
 name = "php"
 display_name = "PHP"
 
-[[programming_languages]]
+[[programming_language]]
 name = "python"
 
-[[programming_languages]]
+[[programming_language]]
 name = "ruby"
 
-[[programming_languages]]
+[[programming_language]]
 name = "rust"
 
-[[programming_languages]]
+[[programming_language]]
 name = "scala"
 
-[[programming_languages]]
+[[programming_language]]
 name = "swift"
 
-[[programming_languages]]
+[[programming_language]]
 name = "javascript/typescript"  # validate
 display_name = "JavaScript/TypeScript"
 
-[[programming_languages]]
+[[programming_language]]
 name = "shell"
 
-[[programming_languages]]
+[[programming_language]]
 name = "json"
 display_name = "JSON"
 
-[[programming_languages]]
+[[programming_language]]
 name = "realmql"
 display_name = "RealmQL"
 
-[[programming_languages]]
+[[programming_language]]
 name = "graphql"
 display_name = "GraphQL"
 
-[[programming_languages]]
+[[programming_language]]
 name = "mql"
 display_name = "MQL"

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3642,7 +3642,7 @@ def test_invalid_facets() -> None:
     :values: dne
 
 .. facet::
-    :name: genres
+    :name: genre
     :values: reference
 
     .. facet::
@@ -3650,7 +3650,7 @@ def test_invalid_facets() -> None:
         :values: dne
 
 .. facet::
-    :name: target_products
+    :name: target_product
     :values: atlas, dne
 
 """,

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2732,23 +2732,23 @@ def test_facets() -> None:
                 "source/index.txt"
             ): """
 .. facet::
-   :name: genres
+   :name: genre
    :values: reference
 
 .. facet::
-   :name: genres
+   :name: genre
    :values: tutorial
 
 .. facet::
-   :name: target_products
+   :name: target_product
    :values: atlas
 
    .. facet::
-      :name: versions
+      :name: version
       :values: v1.2
 
    .. facet::
-      :name: sub_products
+      :name: sub_product
       :values: charts
 
 
@@ -2763,14 +2763,14 @@ Facets
         assert facets is not None
         assert sorted(facets) == sorted(
             [
-                Facet(category="genres", value="reference"),
-                Facet(category="genres", value="tutorial"),
+                Facet(category="genre", value="reference"),
+                Facet(category="genre", value="tutorial"),
                 Facet(
-                    category="target_products",
+                    category="target_product",
                     value="atlas",
                     sub_facets=[
-                        Facet(category="versions", value="v1.2"),
-                        Facet(category="sub_products", value="charts"),
+                        Facet(category="version", value="v1.2"),
+                        Facet(category="sub_product", value="charts"),
                     ],
                 ),
             ]
@@ -2795,20 +2795,20 @@ def test_toml_facets() -> None:
                 "source/index.txt"
             ): """
 .. facet::
-   :name: genres
+   :name: genre
    :values: reference
 .. facet::
-   :name: target_products
+   :name: target_product
    :values: atlas
 
    .. facet::
-      :name: versions
+      :name: version
       :values: v1.2
    .. facet::
-      :name: sub_products
+      :name: sub_product
       :values: charts
 .. facet::
-   :name: genres
+   :name: genre
    :values: tutorial
 
 ===========================
@@ -2819,15 +2819,15 @@ Facets
                 "source/facets.toml"
             ): """
 [[facets]]
-category="target_products"
+category="target_product"
 value = "drivers"
 
     [[facets.sub_facets]]
-    category="sub_products"
+    category="sub_product"
     value = "c_driver"
 
 [[facets]]
-category = "programming_languages"  # validate
+category = "programming_language"  # validate
 value = "shell"
 
 [[facets]]
@@ -2846,17 +2846,17 @@ value = "test"
         assert facets is not None
         assert sorted(facets) == sorted(
             [
-                Facet(category="genres", value="reference"),
-                Facet(category="genres", value="tutorial"),
+                Facet(category="genre", value="reference"),
+                Facet(category="genre", value="tutorial"),
                 Facet(
-                    category="target_products",
+                    category="target_product",
                     value="atlas",
                     sub_facets=[
-                        Facet(category="versions", value="v1.2"),
-                        Facet(category="sub_products", value="charts"),
+                        Facet(category="version", value="v1.2"),
+                        Facet(category="sub_product", value="charts"),
                     ],
                 ),
-                Facet(category="programming_languages", value="shell"),
+                Facet(category="programming_language", value="shell"),
             ]
         )
 

--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -133,7 +133,7 @@ def test_facet_propagation() -> None:
     assert index.facets is not None
     assert index.facets[0].sub_facets is not None
 
-    assert index.facets[0].sub_facets[0].category == "sub_products"
+    assert index.facets[0].sub_facets[0].category == "sub_product"
     assert index.facets[0].sub_facets[0].value == "atlas-app-services"
 
     driver_id = FileId("driver-examples/driver.rst")
@@ -142,7 +142,7 @@ def test_facet_propagation() -> None:
     assert driver.facets is not None
     assert driver.facets[0].sub_facets is not None
 
-    assert driver.facets[0].sub_facets[0].category == "sub_products"
+    assert driver.facets[0].sub_facets[0].category == "sub_product"
     assert driver.facets[0].sub_facets[0].value == "charts"
 
     nest_id = FileId("driver-examples/nest/nest.txt")
@@ -151,7 +151,7 @@ def test_facet_propagation() -> None:
     assert nest.facets is not None
     assert nest.facets[0].sub_facets is not None
 
-    assert nest.facets[0].sub_facets[0].category == "sub_products"
+    assert nest.facets[0].sub_facets[0].category == "sub_product"
     assert nest.facets[0].sub_facets[0].value == "atlas-cli"
 
 

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -354,10 +354,10 @@ class ProjectConfig:
         exist in the child, they will be included in the merged result
 
         e.g.
-            parent_facets = [{ category: "target_products", value: "drivers" }, { category: "programming_languages", value: "scala" }]
-            child_facets = [{ category: "target_products", value: "atlas" }]
+            parent_facets = [{ category: "target_product", value: "drivers" }, { category: "programming_language", value: "scala" }]
+            child_facets = [{ category: "target_product", value: "atlas" }]
 
-            merged_facets = [{ category: "target_products", value: "atlas" }, { category: "programming_languages", value: "scala" }]
+            merged_facets = [{ category: "target_product", value: "atlas" }, { category: "programming_language", value: "scala" }]
         """
         merged_facets: List[Facet] = child_facets
 

--- a/test_data/test_facets/source/driver-examples/facets.toml
+++ b/test_data/test_facets/source/driver-examples/facets.toml
@@ -1,7 +1,7 @@
 [[facets]]
-category="target_products"
+category="target_product"
 value = "atlas"
 
   [[facets.sub_facets]]
-  category="sub_products"
+  category="sub_product"
   value = "charts"

--- a/test_data/test_facets/source/driver-examples/nest/facets.toml
+++ b/test_data/test_facets/source/driver-examples/nest/facets.toml
@@ -1,7 +1,7 @@
 [[facets]]
-category = "target_products"
+category = "target_product"
 value = "atlas"
 
   [[facets.sub_facets]]
-  category="sub_products"
+  category="sub_product"
   value = "atlas-cli"

--- a/test_data/test_facets/source/facets.toml
+++ b/test_data/test_facets/source/facets.toml
@@ -1,8 +1,8 @@
 [[facets]]
-category="target_products"
+category="target_product"
 value = "atlas"
   [[facets.sub_facets]]
-  category="sub_products"
+  category="sub_product"
   value = "atlas-app-services"
 
 [[facets]]


### PR DESCRIPTION
Based on [this comment](https://github.com/10gen/cloud-docs/pull/4768#issuecomment-1677379619) on cloud docs, we should not be pluralizing the taxonomy and facets.

This is necessary in order for the output of [facet generating scripts](https://github.com/10gen/snooty-scripts/tree/main/DOP-3851) to not throw an error, when run by the parser

This will require the parser to have been already released, before the script is run and merged into respective doc sites