### PR TITLE
DOP-3966: Make all internal path handling relative to the project source

### DIFF
--- a/snooty/gizaparser/extracts.py
+++ b/snooty/gizaparser/extracts.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
 from .. import n
@@ -31,7 +30,7 @@ class Extract(Inheritable, HeadingMixin):
 
 class GizaExtractsCategory(GizaCategory[Extract]):
     def parse(
-        self, path: Path, text: Optional[str] = None
+        self, path: n.FileId, text: Optional[str] = None
     ) -> Tuple[Sequence[Extract], str, List[Diagnostic]]:
         extracts, text, diagnostics = parse(Extract, path, self.project_config, text)
 
@@ -49,12 +48,11 @@ class GizaExtractsCategory(GizaCategory[Extract]):
 
     def to_pages(
         self,
-        source_path: Path,
+        source_fileid: n.FileId,
         page_factory: Callable[[str], Tuple[Page, EmbeddedRstParser]],
         extracts: Sequence[Extract],
     ) -> List[Page]:
         pages: List[Page] = []
-        source_fileid = self.project_config.get_fileid(source_path)
 
         for extract in extracts:
             assert extract.ref is not None

--- a/snooty/gizaparser/nodes.py
+++ b/snooty/gizaparser/nodes.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -191,7 +191,7 @@ class GizaFile(Generic[_I]):
 
     __slots__ = ("path", "text", "data")
 
-    path: Path
+    path: n.FileId
     text: str
     data: Sequence[_I]
 
@@ -207,21 +207,21 @@ class GizaCategory(Generic[_I]):
     dg: "networkx.DiGraph[str]" = field(default_factory=networkx.DiGraph)
 
     def parse(
-        self, path: Path, text: Optional[str] = None
+        self, path: n.FileId, text: Optional[str] = None
     ) -> Tuple[Sequence[_I], str, List[Diagnostic]]:
         """Abstract method to parse Giza nodes out of YAML source text."""
         raise NotImplementedError()
 
     def to_pages(
         self,
-        source_path: Path,
+        source_path: n.FileId,
         page_factory: Callable[[str], Tuple[Page, EmbeddedRstParser]],
         data: Sequence[_I],
     ) -> List[Page]:
         """Abstract method to generate pages from a given set of Giza nodes."""
         raise NotImplementedError()
 
-    def add(self, path: Path, text: str, elements: Sequence[_I]) -> None:
+    def add(self, path: n.FileId, text: str, elements: Sequence[_I]) -> None:
         """Add a file with one or more Giza nodes."""
         file_id = path.name
         self.nodes[file_id] = GizaFile(path, text, elements)
@@ -328,7 +328,7 @@ class GizaCategory(Generic[_I]):
         return obj
 
     def reify_file_id(
-        self, file_id: str, diagnostics: Dict[PurePath, List[Diagnostic]]
+        self, file_id: str, diagnostics: Dict[n.FileId, List[Diagnostic]]
     ) -> GizaFile[_I]:
         """Resolve inheritance and substitution in a Giza source file."""
         node = self.nodes[file_id]
@@ -341,7 +341,7 @@ class GizaCategory(Generic[_I]):
         return dataclasses.replace(node, data=data)
 
     def reify_all_files(
-        self, diagnostics: Dict[PurePath, List[Diagnostic]]
+        self, diagnostics: Dict[n.FileId, List[Diagnostic]]
     ) -> Iterator[Tuple[str, GizaFile[_I]]]:
         """Resolve inheritance and substitution in all source files within this category."""
 

--- a/snooty/gizaparser/parse.py
+++ b/snooty/gizaparser/parse.py
@@ -9,7 +9,7 @@ from yaml.composer import Composer
 
 from ..diagnostics import Diagnostic, ErrorParsingYAMLFile, UnmarshallingError
 from ..flutter import LoadError, check_type, mapping_dict
-from ..n import SerializableType
+from ..n import FileId, SerializableType
 from ..types import ProjectConfig
 
 _T = TypeVar("_T")
@@ -54,13 +54,16 @@ def load_yaml(
 
 
 def parse(
-    ty: Type[_T], path: Path, project_config: ProjectConfig, text: Optional[str] = None
+    ty: Type[_T],
+    fileid: FileId,
+    project_config: ProjectConfig,
+    text: Optional[str] = None,
 ) -> Tuple[List[_T], str, List[Diagnostic]]:
     diagnostics: List[Diagnostic] = []
     if text is None:
-        text, diagnostics = project_config.read(path)
+        text, diagnostics = project_config.read(fileid)
 
-    parsed_yaml, parse_diagnostic = load_yaml(path, text)
+    parsed_yaml, parse_diagnostic = load_yaml(project_config.source_path / fileid, text)
     if parse_diagnostic:
         diagnostics.append(parse_diagnostic)
         return ([], text, diagnostics)

--- a/snooty/gizaparser/release.py
+++ b/snooty/gizaparser/release.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
 from .. import n
@@ -44,7 +43,7 @@ class ReleaseSpecification(Inheritable):
 
 class GizaReleaseSpecificationCategory(GizaCategory[ReleaseSpecification]):
     def parse(
-        self, path: Path, text: Optional[str] = None
+        self, path: n.FileId, text: Optional[str] = None
     ) -> Tuple[Sequence[ReleaseSpecification], str, List[Diagnostic]]:
         nodes, text, diagnostics = parse(
             ReleaseSpecification, path, self.project_config, text
@@ -62,12 +61,11 @@ class GizaReleaseSpecificationCategory(GizaCategory[ReleaseSpecification]):
 
     def to_pages(
         self,
-        source_path: Path,
+        source_fileid: n.FileId,
         page_factory: Callable[[str], Tuple[Page, EmbeddedRstParser]],
         nodes: Sequence[ReleaseSpecification],
     ) -> List[Page]:
         pages: List[Page] = []
-        source_fileid = self.project_config.get_fileid(source_path)
 
         for node in nodes:
             assert node.ref is not None

--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Callable, List, MutableSequence, Optional, Sequence, Tuple, Union
 
 from .. import n
@@ -116,21 +115,20 @@ def step_to_page(page: Page, step: Step, rst_parser: EmbeddedRstParser) -> n.Dir
 
 class GizaStepsCategory(GizaCategory[Step]):
     def parse(
-        self, path: Path, text: Optional[str] = None
+        self, path: n.FileId, text: Optional[str] = None
     ) -> Tuple[Sequence[Step], str, List[Diagnostic]]:
         return parse(Step, path, self.project_config, text)
 
     def to_pages(
         self,
-        source_path: Path,
+        source_fileid: n.FileId,
         page_factory: Callable[[str], Tuple[Page, EmbeddedRstParser]],
         steps: Sequence[Step],
     ) -> List[Page]:
-        output_filename = source_path.with_suffix(".rst").name
+        output_filename = source_fileid.with_suffix(".rst").name
         output_filename = output_filename[len("steps-") :]
         page, rst_parser = page_factory(output_filename)
         page.category = "steps"
-        source_fileid = self.project_config.get_fileid(source_path)
         steps_directive = n.Directive((0,), [], "", "procedure", [], {})
         steps_directive.children = [
             step_to_page(page, step, rst_parser) for step in steps

--- a/snooty/gizaparser/test_nodes.py
+++ b/snooty/gizaparser/test_nodes.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from ..diagnostics import Diagnostic
+from ..n import FileId
 from ..types import ProjectConfig
 from . import nodes
 from .release import GizaReleaseSpecificationCategory
@@ -87,8 +88,8 @@ def test_inheritance() -> None:
     )
 
     category: nodes.GizaCategory[TestNode] = nodes.GizaCategory(project_config)
-    category.add(Path("parent.yaml"), "", [parent])
-    category.add(Path("child.yaml"), "", [child])
+    category.add(FileId("parent.yaml"), "", [parent])
+    category.add(FileId("child.yaml"), "", [child])
 
     reified_diagnostics: List[Diagnostic] = []
     reified_child = category.reify(child, reified_diagnostics, set(), set())
@@ -102,21 +103,21 @@ def test_inheritance() -> None:
 
 def test_reify_all_files() -> None:
     """Test to see if repeated refs in a YAML are detected"""
-    project_config = ProjectConfig(Path("test_data"), "")
+    project_config = ProjectConfig(Path("test_data/test_gizaparser"), "")
     project_config.constants["version"] = "3.4"
 
     # Place good path and bad path here
     paths = (
-        "test_data/test_gizaparser/source/includes/release-base.yaml",
-        "test_data/test_gizaparser/source/includes/release-base-repeat.yaml",
+        "includes/release-base.yaml",
+        "includes/release-base-repeat.yaml",
     )
 
     for i, path in enumerate(paths):
-        test_path = Path(path)
+        test_path = FileId(path)
 
         # Change GizaCategory based on file type (steps, release, etc.)
         category = GizaReleaseSpecificationCategory(project_config)
-        all_diagnostics: Dict[PurePath, List[Diagnostic]] = {}
+        all_diagnostics: Dict[FileId, List[Diagnostic]] = {}
 
         extracts, text, diagnostics = category.parse(test_path)
         category.add(test_path, text, extracts)

--- a/snooty/gizaparser/test_parse.py
+++ b/snooty/gizaparser/test_parse.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from ..n import FileId
 from ..types import ProjectConfig
 from .extracts import Extract
 from .parse import parse
@@ -9,7 +10,7 @@ def test_invalid_yaml() -> None:
     project_config = ProjectConfig(Path("test_data"), "")
     pages, text, diagnostics = parse(
         Extract,
-        Path(""),
+        FileId(""),
         project_config,
         """
 ref: troubleshooting-monitoring-agent-fails-to-collect-data

--- a/snooty/gizaparser/test_release.py
+++ b/snooty/gizaparser/test_release.py
@@ -1,7 +1,8 @@
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from ..diagnostics import Diagnostic
+from ..n import FileId
 from ..page import Page
 from ..parser import EmbeddedRstParser
 from ..types import ProjectConfig
@@ -14,38 +15,39 @@ def test_release_specification() -> None:
     project_config = ProjectConfig(root_path, "")
     project_config.constants["version"] = "3.4"
     category = GizaReleaseSpecificationCategory(project_config)
-    path = root_path.joinpath(Path("source/includes/release-specifications.yaml"))
-    parent_path = root_path.joinpath(Path("source/includes/release-base.yaml"))
+
+    fileid = FileId("includes/release-specifications.yaml")
+    parent_fileid = FileId("includes/release-base.yaml")
 
     def add_main_file() -> List[Diagnostic]:
-        extracts, text, parse_diagnostics = category.parse(path)
-        category.add(path, text, extracts)
+        extracts, text, parse_diagnostics = category.parse(fileid)
+        category.add(fileid, text, extracts)
         assert len(parse_diagnostics) == 0
         assert len(extracts) == 2
         return parse_diagnostics
 
     def add_parent_file() -> List[Diagnostic]:
-        extracts, text, parse_diagnostics = category.parse(parent_path)
-        category.add(parent_path, text, extracts)
+        extracts, text, parse_diagnostics = category.parse(parent_fileid)
+        category.add(parent_fileid, text, extracts)
         assert len(parse_diagnostics) == 0
         assert len(extracts) == 2
         return parse_diagnostics
 
-    all_diagnostics: Dict[PurePath, List[Diagnostic]] = {}
-    all_diagnostics[path] = add_main_file()
-    all_diagnostics[parent_path] = add_parent_file()
+    all_diagnostics: Dict[FileId, List[Diagnostic]] = {}
+    all_diagnostics[fileid] = add_main_file()
+    all_diagnostics[parent_fileid] = add_parent_file()
 
     assert len(category) == 2
-    file_id, giza_node = next(category.reify_all_files(all_diagnostics))
+    _, giza_node = next(category.reify_all_files(all_diagnostics))
 
     def create_page(filename: Optional[str]) -> Tuple[Page, EmbeddedRstParser]:
-        page = Page.create(path, filename, "")
-        return (page, EmbeddedRstParser(project_config, page, all_diagnostics[path]))
+        page = Page.create(fileid, filename, "")
+        return (page, EmbeddedRstParser(project_config, page, all_diagnostics[fileid]))
 
-    pages = category.to_pages(path, create_page, giza_node.data)
-    assert [page.fake_full_path().as_posix() for page in pages] == [
-        "test_data/test_gizaparser/source/includes/release/untar-release-osx-x86_64.rst",
-        "test_data/test_gizaparser/source/includes/release/install-ent-windows-default.rst",
+    pages = category.to_pages(fileid, create_page, giza_node.data)
+    assert [page.fake_full_fileid().as_posix() for page in pages] == [
+        "includes/release/untar-release-osx-x86_64.rst",
+        "includes/release/install-ent-windows-default.rst",
     ]
 
     assert all((not diagnostics for diagnostics in all_diagnostics.values()))

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -70,14 +70,22 @@ class ObserveHandler(watchdog.events.PatternMatchingEventHandler):
             watchdog.events.EVENT_TYPE_MODIFIED,
         ):
             logging.info("Rebuilding %s", event.src_path)
-            self.project.update(Path(event.src_path))
+            self.project.update(
+                self.project.config.get_fileid(PurePath(event.src_path))
+            )
         elif event.event_type == watchdog.events.EVENT_TYPE_DELETED:
             logging.info("Deleting %s", event.src_path)
-            self.project.delete(Path(event.src_path))
+            self.project.delete(
+                self.project.config.get_fileid(PurePath(event.src_path))
+            )
         elif isinstance(event, watchdog.events.FileSystemMovedEvent):
             logging.info("Moving %s", event.src_path)
-            self.project.delete(Path(event.src_path))
-            self.project.update(Path(event.dest_path))
+            self.project.delete(
+                self.project.config.get_fileid(PurePath(event.src_path))
+            )
+            self.project.update(
+                self.project.config.get_fileid(PurePath(event.dest_path))
+            )
         else:
             assert False
 

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -65,7 +65,7 @@ class FileId(PurePosixPath):
     def collapse_dots(self) -> "FileId":
         result: List[str] = []
         for part in self.parts:
-            if part == "..":
+            if part == ".." and result:
                 result.pop()
             elif part == ".":
                 continue

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -1,6 +1,5 @@
 import hashlib
 from dataclasses import dataclass, field
-from pathlib import Path, PurePath
 from typing import Dict, List, Optional, Set
 
 from . import n
@@ -27,7 +26,7 @@ class PendingTask:
 
 @dataclass
 class Page:
-    source_path: Path
+    fileid: FileId
     output_filename: str
     source: str
     ast: n.Root
@@ -41,34 +40,34 @@ class Page:
     @classmethod
     def create(
         self,
-        source_path: Path,
+        fileid: FileId,
         output_filename: Optional[str],
         source: str,
         ast: Optional[n.Root] = None,
     ) -> "Page":
         if output_filename is None:
-            output_filename = source_path.name
+            output_filename = fileid.name
 
         if ast is None:
-            ast = n.Root((0,), [], FileId(source_path), {})
+            ast = n.Root((0,), [], fileid, {})
 
         return Page(
-            source_path,
+            fileid,
             output_filename,
             source,
             ast,
             hashlib.blake2b(bytes(source, "utf-8")).hexdigest(),
         )
 
-    def fake_full_path(self) -> PurePath:
+    def fake_full_fileid(self) -> FileId:
         """Return a fictitious path (hopefully) uniquely identifying this output artifact."""
         if self.category:
             # Giza wrote out yaml file artifacts under a directory. e.g. steps-foo.yaml becomes
             # steps/foo.rst
-            return self.source_path.parent.joinpath(
-                PurePath(self.category), self.output_filename
+            return self.fileid.parent.joinpath(
+                FileId(self.category), self.output_filename
             )
-        return self.source_path
+        return self.fileid
 
     def finish(
         self, diagnostics: List[Diagnostic], project: Optional[ProjectInterface] = None

--- a/snooty/parse_cache.py
+++ b/snooty/parse_cache.py
@@ -53,7 +53,7 @@ class CacheData:
         )
 
     def get(
-        self, config: ProjectConfig, path: Path
+        self, config: ProjectConfig, path: FileId
     ) -> Tuple[Page, Sequence[diagnostics.Diagnostic]]:
         """Get a specific page from the cached data with the specified blake2b hash. Raises KeyError
         if the page is not found or the checksum does not match."""
@@ -62,9 +62,7 @@ class CacheData:
         file_hash = hashlib.blake2b(bytes(text, "utf-8")).hexdigest()
 
         try:
-            page, diagnostics = pickle.loads(
-                self.pages[(config.get_fileid(path).as_posix(), file_hash)]
-            )
+            page, diagnostics = pickle.loads(self.pages[(path.as_posix(), file_hash)])
         except KeyError as err:
             self.stats.misses += 1
             raise CacheMiss() from err

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -167,7 +167,7 @@ class JSONVisitor:
     def __init__(
         self,
         project_config: ProjectConfig,
-        docpath: PurePath,
+        docpath: FileId,
         document: tinydocutils.nodes.document,
     ) -> None:
         self.project_config = project_config
@@ -200,9 +200,7 @@ class JSONVisitor:
             self.state.append(n.FieldList((line,), []))
             return
         elif isinstance(node, tinydocutils.nodes.document):
-            self.state.append(
-                n.Root((0,), [], self.project_config.get_fileid(self.docpath), {})
-            )
+            self.state.append(n.Root((0,), [], self.docpath, {}))
             return
         elif isinstance(node, tinydocutils.nodes.field):
             field_name = node.children[0].astext()
@@ -1255,7 +1253,7 @@ class InlineJSONVisitor(JSONVisitor):
 
 
 def parse_rst(
-    parser: rstparser.Parser[JSONVisitor], path: Path, text: Optional[str] = None
+    parser: rstparser.Parser[JSONVisitor], path: FileId, text: Optional[str] = None
 ) -> Sequence[Tuple[Page, List[Diagnostic]]]:
     visitor, text = parser.parse(path, text)
 
@@ -1272,7 +1270,7 @@ def parse_rst(
         result.extend(
             parse_rst(
                 parser,
-                parser.project_config.source_path.joinpath(synthetic_page),
+                synthetic_page,
                 synthetic_page_text,
             )
         )
@@ -1292,7 +1290,7 @@ class EmbeddedRstParser:
         # Crudely make docutils line numbers match
         text = "\n" * lineno + rst.strip()
         parser = rstparser.Parser(self.project_config, JSONVisitor)
-        visitor, _ = parser.parse(self.page.source_path, text)
+        visitor, _ = parser.parse(self.page.fileid, text)
         top_of_state = visitor.state[-1]
         children: MutableSequence[n.Node] = top_of_state.children  # type: ignore
 
@@ -1306,7 +1304,7 @@ class EmbeddedRstParser:
         # Crudely make docutils line numbers match
         text = "\n" * lineno + rst.strip()
         parser = rstparser.Parser(self.project_config, InlineJSONVisitor)
-        visitor, _ = parser.parse(self.page.source_path, text)
+        visitor, _ = parser.parse(self.page.fileid, text)
         top_of_state = visitor.state[-1]
         children: MutableSequence[n.InlineNode] = top_of_state.children  # type: ignore
 
@@ -1424,7 +1422,9 @@ class _Project:
         substitution_nodes: Dict[str, List[n.InlineNode]] = {}
         for k, v in self.config.substitutions.items():
             # XXX: Assume that a single Page is generated (e.g. there's no sharedinclude)
-            page, substitution_diagnostics = parse_rst(inline_parser, root, v)[0]
+            page, substitution_diagnostics = parse_rst(
+                inline_parser, self.config.CONFIG_FILEID, v
+            )[0]
             substitution_nodes[k] = list(
                 deepcopy(child) for child in page.ast.children  # type: ignore
             )
@@ -1450,9 +1450,9 @@ class _Project:
                 )
 
                 # XXX: Assume that a single Page is generated (e.g. there's no sharedinclude)
-                page, banner_diagnostics = parse_rst(inline_parser, root, banner.value)[
-                    0
-                ]
+                page, banner_diagnostics = parse_rst(
+                    inline_parser, self.config.CONFIG_FILEID, banner.value
+                )[0]
                 banner_node.node.children = page.ast.children
                 if banner_node.node.children:
                     self.config.banner_nodes.append(banner_node)
@@ -1503,8 +1503,8 @@ class _Project:
     def get_project_title(self) -> str:
         return self.config.title
 
-    def update(self, path: Path, optional_text: Optional[str] = None) -> None:
-        diagnostics: Dict[PurePath, List[Diagnostic]] = {path: []}
+    def update(self, path: FileId, optional_text: Optional[str] = None) -> None:
+        diagnostics: Dict[FileId, List[Diagnostic]] = {path: []}
         prefix = get_giza_category(path)
         _, ext = os.path.splitext(path)
         pages: List[Page] = []
@@ -1558,13 +1558,11 @@ class _Project:
 
         with self._backend_lock:
             for source_path, diagnostic_list in diagnostics.items():
-                self.backend.on_diagnostics(
-                    self.config.get_fileid(source_path), diagnostic_list
-                )
+                self.backend.on_diagnostics(source_path, diagnostic_list)
 
         for page in pages:
             self._page_updated(page, diagnostic_list)
-            fileid = self.config.get_fileid(page.fake_full_path())
+            fileid = page.fake_full_fileid()
             with self._backend_lock:
                 self.backend.on_update(
                     self.prefix, self.build_identifiers, fileid, page
@@ -1572,11 +1570,11 @@ class _Project:
 
             self.backend.flush()
 
-    def delete(self, path: PurePath) -> None:
-        file_id = os.path.basename(path)
+    def delete(self, fileid: FileId) -> None:
+        path = self.config.source_path / fileid
         for giza_category in self.yaml_mapping.values():
             try:
-                del giza_category[file_id]
+                del giza_category[fileid.name]
             except KeyError:
                 pass
 
@@ -1628,35 +1626,36 @@ class _Project:
     def build(
         self, max_workers: Optional[int] = None, postprocess: bool = True
     ) -> None:
-        all_yaml_diagnostics: Dict[PurePath, List[Diagnostic]] = {}
+        all_yaml_diagnostics: Dict[FileId, List[Diagnostic]] = {}
         with util.PerformanceLogger.singleton().start("parse rst"):
             paths = util.get_files(
                 self.config.source_path, RST_EXTENSIONS, self.config.root
             )
-            self.parse_rst_files(paths, max_workers)
+            fileids = (self.config.get_fileid(path) for path in paths)
+            self.parse_rst_files(fileids, max_workers)
 
         self.propagate_facets()
         # Categorize our YAML files
         logger.debug("Categorizing YAML files")
-        categorized: Dict[str, List[Path]] = collections.defaultdict(list)
+        categorized: Dict[str, List[FileId]] = collections.defaultdict(list)
         for path in util.get_files(
             self.config.source_path, (".yaml",), self.config.root
         ):
             prefix = get_giza_category(path)
             if prefix in self.yaml_mapping:
-                categorized[prefix].append(path)
+                categorized[prefix].append(self.config.get_fileid(path))
 
         # Initialize our YAML file registry
         for prefix, giza_category in self.yaml_mapping.items():
             logger.debug("Parsing %s YAML", prefix)
-            for path in categorized[prefix]:
-                artifacts, text, diagnostics = giza_category.parse(path)
+            for fileid in categorized[prefix]:
+                artifacts, text, diagnostics = giza_category.parse(fileid)
                 if diagnostics:
-                    all_yaml_diagnostics[path] = diagnostics
-                giza_category.add(path, text, artifacts)
+                    all_yaml_diagnostics[fileid] = diagnostics
+                giza_category.add(fileid, text, artifacts)
 
         # Now that all of our YAML files are loaded, generate a page for each one
-        seen_paths: Set[Path] = set()
+        seen_paths: Set[FileId] = set()
         for prefix, giza_category in self.yaml_mapping.items():
             logger.debug("Processing %s YAML: %d nodes", prefix, len(giza_category))
             for file_id, giza_node in giza_category.reify_all_files(
@@ -1668,7 +1667,7 @@ class _Project:
                         giza_node.path,
                         filename,
                         giza_node.text,
-                        n.Root((-1,), [], self.config.get_fileid(FileId(filename)), {}),
+                        n.Root((-1,), [], giza_node.path, {}),
                     )
                     return (
                         page,
@@ -1682,18 +1681,14 @@ class _Project:
                 for page in giza_category.to_pages(
                     giza_node.path, create_page, giza_node.data
                 ):
-                    seen_paths.add(page.source_path)
-                    self._page_updated(
-                        page, all_yaml_diagnostics.get(page.source_path, [])
-                    )
+                    seen_paths.add(page.fileid)
+                    self._page_updated(page, all_yaml_diagnostics.get(page.fileid, []))
 
         # Handle parsing and unmarshaling errors that lead to diagnostics not associated with
         # any page.
         for key in all_yaml_diagnostics:
             if key not in seen_paths:
-                self.pages.set_orphan_diagnostics(
-                    self.config.get_fileid(key), all_yaml_diagnostics[key]
-                )
+                self.pages.set_orphan_diagnostics(key, all_yaml_diagnostics[key])
 
         if postprocess:
             postprocessor_result = self.postprocess()
@@ -1748,12 +1743,12 @@ class _Project:
         return result
 
     def parse_rst_files(
-        self, paths: Iterable[Path], max_workers: Optional[int] = None
+        self, paths: Iterable[FileId], max_workers: Optional[int] = None
     ) -> None:
         pool = multiprocessing.Pool(max_workers)
         try:
             logger.debug("Processing rst files")
-            cache_misses: List[Path] = []
+            cache_misses: List[FileId] = []
 
             hits = 0
 
@@ -1798,12 +1793,11 @@ class _Project:
         # Synchronize our asset watching
         old_assets: Set[StaticAsset] = set()
         removed_assets: Set[StaticAsset] = set()
-        fileid = self.config.get_fileid(page.fake_full_path())
 
-        logger.debug("Updated: %s", fileid)
+        logger.debug("Updated: %s", page.fileid)
 
-        if fileid in self.pages:
-            old_page = self.pages._parsed[fileid][0]
+        if page.fileid in self.pages:
+            old_page = self.pages._parsed[page.fileid][0]
             old_assets = old_page.static_assets
             removed_assets = old_page.static_assets.difference(page.static_assets)
 
@@ -1821,27 +1815,25 @@ class _Project:
 
         # Update dependents
         try:
-            self.asset_dg.remove_node(self.config.get_fileid(page.source_path))
+            self.asset_dg.remove_node(page.fileid)
         except networkx.exception.NetworkXError:
             pass
         self.asset_dg.add_edges_from(
             (
-                self.config.get_fileid(page.source_path),
+                page.fileid,
                 self.config.get_fileid(asset.path),
             )
             for asset in page.static_assets
         )
 
         # Report to our backend
-        self.pages[fileid] = (
+        self.pages[page.fake_full_fileid()] = (
             page,
-            self.config.get_fileid(page.source_path),
+            page.fileid,
             diagnostics_copy,
         )
         with self._backend_lock:
-            self.backend.on_diagnostics(
-                self.config.get_fileid(page.source_path), diagnostics_copy
-            )
+            self.backend.on_diagnostics(page.fileid, diagnostics_copy)
 
     def on_asset_event(self, ev: watchdog.events.FileSystemEvent) -> None:
         asset_path = self.config.get_fileid(Path(ev.src_path))
@@ -1854,7 +1846,7 @@ class _Project:
 
         # Rebuild any pages depending on this asset
         for page_id in list(self.asset_dg.predecessors(asset_path)):
-            self.update(self.pages[page_id].source_path)
+            self.update(self.pages[page_id].fileid)
 
 
 class Project:
@@ -1892,12 +1884,12 @@ class Project:
     def get_project_name(self) -> str:
         return self._project.get_project_name()
 
-    def update(self, path: Path, optional_text: Optional[str] = None) -> None:
+    def update(self, path: FileId, optional_text: Optional[str] = None) -> None:
         """Re-parse a file, optionally using the provided text rather than reading the file."""
         with self._lock:
             self._project.update(path, optional_text)
 
-    def delete(self, path: PurePath) -> None:
+    def delete(self, path: FileId) -> None:
         """Mark a path as having been deleted."""
         with self._lock:
             self._project.delete(path)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -716,12 +716,8 @@ class BannerHandler(Handler):
         """Check if page matches target specified, but assert to ensure this does not run on includes"""
         assert fileid.suffix == ".txt"
 
-        page_path_relative_to_source = page.source_path.relative_to(
-            self.root / "source"
-        )
-
         for target in targets:
-            if page_path_relative_to_source.match(target):
+            if page.fileid.match(target):
                 return True
         return False
 
@@ -1797,7 +1793,7 @@ class Postprocessor:
         def _get_page_from_slug(current_page: Page, slug: str) -> Optional[Page]:
             relative, _ = util.reroot_path(
                 FileId(slug),
-                current_page.source_path,
+                current_page.fileid,
                 context[ProjectConfig].source_path,
             )
 

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -4,7 +4,7 @@ import urllib.parse
 from collections import defaultdict
 from dataclasses import dataclass, field
 from mimetypes import guess_type
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from typing import (
     AbstractSet,
     Any,
@@ -1233,7 +1233,7 @@ class Parser(Generic[_V]):
         self.project_config = project_config
         self.visitor_class = visitor_class
 
-    def parse(self, path: Path, text: Optional[str]) -> Tuple[_V, str]:
+    def parse(self, path: n.FileId, text: Optional[str]) -> Tuple[_V, str]:
         Registry.get(self.project_config.default_domain).activate()
 
         diagnostics: List[Diagnostic] = []
@@ -1249,6 +1249,7 @@ class Parser(Generic[_V]):
 
         parser.parse(text, document)
 
+        assert isinstance(path, n.FileId)
         visitor = self.visitor_class(self.project_config, path, document)
         visitor.add_diagnostics(diagnostics)
         document.walkabout(visitor)

--- a/snooty/test_openapi.py
+++ b/snooty/test_openapi.py
@@ -2,22 +2,23 @@ from pathlib import Path
 
 from . import rstparser
 from .diagnostics import ExpectedPathArg, InvalidURL
+from .n import FileId
 from .parser import JSONVisitor
 from .types import ProjectConfig
 from .util_test import check_ast_testing_string, parse_rst
 
 ROOT_PATH = Path("test_data")
+FILEID = FileId("test.rst")
 
 
 def test_openapi_using_filepath() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", default_domain="mongodb", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
     # Test default parse using file path
     page, diagnostics = parse_rst(
         parser,
-        path,
+        FILEID,
         """
 .. openapi:: /test_parser/openapi-admin-v3.yaml
 """,
@@ -34,14 +35,13 @@ def test_openapi_using_filepath() -> None:
 
 
 def test_openapi_using_url() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", default_domain="mongodb", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
     # Successful
     page, diagnostics = parse_rst(
         parser,
-        path,
+        FILEID,
         """
 .. openapi:: https://raw.githubusercontent.com/mongodb/snooty-parser/master/test_data/test_parser/openapi-admin-v3.yaml
 """,
@@ -59,7 +59,7 @@ def test_openapi_using_url() -> None:
     # Invalid URL
     page, diagnostics = parse_rst(
         parser,
-        path,
+        FILEID,
         """
 .. openapi:: https://mongodb.com
 """,
@@ -70,13 +70,12 @@ def test_openapi_using_url() -> None:
 
 
 def test_openapi_using_realm() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", default_domain="mongodb", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
     page, diagnostics = parse_rst(
         parser,
-        path,
+        FILEID,
         """
 .. openapi:: cloud
    :uses-realm:
@@ -97,7 +96,7 @@ def test_openapi_using_realm() -> None:
 
     page, diagnostics = parse_rst(
         parser,
-        path,
+        FILEID,
         """
 .. openapi:: https://mongodb.com
    :uses-realm:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -45,10 +45,9 @@ ROOT_PATH = Path("test_data")
 
 
 def test_quiz() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test_quiz.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
-    page, diagnostics = parse_rst(parser, tabs_path, None)
+    page, diagnostics = parse_rst(parser, FileId("test_quiz.rst"), None)
     page.finish(diagnostics)
     check_ast_testing_string(
         page.ast,
@@ -74,7 +73,7 @@ def test_quiz() -> None:
 
 def test_chapter() -> None:
     """Test chapter directive"""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -135,7 +134,7 @@ def test_chapter() -> None:
 
 def test_card() -> None:
     """Test card directive"""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -177,10 +176,10 @@ def test_card() -> None:
 
 
 def test_tabs() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test_tabs.rst"))
+    tabs_fileid = FileId("test_tabs.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
-    page, diagnostics = parse_rst(parser, tabs_path, None)
+    page, diagnostics = parse_rst(parser, tabs_fileid, None)
     page.finish(diagnostics)
 
     check_ast_testing_string(
@@ -261,7 +260,7 @@ def test_tabs() -> None:
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
         parser,
-        tabs_path,
+        tabs_fileid,
         """
 .. tabs-drivers::
 
@@ -311,10 +310,9 @@ def test_tabs() -> None:
 
 
 def test_tabsets_with_options() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test_tabs_options.rst"))
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
-    page, diagnostics = parse_rst(parser, tabs_path, None)
+    page, diagnostics = parse_rst(parser, FileId("test_tabs_options.rst"), None)
     page.finish(diagnostics)
 
     check_ast_testing_string(
@@ -334,7 +332,7 @@ def test_tabsets_with_options() -> None:
 
 
 def test_tabs_invalid_yaml() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
+    tabs_path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
@@ -360,7 +358,7 @@ def test_tabs_invalid_yaml() -> None:
 
 
 def test_tabs_reorder() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
+    tabs_path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
@@ -400,7 +398,7 @@ def test_tabs_reorder() -> None:
 
 
 def test_iocodeblock() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
+    tabs_path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -790,7 +788,7 @@ print("hello world")
 
 
 def test_codeblock() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
+    tabs_path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -939,7 +937,7 @@ def test_codeblock() -> None:
 
 
 def test_literalinclude() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1255,7 +1253,7 @@ for (i = 0; i &lt; 10; i++) {
 
 
 def test_include() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1301,7 +1299,7 @@ def test_include() -> None:
 
 
 def test_admonition() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1328,7 +1326,7 @@ def test_admonition() -> None:
 
 
 def test_admonition_versionchanged() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1369,7 +1367,7 @@ def test_admonition_versionchanged() -> None:
 
 
 def test_admonition_deprecated() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1402,7 +1400,7 @@ def test_admonition_deprecated() -> None:
 
 
 def test_banner() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1430,7 +1428,7 @@ def test_banner() -> None:
 
 
 def test_cta_banner() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1488,7 +1486,7 @@ def test_cta_banner() -> None:
 
 
 def test_rst_replacement() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1558,7 +1556,7 @@ foo |double arrow ->| bar
 
 
 def test_labels() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1592,7 +1590,7 @@ def test_labels() -> None:
 
 
 def test_roles() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1700,14 +1698,14 @@ def test_roles() -> None:
 
 def test_doc_role() -> None:
     project_root = ROOT_PATH.joinpath("test_project")
-    path = project_root.joinpath(Path("source/test.rst")).resolve()
+    fileid = FileId("test.rst")
     project_config = ProjectConfig(project_root, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
     # Test bad text
     page, diagnostics = parse_rst(
         parser,
-        path,
+        fileid,
         """
 * :doc:`Testing it <fake-text>`
 * :doc:`Testing this </fake-text>`
@@ -1723,7 +1721,7 @@ def test_doc_role() -> None:
     # Test valid text
     page, diagnostics = parse_rst(
         parser,
-        path,
+        fileid,
         """
 * :doc:`Testing this </index>`
 * :doc:`Testing that <./../source/index>`
@@ -1786,7 +1784,7 @@ def test_doc_role() -> None:
 
 
 def test_rstobject() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1816,7 +1814,7 @@ def test_rstobject() -> None:
 
 
 def test_bad_option() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
@@ -1840,7 +1838,7 @@ def test_bad_option() -> None:
 
 
 def test_accidental_indentation() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1892,7 +1890,7 @@ def test_accidental_indentation() -> None:
 
 
 def test_figure() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -1990,7 +1988,7 @@ def test_figure() -> None:
 
 
 def test_atf_image() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2038,7 +2036,7 @@ def test_atf_image() -> None:
 
 
 def test_glossary_node() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2170,7 +2168,7 @@ def test_glossary_node() -> None:
 
 
 def test_cond() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2209,7 +2207,7 @@ def test_cond() -> None:
 
 
 def test_version() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2303,7 +2301,7 @@ A new paragraph.
 
 
 def test_list() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2362,7 +2360,7 @@ e. Fifth list item
 
 
 def test_list_table() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2585,7 +2583,7 @@ def test_list_table() -> None:
 
 
 def test_footnote() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2638,7 +2636,7 @@ def test_footnote() -> None:
     )
 
     # Test that docutils <label> nodes do not crash the parser.
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2656,7 +2654,7 @@ def test_footnote() -> None:
 
 
 def test_footnote_reference() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2703,13 +2701,12 @@ This is an autonumbered footnote [#]_ in use.
 
 def test_toctree() -> None:
     project_root = ROOT_PATH.joinpath("test_project")
-    path = project_root.joinpath(Path("source/test.rst")).resolve()
     [project_config, project_config_diagnostics] = ProjectConfig.open(project_root)
     parser = rstparser.Parser(project_config, JSONVisitor)
 
     page, diagnostics = parse_rst(
         parser,
-        path,
+        FileId("test.rst"),
         """
 .. toctree::
    :titlesonly:
@@ -2737,7 +2734,7 @@ def test_toctree() -> None:
 
 
 def test_mongo_web_shell() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2819,7 +2816,7 @@ def test_mongo_web_shell() -> None:
 
 
 def test_callable_target() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2879,7 +2876,7 @@ def test_callable_target() -> None:
 
 
 def test_no_weird_targets() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2902,7 +2899,7 @@ def test_no_weird_targets() -> None:
 
 
 def test_dates() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2932,7 +2929,7 @@ def test_problematic() -> None:
     """Test that "<problematic>" nodes by the docutils parser --- typically when a
     role isn't known --- are excluded from the output AST. We might change this
     behavior, but for now we should define it."""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2951,7 +2948,7 @@ def test_problematic() -> None:
 
 
 def test_deprecated() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -2973,7 +2970,7 @@ def test_deprecated() -> None:
 
 
 def test_definition_list() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3036,7 +3033,7 @@ collection.createIndex( { name : -1 }, function(err, result) {
 
 
 def test_required_option() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3059,7 +3056,7 @@ def test_required_option() -> None:
 
 
 def test_fields() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3127,7 +3124,7 @@ specified encryption method and key.</text>
 
 
 def test_malformed_monospace() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, InlineJSONVisitor)
 
@@ -3150,7 +3147,7 @@ def test_malformed_monospace() -> None:
 
 
 def test_malformed_external_link() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, InlineJSONVisitor)
 
@@ -3176,7 +3173,7 @@ def test_malformed_external_link() -> None:
 
 
 def test_explicit_title_parsing() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3212,7 +3209,7 @@ def test_explicit_title_parsing() -> None:
 
 
 def test_invalid_blockquote() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
+    tabs_path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
@@ -3238,7 +3235,7 @@ This is a paragraph.
 
 
 def test_label_matches_heading() -> None:
-    tabs_path = ROOT_PATH.joinpath(Path("test.rst"))
+    tabs_path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
@@ -3257,7 +3254,7 @@ Foobar Baz
     check_ast_testing_string(
         page.ast,
         """
-<root fileid="../test.rst">
+<root fileid="test.rst">
     <target domain="std" name="label">
         <target_identifier ids="['foobar-baz']"></target_identifier>
     </target>
@@ -3270,7 +3267,7 @@ Foobar Baz
 
 def test_duplicate_ref() -> None:
     """docutils changes the target node shape when duplicate labels are used. See: DOP-1326"""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
@@ -3300,7 +3297,7 @@ A Heading
     check_ast_testing_string(
         page.ast,
         """
-<root fileid="../test.rst">
+<root fileid="test.rst">
     <section>
         <heading id="index-page"><text>Index Page</text></heading>
         <target domain="std" name="label">
@@ -3321,7 +3318,7 @@ A Heading
 
 
 def test_trailing_slash() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
     page, diagnostics = parse_rst(
@@ -3344,7 +3341,7 @@ Link to :opsmgr:`Ops Manager </page?q=true>`
     check_ast_testing_string(
         page.ast,
         """
-<root fileid="../test.rst">
+<root fileid="test.rst">
 <paragraph>
     <text>Link to </text><reference refuri="https://www.mongodb.com/docs/compass/current/"><text>Compass</text></reference>
     <text>Link to </text><reference refuri="https://www.mongodb.com/docs/charts/path/"><text>Charts</text></reference>
@@ -3360,7 +3357,7 @@ Link to :opsmgr:`Ops Manager </page?q=true>`
 
 def test_escape() -> None:
     """Ensure that escaping characters after a substitution results in the proper output."""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3383,7 +3380,7 @@ def test_escape() -> None:
     check_ast_testing_string(
         page.ast,
         """
-<root fileid="../test.rst">
+<root fileid="test.rst">
     <substitution_definition name="adl"><text>Atlas Data Lake</text></substitution_definition>
     <paragraph><substitution_reference name="adl"></substitution_reference><text>ss</text></paragraph>
 </root>""",
@@ -3392,7 +3389,7 @@ def test_escape() -> None:
 
 def test_directive_line_offset() -> None:
     """Ensure that line numbers are correctly tracked inside of directives."""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3426,7 +3423,7 @@ Prerequisites
 
 def test_field_list_in_list() -> None:
     """Tests DOP-2975"""
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3460,7 +3457,7 @@ here is an invalid character sequence\x80 oh noooo
 
 
 def test_valid_icon() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3502,7 +3499,7 @@ def test_valid_icon() -> None:
 
 
 def test_invalid_icon() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3540,7 +3537,7 @@ def test_invalid_icon() -> None:
 
 
 def test_invalid_string_argument() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3560,7 +3557,7 @@ def test_invalid_string_argument() -> None:
 
 
 def test_missing_expected_option() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3579,7 +3576,7 @@ def test_missing_expected_option() -> None:
 
 
 def test_invalid_changelog_option() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3600,7 +3597,7 @@ def test_invalid_changelog_option() -> None:
 
 def test_standalone_literal_block() -> None:
     # Issues here discovered in DOP-3753
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
@@ -3629,7 +3626,7 @@ bar
 
 
 def test_invalid_facets() -> None:
-    path = ROOT_PATH.joinpath(Path("test.rst"))
+    path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -329,13 +329,14 @@ Guides
         }
     ) as result:
         diagnostics = result.diagnostics[FileId("index.txt")]
-        assert len(diagnostics) == 6
-        assert isinstance(diagnostics[0], DocUtilsParseError)
-        assert isinstance(diagnostics[1], MissingChild)
-        assert isinstance(diagnostics[2], InvalidChild)
-        assert isinstance(diagnostics[3], InvalidChapter)
-        assert isinstance(diagnostics[4], InvalidChild)
-        assert isinstance(diagnostics[5], MissingChild)
+        assert [type(x) for x in diagnostics] == [
+            DocUtilsParseError,
+            MissingChild,
+            InvalidChild,
+            InvalidChapter,
+            InvalidChild,
+            MissingChild,
+        ]
 
     # Test missing directives in "chapters" directive
     with make_test(

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -64,5 +64,5 @@ def test_static_asset() -> None:
 
 
 def test_page() -> None:
-    page = Page.create(Path("foo.rst"), None, "")
-    assert page.fake_full_path() == PurePath("foo.rst")
+    page = Page.create(FileId("foo.rst"), None, "")
+    assert page.fake_full_fileid() == PurePath("foo.rst")

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -71,6 +71,7 @@ def reroot_path(
 ) -> Tuple[n.FileId, Path]:
     """Files within a project may refer to other files. Return a canonical path
     relative to the project root."""
+
     if filename.is_absolute():
         rel_fn = n.FileId(*filename.parts[1:])
     else:

--- a/snooty/util_test.py
+++ b/snooty/util_test.py
@@ -244,6 +244,6 @@ def make_test(
 
 
 def parse_rst(
-    parser: rstparser.Parser[JSONVisitor], path: Path, text: Optional[str] = None
+    parser: rstparser.Parser[JSONVisitor], path: FileId, text: Optional[str] = None
 ) -> Tuple[Page, List[Diagnostic]]:
     return parse_rst_multi(parser, path, text)[0]


### PR DESCRIPTION
As demonstrated by the new code in `test_project.py::test_cache()`, caches are no longer path-dependent!

A notable change here is that since we now need a FileId for `snooty.toml`, that gets made with `FileId("../snooty.toml")` because FileIds are relative to the source directory.