### PR TITLE
DOP-3921 follow up 

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -139,8 +139,9 @@ class Backend(ProjectBackend):
                 {"checksum": asset.get_checksum(), "key": asset.key}
                 for asset in uploadable_assets
             ],
-            "facets": page.facets,
         }
+        if page.facets:
+            document["facets"] = [facet.serialize() for facet in page.facets]
 
         self.handle_document(
             build_identifiers, page_id, fully_qualified_pageid, document

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -4,7 +4,17 @@ import os.path
 import re
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
-from typing import Dict, List, Match, MutableSequence, Optional, Tuple, Union, Any
+from typing import (
+    Any,
+    Dict,
+    List,
+    Match,
+    MutableSequence,
+    Optional,
+    Tuple,
+    Union,
+)
+
 import tomli
 from typing_extensions import Protocol
 
@@ -118,6 +128,14 @@ class Facet:
 
     def __ge__(self, other: "Facet") -> bool:
         return self.category >= other.category
+
+    def serialize(self) -> n.SerializedNode:
+        result: n.SerializedNode = {"category": self.category, "sub_facets": None}
+        if self.sub_facets:
+            result["sub_facets"] = [
+                sub_facet.serialize() for sub_facet in self.sub_facets
+            ]
+        return result
 
 
 @checked

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -4,16 +4,7 @@ import os.path
 import re
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
-from typing import (
-    Any,
-    Dict,
-    List,
-    Match,
-    MutableSequence,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Dict, List, Match, MutableSequence, Optional, Tuple, Union
 
 import tomli
 from typing_extensions import Protocol
@@ -130,7 +121,11 @@ class Facet:
         return self.category >= other.category
 
     def serialize(self) -> n.SerializedNode:
-        result: n.SerializedNode = {"category": self.category, "sub_facets": None}
+        result: n.SerializedNode = {
+            "category": self.category,
+            "value": self.value,
+            "sub_facets": None,
+        }
         if self.sub_facets:
             result["sub_facets"] = [
                 sub_facet.serialize() for sub_facet in self.sub_facets

--- a/test_data/test_project/source/facets.toml
+++ b/test_data/test_project/source/facets.toml
@@ -1,0 +1,3 @@
+[[facets]]
+category = "target_product"
+value = "atlas"


### PR DESCRIPTION
**Goal:** serialize facets before outputting to document

When testing with this [PR for cloud-docs](https://github.com/10gen/cloud-docs/pull/4768), I encountered an encoding error on master branch (regarding document.facets):

```
(snooty-py3.11) ➜  snooty-parser git:(master) snooty build ../../doc-repos/cloud-docs --output=../../ast-zip/cloud-docs-DOP-3851-b-parsermaster.zip 
INFO:snooty.main:Snooty 0.14.4.dev starting
INFO:snooty.parser:cache: 0 hits and 1796 misses
Traceback (most recent call last):
  File "/Users/seung.park/Library/Caches/pypoetry/virtualenvs/snooty-9xH0rLbM-py3.11/bin/snooty", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/seung.park/Desktop/repositories/snooty-parser/snooty/main.py", line 299, in main
    project.build()
  File "/Users/seung.park/Desktop/repositories/snooty-parser/snooty/parser.py", line 1908, in build
    self._project.build(max_workers, postprocess)
  File "/Users/seung.park/Desktop/repositories/snooty-parser/snooty/parser.py", line 1714, in build
    self.backend.on_update(
  File "/Users/seung.park/Desktop/repositories/snooty-parser/snooty/main.py", line 145, in on_update
    self.handle_document(
  File "/Users/seung.park/Desktop/repositories/snooty-parser/snooty/main.py", line 211, in handle_document
    f"documents/{page_id.without_known_suffix}.bson", bson.encode(document)
                                                      ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/seung.park/Library/Caches/pypoetry/virtualenvs/snooty-9xH0rLbM-py3.11/lib/python3.11/site-packages/bson/__init__.py", line 1014, in encode
    return _dict_to_bson(document, check_keys, codec_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
bson.errors.InvalidDocument: cannot encode object: Facet(category='target_product', value='atlas', sub_facets=None), of type: <class 'snooty.types.Facet'>
```

This has to be serialized into an plain document before being input into [encode](https://pymongo.readthedocs.io/en/stable/api/bson/index.html#bson.BSON.encode) function

Added a facets.toml file that corresponds to taxonomy, to test output of this. (Test failed without changes with same error as above)