### PR TITLE
DOP-4207: preserve user width if specified

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -161,8 +161,14 @@ class PendingFigure(PendingTask):
             options["checksum"] = checksum
             dimensions = self.asset.dimensions
             if dimensions is not None:
-                options["width"] = str(dimensions[0])
-                options["height"] = str(dimensions[1])
+                user_width = options.get("width")
+                if user_width is None:
+                    options["width"] = str(dimensions[0])
+                    options["height"] = str(dimensions[1])
+                else:
+                    options["height"] = str(
+                        dimensions[1] * float(user_width) / dimensions[0]
+                    )
             cache[(self.asset.fileid, 0)] = checksum
         except OSError as err:
             diagnostics.append(

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -97,6 +97,7 @@ from .util import RST_EXTENSIONS
 
 NO_CHILDREN = (n.SubstitutionReference,)
 MULTIPLE_FORWARD_SLASHES = re.compile(r"([\/])\1")
+NON_DIGITS = re.compile(r"\D+")
 NO_AMBIGUOUS_LITERAL_DIAGNOSTICS = (
     os.environ.get("SNOOTY_NO_AMBIGUOUS_LITERAL_DIAGNOSTICS", "0") == "1"
 )
@@ -166,7 +167,7 @@ class PendingFigure(PendingTask):
                     options["width"] = str(dimensions[0])
                     options["height"] = str(dimensions[1])
                 else:
-                    width_num = float(re.sub(r"\D+", "", user_width))
+                    width_num = float(NON_DIGITS.sub("", user_width))
                     options["height"] = str(dimensions[1] * width_num / dimensions[0])
             cache[(self.asset.fileid, 0)] = checksum
         except OSError as err:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -166,9 +166,8 @@ class PendingFigure(PendingTask):
                     options["width"] = str(dimensions[0])
                     options["height"] = str(dimensions[1])
                 else:
-                    options["height"] = str(
-                        dimensions[1] * float(user_width) / dimensions[0]
-                    )
+                    width_num = float(re.sub(r"\D+", "", user_width))
+                    options["height"] = str(dimensions[1] * width_num / dimensions[0])
             cache[(self.asset.fileid, 0)] = checksum
         except OSError as err:
             diagnostics.append(

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1958,7 +1958,7 @@ def test_figure() -> None:
 .. figure:: /test_parser/sample.png
    :alt: sample png
    :figwidth: 100
-   :width: 100
+   :width: 90
    :scale: 1
    :align: left
    :lightbox:
@@ -1974,7 +1974,7 @@ def test_figure() -> None:
         """
 <root fileid="test.rst">
     <directive name="figure" alt="sample png" checksum="af4fbbc65c96b5c8f6f299769e2783b4ab7393f047debc00ffae772b9c5a7665"
-        align="left" border="True" class="class" figwidth="100" lightbox="True" scale="1" width="100.0" height="100.0">
+        align="left" border="True" class="class" figwidth="100" lightbox="True" scale="1" width="90" height="90.0">
         <text>/test_parser/sample.png</text>
     </directive>
 </root>""",

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -1,5 +1,5 @@
 from pathlib import Path, PurePath
-from typing import cast, Tuple
+from typing import Tuple, cast
 
 from .n import FileId
 from .page import Page


### PR DESCRIPTION
Previous PR overwrote user defined widths if they were supplied.

This PR addresses this so that images' and figures' option for width is preserved.

See updated test case to see the preservation in width/height ratio as well.