### PR TITLE
Hotfix: use utf8 encoding when reading toml text

### DIFF
--- a/snooty/test_project.py
+++ b/snooty/test_project.py
@@ -331,6 +331,20 @@ def test_invalid_data() -> None:
             pass
 
 
+def test_invalid_char() -> None:
+    with make_test_project(
+        {
+            Path(
+                "snooty.toml"
+            ): r"""
+name = "invalid–hyphen"
+""",
+            Path("source/index.txt"): r"",
+        }
+    ) as (_project, backend):
+        assert _project.config.name == "invalid–hyphen"
+
+
 def test_duplicate_constant() -> None:
     """Ensure that invalid TOML in snooty.toml results in a nice fatal diagnostic rather
     than a backtrace."""

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -233,7 +233,7 @@ class ProjectConfig:
         diagnostics: List[Diagnostic] = []
         while path.parent != path:
             try:
-                toml_text = path.joinpath("snooty.toml").read_text()
+                toml_text = path.joinpath("snooty.toml").read_text(encoding="utf-8")
                 data = util.parse_toml_and_add_line_info(toml_text)
                 data["root"] = path
                 result, parsed_diagnostics = check_type(


### PR DESCRIPTION
Added a small change to enforce UTF-8 encoding when reading snooty.toml files.

Added a test to ensure this scenario is handled across different environments / machines