### PR TITLE
add link role for mongodb university courses

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1609,6 +1609,10 @@ type = {link = "https://www.mongodb.com/docs/atlas/cli/stable%s", ensure_trailin
 help = """Link to the MongoDB Analyzer documentation."""
 type = {link = "https://www.mongodb.com/docs/mongodb-analyzer%s", ensure_trailing_slash = true}
 
+[role."mdbu-course"]
+help = """Link to a MongoDB University course."""
+type = {link = "https://learn.mongodb.com/courses%s"}
+
 ### Types of objects (directive & role pairs)
 [rstobject."py:class"]
 


### PR DESCRIPTION
working on https://jira.mongodb.org/browse/DOCSP-33799 I noticed that we didn't have a shared role for adding links to mongodb university courses.