### PR TITLE
(DOCSP-32667) Makes MongoDB Atlas the top option on the language selector

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1757,8 +1757,8 @@ platforms = [
   {id = "linux", title = "Linux"},
 ]
 drivers = [
-  {id = "shell", title = "MongoDB Shell"},
   {id = "atlas-ui", title = "MongoDB Atlas"},
+  {id = "shell", title = "MongoDB Shell"},
   {id = "compass", title = "Compass"},
   {id = "c", title = "C"},
   {id = "cpp", title = "C++11"},


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-32667