### PR TITLE
DOP-4225: flag images for lazy loading depending on 

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1743,7 +1743,7 @@ class FacetsHandler(Handler):
 
 
 class ImageHandler(Handler):
-    """Inspects the images on the page and appends a lazy loading option if the image is found below the fold.
+    """Inspects the images on the page and appends a lazy loading option if the image is considered to be below the fold.
 
     An image is considered below the fold if section index > 1 or index of image on page > 2
     """

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1750,14 +1750,12 @@ class ImageHandler(Handler):
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.contents_depth = sys.maxsize
         self.current_section = 0
         self.current_img_index = 0
-        self.max_section_depth = 1
-        self.max_img_depth = 2
+        self.min_section_depth = 1
+        self.min_img_index = 2
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        self.contents_depth = sys.maxsize
         self.current_section = 0
         self.current_img_index = 0
 
@@ -1769,7 +1767,7 @@ class ImageHandler(Handler):
         if isinstance(node, n.Directive) and (
             node.name == "image" or node.name == "figure"
         ):
-            if self.current_section > self.max_section_depth or self.current_img_index > self.max_img_depth:
+            if self.current_section > self.min_section_depth or self.current_img_index > self.min_img_index:
                 node.options["loading"] = "lazy"
             self.current_img_index += 1
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1767,7 +1767,10 @@ class ImageHandler(Handler):
         if isinstance(node, n.Directive) and (
             node.name == "image" or node.name == "figure"
         ):
-            if self.current_section > self.min_section_depth or self.current_img_index > self.min_img_index:
+            if (
+                self.current_section > self.min_section_depth
+                or self.current_img_index > self.min_img_index
+            ):
                 node.options["loading"] = "lazy"
             self.current_img_index += 1
 
@@ -1834,7 +1837,7 @@ class Postprocessor:
             OpenAPIHandler,
             OpenAPIChangelogHandler,
             FacetsHandler,
-            ImageHandler
+            ImageHandler,
         ],
         [TargetHandler, IAHandler, NamedReferenceHandlerPass1],
         [RefsHandler, NamedReferenceHandlerPass2],

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1742,6 +1742,38 @@ class FacetsHandler(Handler):
                 pass
 
 
+class ImageHandler(Handler):
+    """Inspects the images on the page and appends a lazy loading option if the image is found below the fold.
+
+    An image is considered below the fold if section index > 1 or index of image on page > 2
+    """
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self.contents_depth = sys.maxsize
+        self.current_section = 0
+        self.current_img_index = 0
+        self.max_section_depth = 1
+        self.max_img_depth = 2
+
+    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
+        self.contents_depth = sys.maxsize
+        self.current_section = 0
+        self.current_img_index = 0
+
+    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if isinstance(node, n.Section):
+            self.current_section += 1
+            return
+
+        if isinstance(node, n.Directive) and (
+            node.name == "image" or node.name == "figure"
+        ):
+            if self.current_section > self.max_section_depth or self.current_img_index > self.max_img_depth:
+                node.options["loading"] = "lazy"
+            self.current_img_index += 1
+
+
 class PostprocessorResult(NamedTuple):
     pages: Dict[FileId, Page]
     metadata: Dict[str, SerializableType]
@@ -1804,6 +1836,7 @@ class Postprocessor:
             OpenAPIHandler,
             OpenAPIChangelogHandler,
             FacetsHandler,
+            ImageHandler
         ],
         [TargetHandler, IAHandler, NamedReferenceHandlerPass1],
         [RefsHandler, NamedReferenceHandlerPass2],

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from typing import Any, Dict, cast
+import pprint
 
 from snooty.types import Facet
 
@@ -29,6 +30,7 @@ from .diagnostics import (
     SubstitutionRefError,
     TabMustBeDirective,
     TargetNotFound,
+    ImageSizeUndetermined,
 )
 from .n import FileId
 from .util_test import (
@@ -3095,4 +3097,118 @@ value = "test"
   </section>
 </root>
             """,
+        )
+
+
+def test_images() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+
+======
+Images
+======
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+            """
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="index.txt">
+  <section>
+    <heading id="images"><text>Images</text></heading>
+    <directive name="image" alt="img"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img" loading="lazy"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img" loading="lazy"><text>/path/to/image.png</text></directive>
+  </section>
+</root>
+""",
+        )
+
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+
+======
+Images
+======
+
+Image test
+
+======
+Images
+======
+
+Image test
+
+======
+Images
+======
+
+Image test
+
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+
+.. image:: /path/to/image.png
+   :alt: img
+            """
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="index.txt">
+  <section>
+    <heading id="images"><text>Images</text></heading>
+    <paragraph><text>Image test</text></paragraph>
+  </section>
+  <section>
+    <heading id="images-1"><text>Images</text></heading>
+    <paragraph><text>Image test</text></paragraph>
+  </section>
+  <section>
+    <heading id="images-2"><text>Images</text></heading>
+    <paragraph><text>Image test</text></paragraph>
+    <directive name="image" alt="img" loading="lazy"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img" loading="lazy"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img" loading="lazy"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img" loading="lazy"><text>/path/to/image.png</text></directive>
+    <directive name="image" alt="img" loading="lazy"><text>/path/to/image.png</text></directive>
+  </section>
+</root>
+        """,
         )

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3,7 +3,6 @@
 
 from pathlib import Path
 from typing import Any, Dict, cast
-import pprint
 
 from snooty.types import Facet
 
@@ -30,7 +29,6 @@ from .diagnostics import (
     SubstitutionRefError,
     TabMustBeDirective,
     TargetNotFound,
-    ImageSizeUndetermined,
 )
 from .n import FileId
 from .util_test import (


### PR DESCRIPTION
**Goal:** Flag image directives for lazy loading, depending on their occurrence on the RST.

We can tweak the values for `min_section_depth` or `min_img_index`, but these were inspired from [this article for when to use lazy loading](https://web.dev/articles/lcp-lazy-loading?utm_source=lighthouse&utm_medium=devtools#testing_a_fix).

The front end portion is ready [here](https://github.com/mongodb/snooty/pull/981/files#diff-ffd2b22195ccbbae4128ae0f9aa63e3b223dec62b101275024fd4d21509f58e6R53). This will use Gatsby Image to lazy load components once they are in viewport