### PR TITLE
0.15.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.15.2] - 2024-01-01
+## [v0.15.2] - 2024-01-02
 
 ### Changed
 
@@ -183,10 +183,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.13.13] - 2022-11-16
 
-* Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
-* DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
-* DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
-* DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
+- Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
+- DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
+- DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
+- DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
 
 ## [v0.13.12] - 2022-10-19
 
@@ -241,15 +241,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--  Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
--  Rename "Realm" to "App Services" in tabsets (#405)
--  Validate relative URLs in card directives (DOP-3064, #408)
+- Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
+- Rename "Realm" to "App Services" in tabsets (#405)
+- Validate relative URLs in card directives (DOP-3064, #408)
 
 ### Fixed
 
--  Fix upsert logic and added manifest testing (#400).
--  Expand tildes in paths input on the command line (DOP-3078, #409)
--  Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
+- Fix upsert logic and added manifest testing (#400).
+- Expand tildes in paths input on the command line (DOP-3078, #409)
+- Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
 
 ## [v0.13.5] - 2022-05-19
 
@@ -690,7 +690,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Extlinks should use the target name for label if no label set, *not* the raw uri (DOP-1581).
+- Extlinks should use the target name for label if no label set, _not_ the raw uri (DOP-1581).
 - RFC link labels now match legacy (DOP-1581).
 - Render role content when target is not found (DOP-1601).
 - Bump `node` extlink version (DOCSP-12335).
@@ -1290,6 +1290,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only match PAT_EXPLICIT_TILE if needed by role.
 
   Roles are now categorized in one of three ways:
+
   - `text` roles only provide a label field in the AST.
   - `explicit_title` roles provide a target field in the AST, as well as
     optionally a label field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.15.2] - 2024-01-01
+
+### Changed
+
+- The parser will now accept the `--no-caching` flag when creating a cache (#544).
+- Use UTF-8 encoding when reading TOML text (#545).
+
 ## [v0.15.1] - 2023-12-13
 
 ### Changed
@@ -133,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switch from flit to poetry by @i80and in https://github.com/mongodb/snooty-parser/pull/427
 - DOP-3487: Deprecate cssclass directive by @i80and in https://github.com/mongodb/snooty-parser/pull/443
-- DOP-3211:  ref label by @mmeigs in https://github.com/mongodb/snooty-parser/pull/444
+- DOP-3211: ref label by @mmeigs in https://github.com/mongodb/snooty-parser/pull/444
 - Cleanup: use a type for associated products rather than Dict[str, object] by @i80and in https://github.com/mongodb/snooty-parser/pull/446
 - Make bump_version.py also bump the version in pyproject.toml by @i80and in https://github.com/mongodb/snooty-parser/pull/445
 
@@ -176,10 +183,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.13.13] - 2022-11-16
 
-* Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
-* DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
-* DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
-* DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
+- Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
+- DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
+- DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
+- DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
 
 ## [v0.13.12] - 2022-10-19
 
@@ -234,15 +241,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--  Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
--  Rename "Realm" to "App Services" in tabsets (#405)
--  Validate relative URLs in card directives (DOP-3064, #408)
+- Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
+- Rename "Realm" to "App Services" in tabsets (#405)
+- Validate relative URLs in card directives (DOP-3064, #408)
 
 ### Fixed
 
--  Fix upsert logic and added manifest testing (#400).
--  Expand tildes in paths input on the command line (DOP-3078, #409)
--  Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
+- Fix upsert logic and added manifest testing (#400).
+- Expand tildes in paths input on the command line (DOP-3078, #409)
+- Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
 
 ## [v0.13.5] - 2022-05-19
 
@@ -683,7 +690,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Extlinks should use the target name for label if no label set, *not* the raw uri (DOP-1581).
+- Extlinks should use the target name for label if no label set, _not_ the raw uri (DOP-1581).
 - RFC link labels now match legacy (DOP-1581).
 - Render role content when target is not found (DOP-1601).
 - Bump `node` extlink version (DOCSP-12335).
@@ -1283,6 +1290,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only match PAT_EXPLICIT_TILE if needed by role.
 
   Roles are now categorized in one of three ways:
+
   - `text` roles only provide a label field in the AST.
   - `explicit_title` roles provide a target field in the AST, as well as
     optionally a label field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,10 +183,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.13.13] - 2022-11-16
 
-- * Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
-- * DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
-- * DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
-- * DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
+* Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
+* DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
+* DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
+* DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
 
 ## [v0.13.12] - 2022-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,10 +183,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.13.13] - 2022-11-16
 
-- Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
-- DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
-- DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
-- DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
+* Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
+* DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
+* DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
+* DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
 
 ## [v0.13.12] - 2022-10-19
 
@@ -241,15 +241,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
-- Rename "Realm" to "App Services" in tabsets (#405)
-- Validate relative URLs in card directives (DOP-3064, #408)
+-  Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
+-  Rename "Realm" to "App Services" in tabsets (#405)
+-  Validate relative URLs in card directives (DOP-3064, #408)
 
 ### Fixed
 
-- Fix upsert logic and added manifest testing (#400).
-- Expand tildes in paths input on the command line (DOP-3078, #409)
-- Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
+-  Fix upsert logic and added manifest testing (#400).
+-  Expand tildes in paths input on the command line (DOP-3078, #409)
+-  Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
 
 ## [v0.13.5] - 2022-05-19
 
@@ -690,7 +690,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Extlinks should use the target name for label if no label set, _not_ the raw uri (DOP-1581).
+- Extlinks should use the target name for label if no label set, *not* the raw uri (DOP-1581).
 - RFC link labels now match legacy (DOP-1581).
 - Render role content when target is not found (DOP-1601).
 - Bump `node` extlink version (DOCSP-12335).
@@ -1290,7 +1290,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only match PAT_EXPLICIT_TILE if needed by role.
 
   Roles are now categorized in one of three ways:
-
   - `text` roles only provide a label field in the AST.
   - `explicit_title` roles provide a target field in the AST, as well as
     optionally a label field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,10 +183,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.13.13] - 2022-11-16
 
-- Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
-- DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
-- DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
-- DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
+- * Update GitHub actions by @i80and in https://github.com/mongodb/snooty-parser/pull/424
+- * DOP-3159: README overhaul by @seungpark in https://github.com/mongodb/snooty-parser/pull/425
+- * DOP-3307: Generate metadata for OpenAPI content pages by @rayangler in https://github.com/mongodb/snooty-parser/pull/426
+- * DOP-3353: Change OpenAPI metadata source to be spec string by @rayangler in https://github.com/mongodb/snooty-parser/pull/428
 
 ## [v0.13.12] - 2022-10-19
 
@@ -241,15 +241,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
-- Rename "Realm" to "App Services" in tabsets (#405)
-- Validate relative URLs in card directives (DOP-3064, #408)
+-  Added new link roles and mongosyncstate rstobject (#401, #402, #403, #404)
+-  Rename "Realm" to "App Services" in tabsets (#405)
+-  Validate relative URLs in card directives (DOP-3064, #408)
 
 ### Fixed
 
-- Fix upsert logic and added manifest testing (#400).
-- Expand tildes in paths input on the command line (DOP-3078, #409)
-- Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
+-  Fix upsert logic and added manifest testing (#400).
+-  Expand tildes in paths input on the command line (DOP-3078, #409)
+-  Properly handle rst source files with invalid UTF-8 (DOP-3068, #410)
 
 ## [v0.13.5] - 2022-05-19
 
@@ -690,7 +690,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Extlinks should use the target name for label if no label set, _not_ the raw uri (DOP-1581).
+- Extlinks should use the target name for label if no label set, *not* the raw uri (DOP-1581).
 - RFC link labels now match legacy (DOP-1581).
 - Render role content when target is not found (DOP-1601).
 - Bump `node` extlink version (DOCSP-12335).
@@ -1290,7 +1290,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only match PAT_EXPLICIT_TILE if needed by role.
 
   Roles are now categorized in one of three ways:
-
   - `text` roles only provide a label field in the AST.
   - `explicit_title` roles provide a target field in the AST, as well as
     optionally a label field.

--- a/snooty/__init__.py
+++ b/snooty/__init__.py
@@ -1,3 +1,3 @@
 """The Snooty documentation writer's tool."""
 
-__version__ = "0.15.1.dev"
+__version__ = "0.15.2"


### PR DESCRIPTION
Creating a new release commit to unblock [DOP-4170](https://jira.mongodb.org/browse/DOP-4170) by allowing the `--no-caching` flag to be provided to the `create-cache` command.