### PR TITLE
:loud_sound: DOP-3898 adds warning message for invalid nesting of tabs

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -295,7 +295,7 @@ class InvalidNestedTabStructure(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ) -> None:
         super().__init__(
-            f"""Invalid nested tabs: "{name}" """,
+            f"""Detect tabs that contain tabs that contain procedures: : "{name}" """,
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -284,6 +284,22 @@ class ConstantNotDeclared(Diagnostic):
 class InvalidTableStructure(Diagnostic):
     severity = Diagnostic.Level.error
 
+class InvalidNestedTabStructure(Diagnostic):
+    severity = Diagnostic.Level.warning
+
+    def __init__(
+        self,
+        name: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
+        super().__init__(
+            f"""Invalid nested tabs: "{name}" """,
+            start,
+            end,
+        )
+        self.name = name
+
 
 class MissingOption(Diagnostic):
     severity = Diagnostic.Level.error

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -284,6 +284,7 @@ class ConstantNotDeclared(Diagnostic):
 class InvalidTableStructure(Diagnostic):
     severity = Diagnostic.Level.error
 
+
 class InvalidNestedTabStructure(Diagnostic):
     severity = Diagnostic.Level.warning
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -555,7 +555,6 @@ class TabsSelectorHandler(Handler):
         if not isinstance(node, n.Directive):
             return
 
-        self.scan_for_pattern(fileid_stack, node)
         self.scanned_pattern = []
         self.stack.append(node.name)
 
@@ -602,11 +601,11 @@ class TabsSelectorHandler(Handler):
         self.selectors = {}
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        if len(self.selectors) == 0:
-            return
-
         self.stack = []
         self.scanned_pattern = []
+
+        if len(self.selectors) == 0:
+            return
 
         for tabset_name, tabsets in self.selectors.items():
             if len(tabsets) == 0:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -555,7 +555,9 @@ class TabsSelectorHandler(Handler):
         if not isinstance(node, n.Directive):
             return
 
-        self.scanned_pattern = []
+        self.scan_for_pattern(fileid_stack, node)
+        if len(self.scanned_pattern) > 0:
+            self.scanned_pattern = []
         self.stack.append(node.name)
 
         if node.name == "tabs-pillstrip" or node.name == "tabs-selector":

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -533,8 +533,8 @@ class TabsSelectorHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
-        self.stack = []
-        self.scanned_pattern = []
+        self.stack: List[str] = []
+        self.scanned_pattern: List[str] = []
 
     def scan_for_pattern(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         starting_point = 0

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -603,11 +603,12 @@ class TabsSelectorHandler(Handler):
 
 
 
-
-
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         if len(self.selectors) == 0:
             return
+
+        self.stack = []
+        self.scanned_pattern = []
         
 
         for tabset_name, tabsets in self.selectors.items():

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -535,27 +535,28 @@ class TabsSelectorHandler(Handler):
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
         self.stack = []
         self.scanned_pattern = []
-    
+
     def scan_for_pattern(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         starting_point = 0
-        target_pattern = ['tabs', 'tabs', 'procedure']
+        target_pattern = ["tabs", "tabs", "procedure"]
         target_pattern_len = len(target_pattern)
-        if(len(self.scanned_pattern) > 0):
+        if len(self.scanned_pattern) > 0:
             reverse_list = reversed(self.scanned_pattern)
             for item in reverse_list:
-                if(item == target_pattern[starting_point]):
+                if item == target_pattern[starting_point]:
                     starting_point += 1
-                if(starting_point >= target_pattern_len):
+                if starting_point >= target_pattern_len:
                     self.context.diagnostics[fileid_stack.current].append(
-                        InvalidNestedTabStructure(' '.join(reversed(self.scanned_pattern)), node.start[0])
+                        InvalidNestedTabStructure(
+                            " ".join(reversed(self.scanned_pattern)), node.start[0]
+                        )
                     )
                     return
-               
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
             return
-        
+
         self.scan_for_pattern(fileid_stack, node)
         self.scanned_pattern = []
         self.stack.append(node.name)
@@ -594,14 +595,12 @@ class TabsSelectorHandler(Handler):
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
             return
-        
+
         popped_item = self.stack.pop()
         self.scanned_pattern.append(popped_item)
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.selectors = {}
-
-
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         if len(self.selectors) == 0:
@@ -609,7 +608,6 @@ class TabsSelectorHandler(Handler):
 
         self.stack = []
         self.scanned_pattern = []
-        
 
         for tabset_name, tabsets in self.selectors.items():
             if len(tabsets) == 0:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -545,7 +545,9 @@ class TabsSelectorHandler(Handler):
                     starting_point += 1
                 if starting_point >= target_pattern_len:
                     self.context.diagnostics[fileid_stack.current].append(
-                        InvalidNestedTabStructure(" ".join(self.scanned_pattern), node.start[0])
+                        InvalidNestedTabStructure(
+                            " ".join(self.scanned_pattern), node.start[0]
+                        )
                     )
                     self.scanned_pattern = []
                     return
@@ -590,13 +592,12 @@ class TabsSelectorHandler(Handler):
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
             return
-        
+
         if node.name == "procedure":
             self.scan_for_pattern(fileid_stack, node)
-        
+
         if len(self.scanned_pattern) > 0:
             self.scanned_pattern.pop()
-
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.selectors = {}

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -533,7 +533,6 @@ class TabsSelectorHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
-        self.stack: List[str] = []
         self.scanned_pattern: List[str] = []
         self.target_pattern = ["tabs", "tabs", "procedure"]
 
@@ -541,24 +540,21 @@ class TabsSelectorHandler(Handler):
         starting_point = 0
         target_pattern_len = len(self.target_pattern)
         if len(self.scanned_pattern) > 0:
-            reverse_list = list(reversed(self.scanned_pattern))
-            for item in reverse_list:
+            for item in self.scanned_pattern:
                 if item == self.target_pattern[starting_point]:
                     starting_point += 1
                 if starting_point >= target_pattern_len:
                     self.context.diagnostics[fileid_stack.current].append(
-                        InvalidNestedTabStructure(" ".join(reverse_list), node.start[0])
+                        InvalidNestedTabStructure(" ".join(self.scanned_pattern), node.start[0])
                     )
+                    self.scanned_pattern = []
                     return
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
             return
 
-        self.scan_for_pattern(fileid_stack, node)
-        if len(self.scanned_pattern) > 0:
-            self.scanned_pattern = []
-        self.stack.append(node.name)
+        self.scanned_pattern.append(node.name)
 
         if node.name == "tabs-pillstrip" or node.name == "tabs-selector":
             if len(node.argument) == 0:
@@ -594,16 +590,18 @@ class TabsSelectorHandler(Handler):
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
             return
+        
+        if node.name == "procedure":
+            self.scan_for_pattern(fileid_stack, node)
+        
+        if len(self.scanned_pattern) > 0:
+            self.scanned_pattern.pop()
 
-        popped_item = self.stack.pop()
-        self.scanned_pattern.append(popped_item)
-        self.scan_for_pattern(fileid_stack, node)
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.selectors = {}
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        self.stack = []
         self.scanned_pattern = []
 
         if len(self.selectors) == 0:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -549,7 +549,6 @@ class TabsSelectorHandler(Handler):
                             " ".join(self.scanned_pattern), node.start[0]
                         )
                     )
-                    self.scanned_pattern = []
                     return
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
@@ -596,8 +595,7 @@ class TabsSelectorHandler(Handler):
         if node.name == "procedure":
             self.scan_for_pattern(fileid_stack, node)
 
-        if len(self.scanned_pattern) > 0:
-            self.scanned_pattern.pop()
+        self.scanned_pattern.pop()
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.selectors = {}

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -50,6 +50,7 @@ from .diagnostics import (
     InvalidIAEntry,
     InvalidIALinkedData,
     InvalidInclude,
+    InvalidNestedTabStructure,
     InvalidOpenApiResponse,
     InvalidTocTree,
     InvalidVersion,
@@ -532,10 +533,32 @@ class TabsSelectorHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
+        self.stack = []
+        self.scanned_pattern = []
+    
+    def scan_for_pattern(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        starting_point = 0
+        target_pattern = ['tabs', 'tabs', 'procedure']
+        target_pattern_len = len(target_pattern)
+        if(len(self.scanned_pattern) > 0):
+            reverse_list = reversed(self.scanned_pattern)
+            for item in reverse_list:
+                if(item == target_pattern[starting_point]):
+                    starting_point += 1
+                if(starting_point >= target_pattern_len):
+                    self.context.diagnostics[fileid_stack.current].append(
+                        InvalidNestedTabStructure(' '.join(reversed(self.scanned_pattern)), node.start[0])
+                    )
+                    return
+               
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
             return
+        
+        self.scan_for_pattern(fileid_stack, node)
+        self.scanned_pattern = []
+        self.stack.append(node.name)
 
         if node.name == "tabs-pillstrip" or node.name == "tabs-selector":
             if len(node.argument) == 0:
@@ -568,12 +591,24 @@ class TabsSelectorHandler(Handler):
             }
             self.selectors[tabset_name].append(tabs)
 
+    def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if not isinstance(node, n.Directive):
+            return
+        
+        popped_item = self.stack.pop()
+        self.scanned_pattern.append(popped_item)
+
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.selectors = {}
+
+
+
+
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         if len(self.selectors) == 0:
             return
+        
 
         for tabset_name, tabsets in self.selectors.items():
             if len(tabsets) == 0:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -535,21 +535,19 @@ class TabsSelectorHandler(Handler):
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
         self.stack: List[str] = []
         self.scanned_pattern: List[str] = []
+        self.target_pattern = ["tabs", "tabs", "procedure"]
 
     def scan_for_pattern(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         starting_point = 0
-        target_pattern = ["tabs", "tabs", "procedure"]
-        target_pattern_len = len(target_pattern)
+        target_pattern_len = len(self.target_pattern)
         if len(self.scanned_pattern) > 0:
-            reverse_list = reversed(self.scanned_pattern)
+            reverse_list = list(reversed(self.scanned_pattern))
             for item in reverse_list:
-                if item == target_pattern[starting_point]:
+                if item == self.target_pattern[starting_point]:
                     starting_point += 1
                 if starting_point >= target_pattern_len:
                     self.context.diagnostics[fileid_stack.current].append(
-                        InvalidNestedTabStructure(
-                            " ".join(reversed(self.scanned_pattern)), node.start[0]
-                        )
+                        InvalidNestedTabStructure(" ".join(reverse_list), node.start[0])
                     )
                     return
 
@@ -598,6 +596,7 @@ class TabsSelectorHandler(Handler):
 
         popped_item = self.stack.pop()
         self.scanned_pattern.append(popped_item)
+        self.scan_for_pattern(fileid_stack, node)
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.selectors = {}

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -90,6 +90,30 @@ def test_tabs_contain_tabs_contain_procedures() -> None:
 
 """,
             Path(
+                "source/page2.txt"
+            ): """
+.. tabs-platforms::
+
+   .. tab::
+      :tabid: windows
+
+      Select the appropriate tab based on your Linux distribution and
+      desired package from the tabs below:
+
+      .. tabs::
+
+         .. tab::
+            :tabid: homebrew
+
+            .. include:: /includes/test.rst
+
+             To manually install :binary:`mongosh` using a downloaded ``.zip``
+
+            .. procedure::
+
+
+""",
+            Path(
                 "source/includes/test.rst"
             ): """
 :option:`--verbose`
@@ -101,6 +125,10 @@ def test_tabs_contain_tabs_contain_procedures() -> None:
         }
     ) as result:
         diagnostics = result.diagnostics[FileId("page1.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], InvalidNestedTabStructure)
+
+        diagnostics = result.diagnostics[FileId("page2.txt")]
         assert len(diagnostics) == 1
         assert isinstance(diagnostics[0], InvalidNestedTabStructure)
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -114,6 +114,31 @@ def test_tabs_contain_tabs_contain_procedures() -> None:
 
 """,
             Path(
+                "source/page3.txt"
+            ): """
+.. tabs-platforms::
+
+   .. tab::
+      :tabid: windows
+
+      .. tabs::
+
+         .. tab::
+            :tabid: homebrew
+
+            .. procedure::
+
+               .. step::
+
+                  foo
+
+            .. note::
+
+               Wow
+
+
+""",
+            Path(
                 "source/includes/test.rst"
             ): """
 :option:`--verbose`

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -136,6 +136,18 @@ def test_tabs_contain_tabs_contain_procedures() -> None:
 
                Wow
 
+         .. tab::
+            :tabid: oh yeah
+
+            .. procedure::
+
+            .. tabs::
+
+               .. tab::
+                  :tabid: homebrew
+
+                  .. procedure::
+
 
 """,
             Path(
@@ -158,8 +170,10 @@ def test_tabs_contain_tabs_contain_procedures() -> None:
         assert isinstance(diagnostics[0], InvalidNestedTabStructure)
 
         diagnostics = result.diagnostics[FileId("page3.txt")]
-        assert len(diagnostics) == 1
+        assert len(diagnostics) == 3
         assert isinstance(diagnostics[0], InvalidNestedTabStructure)
+        assert isinstance(diagnostics[1], InvalidNestedTabStructure)
+        assert isinstance(diagnostics[2], InvalidNestedTabStructure)
 
 
 def test_ia() -> None:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -157,6 +157,10 @@ def test_tabs_contain_tabs_contain_procedures() -> None:
         assert len(diagnostics) == 1
         assert isinstance(diagnostics[0], InvalidNestedTabStructure)
 
+        diagnostics = result.diagnostics[FileId("page3.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], InvalidNestedTabStructure)
+
 
 def test_ia() -> None:
     with make_test(


### PR DESCRIPTION
The implementation within this PR focuses on detecting tabs that contain tabs that contain procedures. 

Some examples are

```
.. tabs::

   .. tab::

      .. tabs::

         .. tab

            .. include:: /includes/fact-a-procedure.rst
```

The modification happens in the `TabsSelectorHandler` class. The approach is as follows

Create two new stacks. When you enter a node first scan the pattern stack (holds the possible invalid patterns) and then append that node to the stack which acts as a container for all nodes, and when you exit a node pop the item off of that container stack, and when you exit a page clear the stacks altogether. 

This should only happen when entering a directive node.

## Possible Patterns (as examples):

1. `tabs > tab > include > tabs > tab > include > procedure`
2. `tabs > tab > tabs > tab > procedure`
3. `tabs > tab > section > tabs > tab > include > section > procedure`

With this new implementation we wanted to capture if there was any performance hit, so captured a before and after measurement. 

**before**

```
parse rst      1.02
copy           0.04
postprocessing 0.21
commit         0.00
serialization  0.06
```

**after**

```
parse rst      1.03
copy           0.05
postprocessing 0.22
commit         0.00
serialization  0.06
```
