### PR TITLE
Update Realm SDK role URI

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1461,7 +1461,7 @@ type = {link = "https://github.com/mongodb/specifications/blob/master/source%s"}
 type = {link = "https://www.mongodb.com/docs/realm-sdks/js/latest/%s"}
 
 [role."realm-react-sdk"]
-type = {link = "https://www.mongodb.com/docs/realm-sdks/js/realm-react/latest/%s"}
+type = {link = "https://www.mongodb.com/docs/realm-sdks/react/latest/%s"}
 
 [role."js-web-sdk"]
 type = {link = "https://www.mongodb.com/docs/realm-sdks/js/realm-web/latest/%s"}


### PR DESCRIPTION
The URI for the latest `@realm/react` API docs has changed since I added this role. It's a tiny update, but an important one. 😄 