### PR TITLE
DOP-3993: Allow card group to link data for IA entry

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -526,6 +526,22 @@ class InvalidIAEntry(Diagnostic):
         )
 
 
+class InvalidIALinkedData(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        msg: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"Unable to link data for IA: {msg}",
+            start,
+            end,
+        )
+
+
 class UnknownTabset(Diagnostic):
     severity = Diagnostic.Level.error
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1158,6 +1158,8 @@ class IAHandler(Handler):
                 )
                 continue
 
+            # The following options are the most important for ensuring working
+            # links on the side nav, but we can extend this to all options if needed
             headline = card.options.get("headline", "")
             url = card.options.get("url", "")
             if not headline or not url:
@@ -1168,12 +1170,7 @@ class IAHandler(Handler):
                 )
                 continue
 
-            self.entry_ids[entry_id].append(
-                {
-                    "headline": headline,
-                    "url": url,
-                }
-            )
+            self.entry_ids[entry_id].append(card.options)
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or not (

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -646,6 +646,7 @@ options.columns = "nonnegative_integer"
 options.layout = "card_layout"
 options.style = "card_style"
 options.type = "card_group_type"
+options.ia-entry-id = "string"
 example = """.. card-group::
    ${1::columns: 2}
    :layout: ${3:|default,carousel| (Optional)}
@@ -924,6 +925,7 @@ argument_type = "string"
 options.url = "string"
 options.project-name = "string"
 options.primary = "flag"
+options.id = "string"
 example = """.. entry:: ${0: string}
    ${1::url: (string)
    :project-name: (string) [optional]


### PR DESCRIPTION
### Ticket

DOP-3993

### Notes

* Adds an optional id to IA entries. This ID can be referenced by a `card-group` directive to link card data with an IA entry. This data will be usable in the side nav.
  * The concept of linking data this way might be weird... This is for a (probably) one-off instance for the new homepage, but hopefully this is okay. I'm open to suggestions!
* Linked data will be present in the metadata to allow different pages with similar IA entries to render the linked data in multiple places.
* Relevant [frontend PR](https://github.com/mongodb/snooty/pull/890)
* Relevant [rST commit](https://github.com/mongodb/docs-landing/pull/132/commits/d157270c47a843add7f83e529357be7bcded8825)