### PR TITLE
DOP-4141: Catch TOML parsing errors in snooty.toml

### DIFF
--- a/snooty/test_util.py
+++ b/snooty/test_util.py
@@ -248,3 +248,13 @@ def test_structural_hash() -> None:
             set(),
         )
     )
+
+
+def test_toml_exception_to_source_info() -> None:
+    with pytest.raises(util.TOMLDecodeErrorWithSourceInfo) as exception:
+        util.parse_toml_and_add_line_info("\n\x00")
+    assert exception.value.lineno == 2
+
+    with pytest.raises(util.TOMLDecodeErrorWithSourceInfo) as exception:
+        util.parse_toml_and_add_line_info("[constants]\n\nfoo=5\nfoo=10")
+    assert exception.value.lineno == 4

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -247,7 +247,7 @@ class ProjectConfig:
                 pass
             except util.TOMLDecodeErrorWithSourceInfo as err:
                 diagnostics.append(UnmarshallingError(str(err), err.lineno))
-            except (LoadError, tomli.TOMLDecodeError) as err:
+            except LoadError as err:
                 diagnostics.append(UnmarshallingError(str(err), 0))
 
             path = path.parent

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -19,7 +19,7 @@ from typing import (
 import tomli
 from typing_extensions import Protocol
 
-from . import n, specparser, taxonomy
+from . import n, specparser, taxonomy, util
 from .diagnostics import (
     CannotOpenFile,
     ConstantNotDeclared,
@@ -233,19 +233,21 @@ class ProjectConfig:
         diagnostics: List[Diagnostic] = []
         while path.parent != path:
             try:
-                with path.joinpath("snooty.toml").open("rb") as f:
-                    data = tomli.load(f)
-                    data["root"] = path
-                    result, parsed_diagnostics = check_type(
-                        ProjectConfig, data
-                    ).render_constants()
+                toml_text = path.joinpath("snooty.toml").read_text()
+                data = util.parse_toml_and_add_line_info(toml_text)
+                data["root"] = path
+                result, parsed_diagnostics = check_type(
+                    ProjectConfig, data
+                ).render_constants()
 
-                    parsed_diagnostics.extend(cls.validate_data(result.data))
+                parsed_diagnostics.extend(cls.validate_data(result.data))
 
-                    return result, parsed_diagnostics
+                return result, parsed_diagnostics
             except FileNotFoundError:
                 pass
-            except LoadError as err:
+            except util.TOMLDecodeErrorWithSourceInfo as err:
+                diagnostics.append(UnmarshallingError(str(err), err.lineno))
+            except (LoadError, tomli.TOMLDecodeError) as err:
                 diagnostics.append(UnmarshallingError(str(err), 0))
 
             path = path.parent


### PR DESCRIPTION
Additionally make snooty.toml parsing errors generally fatal, rather than continuing with a blank project configuration.