### PR TITLE
Use os._exit() to exit quickly once we've finished our work

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -330,8 +330,10 @@ def main() -> None:
     finally:
         backend.close()
 
+    exit_code = 0
     if args["build"] and backend.total_errors > 0:
         exit_code = (
             1 if project.config.fail_on_diagnostics else EXIT_STATUS_ERROR_DIAGNOSTICS
         )
-        sys.exit(exit_code)
+
+    os._exit(exit_code)


### PR DESCRIPTION
This saves a significant amount of time (5.5 seconds on my laptop) for some reason. There must be a number of atexit() handlers or something, but we've already flushed our output artifacts and child processes can exit asynchronously once their pipes are closed.

I don't love doing this, but it's required to meet our benchmark targets in lieu of some extended investigation that may or may not even be actionable