### PR TITLE
DOP-4279: Parser identifies if an Instruqt lab is on the page

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1147,18 +1147,16 @@ class InstruqtHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
         self.has_instruqt_directive = False
-        self.instruqt_title = ""
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.has_instruqt_directive = False
-        self.instruqt_title = ""
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         if not self.has_instruqt_directive:
             return
 
         else:
-            page.ast.options["instruqt_title"] = self.instruqt_title
+            page.ast.options["instruqt"] = self.has_instruqt_directive
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "instruqt":
@@ -1170,12 +1168,8 @@ class InstruqtHandler(Handler):
                     DuplicateDirective(node.name, node.start[0])
                 )
                 return
-
-            self.has_instruqt_directive = True
-            title = node.options.get("title", "")
-
-            if title:
-                self.instruqt_title = title
+            else:
+                self.has_instruqt_directive = True
 
 
 class IAHandler(Handler):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1157,7 +1157,7 @@ class InstruqtHandler(Handler):
         if not self.has_instruqt_directive:
             return
 
-        elif isinstance(page.ast, n.Root):
+        else:
             page.ast.options["title"] = [self.instruqt_title]
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
@@ -1168,7 +1168,7 @@ class InstruqtHandler(Handler):
             self.has_instruqt_directive = True
             title = node.options.get("title", "")
 
-            if len(title) != 0:
+            if not title:
                 self.instruqt_title = title
                 #  self.context.diagnostics[fileid_stack.current].append(
                 #     MissingOption() )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1141,6 +1141,39 @@ class OpenAPIChangelogHandler(Handler):
             return
 
 
+class InstruqtHandler(Handler):
+    """Identify if Instruqt directive is present on a page and add title as a page-level option if so"""
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self.has_instruqt_directive = False
+        self.instruqt_title = ""
+
+    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
+        self.has_instruqt_directive = False
+        self.instruqt_title = ""
+
+    def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
+        if not self.has_instruqt_directive:
+            return
+
+        elif isinstance(page.ast, n.Root):
+            page.ast.options["title"] = [self.instruqt_title]
+
+    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if not isinstance(node, n.Directive) or node.name != "instruqt":
+            return
+
+        if isinstance(node, n.Directive) and node.name == "instruqt":
+            self.has_instruqt_directive = True
+            title = node.options.get("title", "")
+
+            if len(title) != 0:
+                self.instruqt_title = title
+                #  self.context.diagnostics[fileid_stack.current].append(
+                #     MissingOption() )
+
+
 class IAHandler(Handler):
     """Identify IA directive on a page and save a list of its entries as a page-level option."""
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1158,7 +1158,7 @@ class InstruqtHandler(Handler):
             return
 
         else:
-            page.ast.options["title"] = [self.instruqt_title]
+            page.ast.options["instruqt_title"] = self.instruqt_title
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "instruqt":
@@ -1168,10 +1168,9 @@ class InstruqtHandler(Handler):
             self.has_instruqt_directive = True
             title = node.options.get("title", "")
 
-            if not title:
+            if title:
                 self.instruqt_title = title
-                #  self.context.diagnostics[fileid_stack.current].append(
-                #     MissingOption() )
+
 
 
 class IAHandler(Handler):
@@ -1865,6 +1864,7 @@ class Postprocessor:
             ProgramOptionHandler,
             TabsSelectorHandler,
             ContentsHandler,
+            InstruqtHandler,
             BannerHandler,
             GuidesHandler,
             OpenAPIHandler,

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1155,21 +1155,18 @@ class InstruqtHandler(Handler):
         if not self.has_instruqt_directive:
             return
 
-        else:
-            page.ast.options["instruqt"] = self.has_instruqt_directive
+        page.ast.options["instruqt"] = self.has_instruqt_directive
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "instruqt":
             return
 
-        if isinstance(node, n.Directive) and node.name == "instruqt":
-            if self.has_instruqt_directive:
-                self.context.diagnostics[fileid_stack.current].append(
-                    DuplicateDirective(node.name, node.start[0])
-                )
-                return
-            else:
-                self.has_instruqt_directive = True
+        elif self.has_instruqt_directive:
+            self.context.diagnostics[fileid_stack.current].append(
+                DuplicateDirective(node.name, node.start[0])
+            )
+            return
+        self.has_instruqt_directive = True
 
 
 class IAHandler(Handler):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1165,12 +1165,17 @@ class InstruqtHandler(Handler):
             return
 
         if isinstance(node, n.Directive) and node.name == "instruqt":
+            if self.has_instruqt_directive:
+                self.context.diagnostics[fileid_stack.current].append(
+                    DuplicateDirective(node.name, node.start[0])
+                )
+                return
+
             self.has_instruqt_directive = True
             title = node.options.get("title", "")
 
             if title:
                 self.instruqt_title = title
-
 
 
 class IAHandler(Handler):

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -770,7 +770,7 @@ content_type = "block"
 [directive."mongodb:instruqt"]
 content_type = "block"
 argument_type = "string"
-options.title = "string"
+options.title = {type = "string", required = true}
 
 [directive."mongodb:introduction"]
 content_type = "block"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -770,6 +770,7 @@ content_type = "block"
 [directive."mongodb:instruqt"]
 content_type = "block"
 argument_type = "string"
+options.title = "string"
 
 [directive."mongodb:introduction"]
 content_type = "block"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2167,6 +2167,7 @@ Reference `GitHub`_
         diagnostics = result.diagnostics[FileId(active_file)]
         assert len(diagnostics) == 1
 
+
 def test_instruqt_directive() -> None:
     with make_test(
         {
@@ -2206,8 +2207,49 @@ Title
 </root>
 """,
         )
+    with make_test(
+        {
+            Path(
+                "source/page1.txt"
+            ): """
 
-        
+=====
+Title
+=====
+
+.. instruqt::
+    :title: TestLab
+
+.. instruqt::
+    :title: Test Another Lab
+
+""",
+        }
+    ) as result:
+        active_file = "page1.txt"
+        diagnostics = result.diagnostics[FileId(active_file)]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], DuplicateDirective)
+        page = result.pages[FileId(active_file)]
+        print(ast_to_testing_string(page.ast))
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="page1.txt" instruqt_title="TestLab">
+<section> 
+<heading id="title">
+<text> Title
+</text>
+</heading>
+<directive domain="mongodb" name= "instruqt" title="TestLab">
+</directive>
+<directive domain="mongodb" name= "instruqt" title="Test Another Lab">
+</directive>
+</section>
+</root>
+""",
+        )
+
 
 def test_contents_directive() -> None:
     with make_test(

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2194,7 +2194,7 @@ Title
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page.txt">
+<root fileid="page.txt" instruqt_title="TestLab">
 <section> 
 <heading id="title">
 <text> Title

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2167,6 +2167,47 @@ Reference `GitHub`_
         diagnostics = result.diagnostics[FileId(active_file)]
         assert len(diagnostics) == 1
 
+def test_instruqt_directive() -> None:
+    with make_test(
+        {
+            Path(
+                "source/page.txt"
+            ): """
+
+=====
+Title
+=====
+
+.. instruqt::
+    :title: TestLab
+
+
+
+""",
+        }
+    ) as result:
+        active_file = "page.txt"
+        diagnostics = result.diagnostics[FileId(active_file)]
+        assert len(diagnostics) == 0
+        page = result.pages[FileId(active_file)]
+        print(ast_to_testing_string(page.ast))
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="page.txt">
+<section> 
+<heading id="title">
+<text> Title
+</text>
+</heading>
+<directive domain="mongodb" name= "instruqt" title="TestLab">
+</directive>
+</section>
+</root>
+""",
+        )
+
+        
 
 def test_contents_directive() -> None:
     with make_test(

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2194,7 +2194,7 @@ Title
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page.txt" instruqt_title="TestLab">
+<root fileid="page.txt" instruqt="True">
 <section> 
 <heading id="title">
 <text> Title
@@ -2233,7 +2233,7 @@ Title
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page1.txt" instruqt_title="TestLab">
+<root fileid="page1.txt" instruqt="True">
 <section> 
 <heading id="title">
 <text> Title
@@ -2271,7 +2271,7 @@ Title
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page2.txt" instruqt_title="">
+<root fileid="page2.txt" instruqt="True">
 <section> 
 <heading id="title">
 <text> Title

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2191,7 +2191,6 @@ Title
         diagnostics = result.diagnostics[FileId(active_file)]
         assert len(diagnostics) == 0
         page = result.pages[FileId(active_file)]
-        print(ast_to_testing_string(page.ast))
         check_ast_testing_string(
             page.ast,
             """
@@ -2231,7 +2230,6 @@ Title
         assert len(diagnostics) == 1
         assert isinstance(diagnostics[0], DuplicateDirective)
         page = result.pages[FileId(active_file)]
-        print(ast_to_testing_string(page.ast))
         check_ast_testing_string(
             page.ast,
             """
@@ -2244,6 +2242,42 @@ Title
 <directive domain="mongodb" name= "instruqt" title="TestLab">
 </directive>
 <directive domain="mongodb" name= "instruqt" title="Test Another Lab">
+</directive>
+</section>
+</root>
+""",
+        )
+    with make_test(
+        {
+            Path(
+                "source/page2.txt"
+            ): """
+
+=====
+Title
+=====
+
+.. instruqt::
+
+""",
+        }
+    ) as result:
+        active_file = "page2.txt"
+        diagnostics = result.diagnostics[FileId(active_file)]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], DocUtilsParseError)
+        page = result.pages[FileId(active_file)]
+        print(ast_to_testing_string(page.ast))
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="page2.txt" instruqt_title="">
+<section> 
+<heading id="title">
+<text> Title
+</text>
+</heading>
+<directive domain="mongodb" name="instruqt">
 </directive>
 </section>
 </root>


### PR DESCRIPTION
### Context

[DOP-4279](https://jira.mongodb.org/browse/DOP-4279)

Instruqt labs are currently embedded into the content of a docs page but instead, we want them to appear after a click of a button next to the page's title heading. To accomplish this, the frontend must know if the page has a lab within the page AST.

([Current display of Instruqt Labs](https://github.com/mongodb/docs/blob/eea48f019634747775072cbf6bdf8c9ff13b4b79/source/tutorial/getting-started.txt#L29))

Page ASTs have a page-level option that determines if a lab should be shown.
The instruqt directive has support for a new title option

### Notes
These changes were tested with tests added to test_processor.py. 
Only one Instruqt directive should be present per page; if there are two a diagnostic error will be produced.