### PR TITLE
Split out Realm Kotlin SDK role to sync and base URLs

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1434,7 +1434,10 @@ type = {link = "https://www.mongodb.com/docs/realm-sdks/java/latest/%s"}
 type = {link = "https://www.mongodb.com/docs/realm-sdks/java/latest/kotlin-extensions/%s"}
 
 [role."kotlin-sdk"]
-type = {link = "https://www.mongodb.com/docs/realm-sdks/kotlin/latest/%s"}
+type = {link = "https://www.mongodb.com/docs/realm-sdks/kotlin/latest/library-base/%s"}
+
+[role."kotlin-sync-sdk"]
+type = {link = "https://www.mongodb.com/docs/realm-sdks/kotlin/latest/library-sync/%s"}
 
 [role."swift-sdk"]
 type = {link = "https://www.mongodb.com/docs/realm-sdks/swift/latest/%s"}


### PR DESCRIPTION
This PR: 
- updates the existing `kotlin-sdk` role to point to the base library
- adds a new `kotlin-sync-sdk` role, which points to the sync library