### PR TITLE
Support passing options like --rstspec into the create-cache command

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -2,8 +2,8 @@
 
 Usage:
   snooty build [--no-caching] <source-path> [--output=<path>] [options]
-  snooty watch [--no-caching] <source-path>
-  snooty create-cache         <source-path>
+  snooty watch [--no-caching] <source-path> [options]
+  snooty create-cache         <source-path> [options]
   snooty [--no-caching] language-server
 
 Options:


### PR DESCRIPTION
Without this, there is no way to create a cache file compatible with our infrastructure. Whoops.