### PR TITLE
[DOP-3992]: Add landing:more-ways directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -584,6 +584,7 @@ options.video_url = { type = "uri", required = true }
 
 example = """.. landing:more-ways::
    :video_url: ${1: full video url}
+   
    ${2: More ways content}
  """
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -582,7 +582,7 @@ argument_type = "string"
 content_type = "block"
 options.video_url = { type = "uri", required = true }
 
-example = """.. landing:more-ways
+example = """.. landing:more-ways::
    :video: ${1: full video url}
    ${2: More ways content}
  """

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -576,6 +576,18 @@ content_type = "block"
 #    ${0: quoted content}
 # """
 
+#### docs-landing directives
+[directive."landing:more-ways"]
+argument_type = "string"
+content_type = "block"
+options.video_url = { type = "uri", required = true }
+
+example = """.. landing:more-ways
+   :video: ${1: full video url}
+   ${2: More ways content}
+ """
+
+
 ##### Internal "mongodb" directives
 [directive."mongodb:banner"]
 help = """A skinny admonition, meant for alerts or smaller notifications."""

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -582,10 +582,10 @@ argument_type = "string"
 content_type = "block"
 options.video_url = { type = "uri", required = true }
 
-example = """.. landing:more-ways::
-   :video_url: ${1: full video url}
-   
-   ${2: More ways content}
+example = """.. landing:more-ways:: ${1: the value of the H3 that should be rendered by the front-end}
+   :video_url: ${2: full video url}
+
+   ${3: More ways content}
  """
 
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -583,7 +583,7 @@ content_type = "block"
 options.video_url = { type = "uri", required = true }
 
 example = """.. landing:more-ways::
-   :video: ${1: full video url}
+   :video_url: ${1: full video url}
    ${2: More ways content}
  """
 

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -139,7 +139,7 @@ def test_landing_more_ways() -> None:
     parser = rstparser.Parser(project_config, JSONVisitor)
 
     MORE_WAYS_CONTENT = """
-.. landing:more-ways::
+.. landing:more-ways:: Connecting to a Cluster
     :video_url: https://www.youtube.com/watch?v=Wt_f3-1GxH0&ab_channel=MongoDB
 
     In this MongoDB University video, learn how to connect to a cluster 

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -132,6 +132,31 @@ def test_chapter() -> None:
     assert isinstance(diagnostics[0], CannotOpenFile)
 
 
+def test_landing_more_ways() -> None:
+    """Test landing:more-ways directive"""
+    path = FileId("test.rst")
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    MORE_WAYS_CONTENT = """
+.. landing:more-ways::
+    :video_url: https://www.youtube.com/watch?v=Wt_f3-1GxH0&ab_channel=MongoDB
+
+    In this MongoDB University video, learn how to connect to a cluster 
+    efficiently. Explore connection methods, replica sets, and sharded 
+    clusters, gaining insights into managing and optimizing cluster 
+    connections for seamless and scalable data operations.
+
+    .. cta::
+        `Continue on to MongoDB University <https://learn.mongodb.com>`__
+    """
+
+    page, diagnostics = parse_rst(parser, path, MORE_WAYS_CONTENT)
+
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0
+
+
 def test_card() -> None:
     """Test card directive"""
     path = FileId("test.rst")

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -132,31 +132,6 @@ def test_chapter() -> None:
     assert isinstance(diagnostics[0], CannotOpenFile)
 
 
-def test_landing_more_ways() -> None:
-    """Test landing:more-ways directive"""
-    path = FileId("test.rst")
-    project_config = ProjectConfig(ROOT_PATH, "", source="./")
-    parser = rstparser.Parser(project_config, JSONVisitor)
-
-    MORE_WAYS_CONTENT = """
-.. landing:more-ways:: Connecting to a Cluster
-    :video_url: https://www.youtube.com/watch?v=Wt_f3-1GxH0&ab_channel=MongoDB
-
-    In this MongoDB University video, learn how to connect to a cluster 
-    efficiently. Explore connection methods, replica sets, and sharded 
-    clusters, gaining insights into managing and optimizing cluster 
-    connections for seamless and scalable data operations.
-
-    .. cta::
-        `Continue on to MongoDB University <https://learn.mongodb.com>`__
-    """
-
-    page, diagnostics = parse_rst(parser, path, MORE_WAYS_CONTENT)
-
-    page.finish(diagnostics)
-    assert len(diagnostics) == 0
-
-
 def test_card() -> None:
     """Test card directive"""
     path = FileId("test.rst")


### PR DESCRIPTION
## Ticket

[DOP-3992](https://jira.mongodb.org/browse/DOP-3992)

## Notes

Instead of having the video directive be adjacent to the `landing:more-ways` directive, I decided to add an option to take the video URL so that the frontend can handle rendering the video component. This simplifies organizing and styling the content within the component. 

I'm not sure if this is an ideal approach, so I am definitely open to suggestions for an alternative for handling the video component.