### PR TITLE
warning when containing sibling directives as subsection

### DIFF
--- a/snooty/tinydocutils/states.py
+++ b/snooty/tinydocutils/states.py
@@ -2358,7 +2358,7 @@ class Body(RSTState):
             self.memo.directive = directive_instance
             self.memo.parent_level = self.memo.section_level
             result = directive_instance.run()
-            self.memo.parent_level = self.memo.section_level
+            # self.memo.parent_level = self.memo.section_level
             
             # successfully parsed directive, set current level
             

--- a/snooty/tinydocutils/states.py
+++ b/snooty/tinydocutils/states.py
@@ -1088,6 +1088,7 @@ class RSTState(State):
         """
         memo = self.memo
         title_styles = memo.title_styles
+        
         mylevel = memo.section_level
         try:  # check for existing title style
             level = title_styles.index(style) + 1
@@ -1100,9 +1101,15 @@ class RSTState(State):
                 return False
         if level <= mylevel:  # sibling or supersection
             memo.section_level = level  # bubble up to parent section
+            
             if style.overline is not None:
                 memo.section_bubble_up_kludge = True
 
+            self.parent.append(self.reporter.warning(
+                "Directives cannot contain sections that are sibling to the parent directive's section",
+                line=lineno
+            ))
+            
             # back up 2 lines for underline title, 3 for overline title
             self.state_machine.previous_line(style.length() + 1)
             raise EOFError  # let parent section re-evaluate

--- a/snooty/tinydocutils/states.py
+++ b/snooty/tinydocutils/states.py
@@ -1088,7 +1088,7 @@ class RSTState(State):
         """
         memo = self.memo
         title_styles = memo.title_styles
-        
+
         mylevel = memo.section_level
         try:  # check for existing title style
             level = title_styles.index(style) + 1
@@ -1101,15 +1101,17 @@ class RSTState(State):
                 return False
         if level <= mylevel:  # sibling or supersection
             memo.section_level = level  # bubble up to parent section
-            
+
             if style.overline is not None:
                 memo.section_bubble_up_kludge = True
 
-            self.parent.append(self.reporter.warning(
-                "Directives cannot contain sections that are sibling to the parent directive's section",
-                line=lineno
-            ))
-            
+            self.parent.append(
+                self.reporter.warning(
+                    "Directives cannot contain sections that are sibling to the parent directive's section",
+                    line=lineno,
+                )
+            )
+
             # back up 2 lines for underline title, 3 for overline title
             self.state_machine.previous_line(style.length() + 1)
             raise EOFError  # let parent section re-evaluate


### PR DESCRIPTION
[DOP-3969](https://jira.mongodb.org/browse/DOP-3969)

Adds warning when a sibling subsection is encountered during parsing.