### PR TITLE
DOP-4207: remove warning for svgs

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -161,8 +161,14 @@ class PendingFigure(PendingTask):
             options["checksum"] = checksum
             dimensions = self.asset.dimensions
             if dimensions is not None:
-                options["width"] = str(dimensions[0])
-                options["height"] = str(dimensions[1])
+                user_width = options.get("width")
+                if user_width is None:
+                    options["width"] = str(dimensions[0])
+                    options["height"] = str(dimensions[1])
+                else:
+                    options["height"] = str(
+                        dimensions[1] * float(user_width) / dimensions[0]
+                    )
             cache[(self.asset.fileid, 0)] = checksum
         except OSError as err:
             diagnostics.append(

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -97,6 +97,7 @@ from .util import RST_EXTENSIONS
 
 NO_CHILDREN = (n.SubstitutionReference,)
 MULTIPLE_FORWARD_SLASHES = re.compile(r"([\/])\1")
+NON_DIGITS = re.compile(r"\D+")
 NO_AMBIGUOUS_LITERAL_DIAGNOSTICS = (
     os.environ.get("SNOOTY_NO_AMBIGUOUS_LITERAL_DIAGNOSTICS", "0") == "1"
 )
@@ -166,7 +167,7 @@ class PendingFigure(PendingTask):
                     options["width"] = str(dimensions[0])
                     options["height"] = str(dimensions[1])
                 else:
-                    width_num = float(re.sub(r"\D+", "", user_width))
+                    width_num = float(NON_DIGITS.sub("", user_width))
                     options["height"] = str(dimensions[1] * width_num / dimensions[0])
             cache[(self.asset.fileid, 0)] = checksum
         except OSError as err:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -166,9 +166,8 @@ class PendingFigure(PendingTask):
                     options["width"] = str(dimensions[0])
                     options["height"] = str(dimensions[1])
                 else:
-                    options["height"] = str(
-                        dimensions[1] * float(user_width) / dimensions[0]
-                    )
+                    width_num = float(re.sub(r"\D+", "", user_width))
+                    options["height"] = str(dimensions[1] * width_num / dimensions[0])
             cache[(self.asset.fileid, 0)] = checksum
         except OSError as err:
             diagnostics.append(

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1958,7 +1958,7 @@ def test_figure() -> None:
 .. figure:: /test_parser/sample.png
    :alt: sample png
    :figwidth: 100
-   :width: 100
+   :width: 90
    :scale: 1
    :align: left
    :lightbox:
@@ -1974,7 +1974,7 @@ def test_figure() -> None:
         """
 <root fileid="test.rst">
     <directive name="figure" alt="sample png" checksum="af4fbbc65c96b5c8f6f299769e2783b4ab7393f047debc00ffae772b9c5a7665"
-        align="left" border="True" class="class" figwidth="100" lightbox="True" scale="1" width="100.0" height="100.0">
+        align="left" border="True" class="class" figwidth="100" lightbox="True" scale="1" width="90" height="90.0">
         <text>/test_parser/sample.png</text>
     </directive>
 </root>""",

--- a/snooty/test_types.py
+++ b/snooty/test_types.py
@@ -1,5 +1,5 @@
 from pathlib import Path, PurePath
-from typing import cast, Tuple
+from typing import Tuple, cast
 
 from .n import FileId
 from .page import Page

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -36,7 +36,7 @@ from .n import FileId, SerializableType
 FileSource = Union[Path, str]
 PAT_VARIABLE = re.compile(r"{\+([\w-]+)\+}")
 PAT_GIT_MARKER = re.compile(r"^<<<<<<< .*?^=======\n.*?^>>>>>>>", re.M | re.S)
-IMAGE_SIZING_EXT = [".png", ".avif", ".jpg", ".jpeg", ".webp"]
+IMAGE_SIZING_EXT = {".png", ".avif", ".jpg", ".jpeg", ".webp"}
 BuildIdentifierSet = Dict[str, Optional[str]]
 logger = logging.getLogger(__name__)
 

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -36,6 +36,7 @@ from .n import FileId, SerializableType
 FileSource = Union[Path, str]
 PAT_VARIABLE = re.compile(r"{\+([\w-]+)\+}")
 PAT_GIT_MARKER = re.compile(r"^<<<<<<< .*?^=======\n.*?^>>>>>>>", re.M | re.S)
+IMAGE_SIZING_EXT = [".png", ".avif", ".jpg", ".jpeg", ".webp"]
 BuildIdentifierSet = Dict[str, Optional[str]]
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,8 @@ class StaticAsset:
         if self._data is None:
             self._data = self.path.read_bytes()
             self._checksum = hashlib.blake2b(self._data, digest_size=32).hexdigest()
+            if self.path.suffix not in IMAGE_SIZING_EXT:
+                return
             try:
                 width, height = imagesize.get(self.path)
                 if width <= 0 or height <= 0:


### PR DESCRIPTION
Goal: Remove warnings such as the following for images that do not need dimensions to preload in the browser.

```
WARNING(core/csfle/reference/encryption-components.txt:0ish): WARNING! Intrinsic size for image not calculated at path /Users/seung.park/Desktop/doc-repos/docs-mongodb-internal/source/images/client-side-field-level-encryption-diagram.svg. Image may not be lazy loaded.
```

Only the file formats that are defined in the constant are supported for image processing on the front end, and thus can be lazy loaded in the future.