### PR TITLE
DOP-4070: Automatically find a viable cache file from a given URL prefix

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1749,7 +1749,7 @@ class _Project:
     def load_cache(self) -> None:
         self.cache = self.cache_file.read()
 
-    def update_cache(self, optimize: bool = False) -> None:
+    def update_cache(self, optimize: bool = True) -> None:
         cache = parse_cache.CacheData(self.cache_file.generate_specifier(), {})
         self.pages.add_to_cache(cache)
         self.cache_file.persist(cache, optimize=optimize)
@@ -1883,7 +1883,7 @@ class Project:
         with self._lock:
             self._project.load_cache()
 
-    def update_cache(self, optimize: bool = False) -> None:
+    def update_cache(self, optimize: bool = True) -> None:
         with self._lock:
             self._project.update_cache(optimize)
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -3,6 +3,9 @@ data_fields = ["source_page_template", "assets"]
 [meta]
 version = 0
 
+[build]
+cache_url_prefix = "https://snooty-parse-cache.s3.us-east-2.amazonaws.com/"
+
 [enum]
 alignment = ["left", "center", "right"]
 backlinks = ["entry", "top", "none"]
@@ -583,8 +586,8 @@ content_type = "block"
 argument_type = "string"
 example = """ .. landing:explore:: Explore the Document Model
 
-   MongoDB is a flexible, schema-less NoSQL database. 
-   It stores data as JSON-like documents, enabling nested structures, 
+   MongoDB is a flexible, schema-less NoSQL database.
+   It stores data as JSON-like documents, enabling nested structures,
    easy scalability, and efficient querying for modern applications.
 
    .. button:: Launch Interactive Lab
@@ -592,7 +595,7 @@ example = """ .. landing:explore:: Explore the Document Model
 
    .. code-block:: python
       :copyable: true
-      
+
       import datetime
       personDocument = {
          "name": { "first": "Alan", "last": "Turing" },

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -260,10 +260,17 @@ class RstObject:
 
 @checked
 @dataclass
+class BuildSettings:
+    cache_url_prefix: Optional[str] = field(default=None)
+
+
+@checked
+@dataclass
 class Spec:
     """The spec root."""
 
     meta: Meta
+    build: BuildSettings = field(default_factory=BuildSettings)
     enum: Dict[str, List[str]] = field(default_factory=dict)
     directive: Dict[str, Directive] = field(default_factory=dict)
     role: Dict[str, Role] = field(default_factory=dict)

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -645,7 +645,8 @@ def structural_hash(obj: object) -> bytes:
     are subject to change and are not stable across releases.
 
     Fields in dataclasses with metadata value of "nohash" are skipped."""
-    hasher = hashlib.blake2b()
+    # blake2b160 should be more than enough
+    hasher = hashlib.blake2b(digest_size=20)
     if isinstance(obj, (int, str, float, PurePath)):
         hasher.update(bytes("P" + str(obj), "utf-8"))
     elif dataclasses.is_dataclass(obj):


### PR DESCRIPTION
We also gzip the cache files. Decompression of our largest file (Atlas) takes 100-200 milliseconds, but I judge it worthwhile for storage and bandwidth savings. In the future, switching to zstd would be worth it, but we don't need to think about that right now.

We also turn on pickle optimization by default to recoup some of that time cost.