### PR TITLE
DOP-3969: Raise a diagnostic for section structures that cannot fit into a tree

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -531,7 +531,7 @@ class BaseDocutilsDirective(tinydocutils.directives.Directive):
 
         # Parse the content
         self.state.nested_parse(
-            self.content, self.content_offset, node, match_titles=True
+            self.content, self.content_offset, node, match_titles=True, empty_memo=True
         )
 
         return [node]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3738,6 +3738,7 @@ def test_inconsistent_levels() -> None:
     project_config = ProjectConfig(ROOT_PATH, "")
     parser = rstparser.Parser(project_config, JSONVisitor)
 
+    # Re-opening a section level is not permitted
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -3760,6 +3761,7 @@ Query Result Format
     assert [type(d) for d in diagnostics] == [DocUtilsParseError]
     print(ast_to_testing_string(page.ast))
 
+    # Opening a new child level is fine
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -3799,6 +3801,8 @@ Query Result Format
 """,
     )
 
+    # Ensuring for my own satisfaction that a diagnostic is raised if we try shenanigans in non-directive
+    # block contexts.
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -3816,6 +3820,8 @@ Query Result Format
     page.finish(diagnostics)
     assert [type(d) for d in diagnostics] == [DocUtilsParseError]
 
+    # A less trivial error case where a child section is opened, but then subsequently
+    # the parent section is added to.
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -3837,8 +3843,8 @@ Procedure
     )
     page.finish(diagnostics)
     assert [type(d) for d in diagnostics] == [DocUtilsParseError]
-    # print(ast_to_testing_string(page.ast))
 
+    # Multiple sub-sections is fine
     page, diagnostics = parse_rst(
         parser,
         path,

--- a/snooty/tinydocutils/states.py
+++ b/snooty/tinydocutils/states.py
@@ -1112,7 +1112,7 @@ class RSTState(State):
             if level <= self.memo.minimum_level_stack[-1]:
                 self.parent.append(
                     self.reporter.error(
-                        "Block content cannot contain sections that are sibling to the parent element's section level",
+                        "Directives cannot contain sections that are sibling or parent to the parent element's section level (https://github.com/mongodb/snooty-parser/wiki/Section-Hierarchy-Must-Be-Linear)",
                         line=lineno,
                     )
                 )


### PR DESCRIPTION
Our approach here is to add a stack of "minimum heading levels" to our parsing memo. When we enter and exit a directive, we push and pop the current heading level, respectively.

This allows us to warn when we encounter a section with an unacceptably low section level.