### PR TITLE
DOP-3851: add perl programming language

### DIFF
--- a/snooty/taxonomy.toml
+++ b/snooty/taxonomy.toml
@@ -180,6 +180,9 @@ name = "java"
 name = "kotlin"
 
 [[programming_language]]
+name = "perl"
+
+[[programming_language]]
 name = "php"
 display_name = "PHP"
 


### PR DESCRIPTION
Minor comment in spreadsheet [here](https://docs.google.com/spreadsheets/d/1HvVo3REeyAUrOgicLsMMRVOQLmpNjFCbHxF4sNEOEK4/edit?disco=AAAA3LFXfss)

Requires for us to have `perl` as an option for programming language facets