### PR TITLE
DOP-4043

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -532,26 +532,25 @@ class JSONVisitor:
     def handle_facet(self, node: rstparser.directive, line: int) -> None:
         for value in node["options"]["values"].split(","):
             ref: Union[rstparser.directive, tinydocutils.nodes.Element] = node
-            for value in ref["options"]["values"].split(","):
-                single_value = value.strip()
-                try:
-                    facet_str_pairs: List[tuple[str, str]] = [
-                        (ref["options"]["name"], single_value)
-                    ]
+            single_value = value.strip()
+            try:
+                facet_str_pairs: List[tuple[str, str]] = [
+                    (ref["options"]["name"], single_value)
+                ]
 
-                    while ref.parent and ref.parent.get("name") == "facet":
-                        ref = ref.parent
-                        # parent facet with children can only have one value
-                        # no need to traverse in multiple directions
-                        facet_str_pairs.append(
-                            (ref["options"]["name"], ref["options"]["values"])
-                        )
-
-                    taxonomy.TaxonomySpec.validate_key_value_pairs(facet_str_pairs)
-                except KeyError:
-                    self.diagnostics.append(
-                        MissingFacet(f"{node['options']['name']}:{single_value}", line)
+                while ref.parent and ref.parent.get("name") == "facet":
+                    ref = ref.parent
+                    # parent facet with children can only have one value
+                    # no need to traverse in multiple directions
+                    facet_str_pairs.append(
+                        (ref["options"]["name"], ref["options"]["values"])
                     )
+
+                taxonomy.TaxonomySpec.validate_key_value_pairs(facet_str_pairs)
+            except KeyError:
+                self.diagnostics.append(
+                    MissingFacet(f"{node['options']['name']}:{single_value}", line)
+                )
 
     def handle_tabset(self, node: n.Directive) -> None:
         tabset = node.options["tabset"]

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -530,27 +530,28 @@ class JSONVisitor:
             popped.children = [n.Section((node.get_line(),), popped.children)]
 
     def handle_facet(self, node: rstparser.directive, line: int) -> None:
-        ref: Union[rstparser.directive, tinydocutils.nodes.Element] = node
-        for value in ref["options"]["values"].split(","):
-            single_value = value.strip()
-            try:
-                facet_str_pairs: List[tuple[str, str]] = [
-                    (ref["options"]["name"], single_value)
-                ]
+        for value in node["options"]["values"].split(","):
+            ref: Union[rstparser.directive, tinydocutils.nodes.Element] = node
+            for value in ref["options"]["values"].split(","):
+                single_value = value.strip()
+                try:
+                    facet_str_pairs: List[tuple[str, str]] = [
+                        (ref["options"]["name"], single_value)
+                    ]
 
-                while ref.parent and ref.parent.get("name") == "facet":
-                    ref = ref.parent
-                    # parent facet with children can only have one value
-                    # no need to traverse in multiple directions
-                    facet_str_pairs.append(
-                        (ref["options"]["name"], ref["options"]["values"])
+                    while ref.parent and ref.parent.get("name") == "facet":
+                        ref = ref.parent
+                        # parent facet with children can only have one value
+                        # no need to traverse in multiple directions
+                        facet_str_pairs.append(
+                            (ref["options"]["name"], ref["options"]["values"])
+                        )
+
+                    taxonomy.TaxonomySpec.validate_key_value_pairs(facet_str_pairs)
+                except KeyError:
+                    self.diagnostics.append(
+                        MissingFacet(f"{node['options']['name']}:{single_value}", line)
                     )
-
-                taxonomy.TaxonomySpec.validate_key_value_pairs(facet_str_pairs)
-            except KeyError:
-                self.diagnostics.append(
-                    MissingFacet(f"{node['options']['name']}:{single_value}", line)
-                )
 
     def handle_tabset(self, node: n.Directive) -> None:
         tabset = node.options["tabset"]

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -531,7 +531,7 @@ class JSONVisitor:
 
     def handle_facet(self, node: rstparser.directive, line: int) -> None:
         ref: Union[rstparser.directive, tinydocutils.nodes.Element] = node
-        for value in ref["options"]["values"].split(','):
+        for value in ref["options"]["values"].split(","):
             single_value = value.strip()
             try:
                 facet_str_pairs: List[tuple[str, str]] = [
@@ -549,9 +549,7 @@ class JSONVisitor:
                 taxonomy.TaxonomySpec.validate_key_value_pairs(facet_str_pairs)
             except KeyError:
                 self.diagnostics.append(
-                    MissingFacet(
-                        f"{node['options']['name']}:{single_value}", line
-                    )
+                    MissingFacet(f"{node['options']['name']}:{single_value}", line)
                 )
 
     def handle_tabset(self, node: n.Directive) -> None:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -530,25 +530,29 @@ class JSONVisitor:
             popped.children = [n.Section((node.get_line(),), popped.children)]
 
     def handle_facet(self, node: rstparser.directive, line: int) -> None:
-        try:
-            ref: Union[rstparser.directive, tinydocutils.nodes.Element] = node
-            facet_str_pairs: List[tuple[str, str]] = [
-                (ref["options"]["name"], ref["options"]["values"])
-            ]
+        ref: Union[rstparser.directive, tinydocutils.nodes.Element] = node
+        for value in ref["options"]["values"].split(','):
+            single_value = value.strip()
+            try:
+                facet_str_pairs: List[tuple[str, str]] = [
+                    (ref["options"]["name"], single_value)
+                ]
 
-            while ref.parent and ref.parent.get("name") == "facet":
-                ref = ref.parent
-                facet_str_pairs.append(
-                    (ref["options"]["name"], ref["options"]["values"])
-                )
+                while ref.parent and ref.parent.get("name") == "facet":
+                    ref = ref.parent
+                    # parent facet with children can only have one value
+                    # no need to traverse in multiple directions
+                    facet_str_pairs.append(
+                        (ref["options"]["name"], ref["options"]["values"])
+                    )
 
-            taxonomy.TaxonomySpec.validate_key_value_pairs(facet_str_pairs)
-        except KeyError:
-            self.diagnostics.append(
-                MissingFacet(
-                    f"{node['options']['name']}:{node['options']['values']}", line
+                taxonomy.TaxonomySpec.validate_key_value_pairs(facet_str_pairs)
+            except KeyError:
+                self.diagnostics.append(
+                    MissingFacet(
+                        f"{node['options']['name']}:{single_value}", line
+                    )
                 )
-            )
 
     def handle_tabset(self, node: n.Directive) -> None:
         tabset = node.options["tabset"]

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1650,10 +1650,10 @@ class FacetsHandler(Handler):
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "facet":
             return
-        
+
         facet_values = node.options["values"]
 
-        for facet_value in facet_values.split(','):
+        for facet_value in facet_values.split(","):
             facet_node = Facet(category=node.options["name"], value=facet_value.strip())
 
             if self.parent_stack:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1650,21 +1650,24 @@ class FacetsHandler(Handler):
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "facet":
             return
+        
+        facet_values = node.options["values"]
 
-        facet_node = Facet(category=node.options["name"], value=node.options["values"])
+        for facet_value in facet_values.split(','):
+            facet_node = Facet(category=node.options["name"], value=facet_value.strip())
 
-        if self.parent_stack:
-            parent = self.parent_stack[-1][0]
-            if parent.sub_facets is not None:
-                parent.sub_facets.append(facet_node)
-        else:
-            self.facets.append(facet_node)
+            if self.parent_stack:
+                parent = self.parent_stack[-1][0]
+                if parent.sub_facets is not None:
+                    parent.sub_facets.append(facet_node)
+            else:
+                self.facets.append(facet_node)
 
-        if node.children:
-            facet_node.sub_facets = []
-            num_children = len(node.children)
-            self.parent_stack.append((facet_node, num_children))
-        self.removal_nodes.append(node)
+            if node.children:
+                facet_node.sub_facets = []
+                num_children = len(node.children)
+                self.parent_stack.append((facet_node, num_children))
+            self.removal_nodes.append(node)
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "facet":

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1654,8 +1654,6 @@ class FacetsHandler(Handler):
         def get_children_total(
             child: n.Node,
         ) -> int:
-            if not isinstance(node, n.Directive) or node.name != "facet":
-                return 0
             return (
                 len(child.options["values"].split(","))
                 if hasattr(child, "options")

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3690,3 +3690,25 @@ def test_invalid_facets() -> None:
         diagnostic.message.find("target_product:dne") != -1
         for diagnostic in diagnostics
     )
+
+
+def test_valid_facets() -> None:
+    path = FileId("test.rst")
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. facet::
+    :name: target_product
+    :values: atlas
+
+    .. facet::
+        :name: sub_product
+        :values: charts, atlas-cli
+    """,
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 0

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3682,8 +3682,8 @@ def test_invalid_facets() -> None:
 """,
     )
     page.finish(diagnostics)
-    print(diagnostics)
     assert len(diagnostics) == 3
     assert isinstance(diagnostics[0], MissingFacet)
     assert isinstance(diagnostics[1], MissingFacet)
     assert isinstance(diagnostics[2], MissingFacet)
+    assert any(diagnostic.message.find('target_product:dne') != -1 for diagnostic in diagnostics)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3686,4 +3686,7 @@ def test_invalid_facets() -> None:
     assert isinstance(diagnostics[0], MissingFacet)
     assert isinstance(diagnostics[1], MissingFacet)
     assert isinstance(diagnostics[2], MissingFacet)
-    assert any(diagnostic.message.find('target_product:dne') != -1 for diagnostic in diagnostics)
+    assert any(
+        diagnostic.message.find("target_product:dne") != -1
+        for diagnostic in diagnostics
+    )

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2893,7 +2893,7 @@ def test_toml_facets() -> None:
       :values: v1.2
    .. facet::
       :name: sub_product
-      :values: charts
+      :values: charts,atlas-cli
 .. facet::
    :name: genre
    :values: tutorial
@@ -2941,6 +2941,7 @@ value = "test"
                     sub_facets=[
                         Facet(category="version", value="v1.2"),
                         Facet(category="sub_product", value="charts"),
+                        Facet(category="sub_product", value="atlas-cli"),
                     ],
                 ),
                 Facet(category="programming_language", value="shell"),

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2846,7 +2846,7 @@ Facets
     ) as result:
         page = result.pages[FileId("index.txt")]
         facets = page.facets
-        sortFn = (lambda facet: facet.category + facet.value)
+        sortFn = lambda facet: facet.category + facet.value
         assert facets is not None
         assert facets.sort(key=sortFn) == (
             [

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2820,13 +2820,10 @@ def test_facets() -> None:
             Path(
                 "source/index.txt"
             ): """
-.. facet::
-   :name: genre
-   :values: reference
 
 .. facet::
    :name: genre
-   :values: tutorial
+   :values: tutorial, reference
 
 .. facet::
    :name: target_product
@@ -2849,11 +2846,12 @@ Facets
     ) as result:
         page = result.pages[FileId("index.txt")]
         facets = page.facets
+        sortFn = (lambda facet: facet.category + facet.value)
         assert facets is not None
-        assert sorted(facets) == sorted(
+        assert facets.sort(key=sortFn) == (
             [
-                Facet(category="genre", value="reference"),
                 Facet(category="genre", value="tutorial"),
+                Facet(category="genre", value="reference"),
                 Facet(
                     category="target_product",
                     value="atlas",
@@ -2863,7 +2861,7 @@ Facets
                     ],
                 ),
             ]
-        )
+        ).sort(key=sortFn)
 
         check_ast_testing_string(
             page.ast,


### PR DESCRIPTION
**Context:** Currently, parser does not allow how to handle multiple facet values on a single ReST line.

This bug has been reported across different writers' PR's having warnings for multiple values on a single line:

See job logs for examples of `WARNING(data-api.txt:6ish): Facet specified is not a valid facet: programming_language:shell, json`
[cloud docs example here](https://github.com/10gen/cloud-docs/pull/4877)
[docs app services example here](https://github.com/mongodb/docs-app-services/pull/588)

**PR description:**
- parse `facet.values` for multiple string values separated by comma. construct multiple Facet objects from single line
- if a facet has a parent, assume this has only one value (as multiple children Facets cannot belong to same parent Facet)
- update unit tests to include multiple values in single line and add expected values