### PR TITLE
DOP-4319 added drawer option

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1162,7 +1162,6 @@ class InstruqtHandler(Handler):
             return
 
         elif self.has_instruqt_drawer:
-            print("DUPE")
             self.context.diagnostics[fileid_stack.current].append(
                 DuplicateDirective(node.name, node.start[0])
             )
@@ -1170,6 +1169,9 @@ class InstruqtHandler(Handler):
 
         elif node.options.get("drawer"):
             self.has_instruqt_drawer = True
+            return
+
+        self.has_instruqt_drawer = False
 
 
 class IAHandler(Handler):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1146,27 +1146,30 @@ class InstruqtHandler(Handler):
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.has_instruqt_directive = False
+        self.has_instruqt_drawer = False
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        self.has_instruqt_directive = False
+        self.has_instruqt_drawer = False
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        if not self.has_instruqt_directive:
+        if not self.has_instruqt_drawer:
             return
 
-        page.ast.options["instruqt"] = self.has_instruqt_directive
+        page.ast.options["instruqt"] = self.has_instruqt_drawer
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "instruqt":
             return
 
-        elif self.has_instruqt_directive:
+        elif self.has_instruqt_drawer:
+            print("DUPE")
             self.context.diagnostics[fileid_stack.current].append(
                 DuplicateDirective(node.name, node.start[0])
             )
             return
-        self.has_instruqt_directive = True
+
+        elif node.options.get("drawer"):
+            self.has_instruqt_drawer = True
 
 
 class IAHandler(Handler):

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -771,6 +771,7 @@ content_type = "block"
 content_type = "block"
 argument_type = "string"
 options.title = {type = "string", required = true}
+options.drawer = "boolean"
 
 [directive."mongodb:introduction"]
 content_type = "block"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2181,6 +2181,7 @@ Title
 
 .. instruqt::
     :title: TestLab
+    :drawer: True
 
 
 
@@ -2200,7 +2201,7 @@ Title
 <text> Title
 </text>
 </heading>
-<directive domain="mongodb" name= "instruqt" title="TestLab">
+<directive domain="mongodb" name= "instruqt" title="TestLab" drawer="True">
 </directive>
 </section>
 </root>
@@ -2218,9 +2219,11 @@ Title
 
 .. instruqt::
     :title: TestLab
+    :drawer: True
 
 .. instruqt::
     :title: Test Another Lab
+    :drawer: True
 
 """,
         }
@@ -2239,9 +2242,9 @@ Title
 <text> Title
 </text>
 </heading>
-<directive domain="mongodb" name= "instruqt" title="TestLab">
+<directive domain="mongodb" name= "instruqt" title="TestLab" drawer="True">
 </directive>
-<directive domain="mongodb" name= "instruqt" title="Test Another Lab">
+<directive domain="mongodb" name= "instruqt" title="Test Another Lab" drawer="True">
 </directive>
 </section>
 </root>
@@ -2258,26 +2261,26 @@ Title
 =====
 
 .. instruqt::
+    :Title: Test Lab
 
 """,
         }
     ) as result:
         active_file = "page2.txt"
         diagnostics = result.diagnostics[FileId(active_file)]
-        assert len(diagnostics) == 1
-        assert isinstance(diagnostics[0], DocUtilsParseError)
+        assert len(diagnostics) == 0
         page = result.pages[FileId(active_file)]
         print(ast_to_testing_string(page.ast))
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page2.txt" instruqt="True">
+<root fileid="page2.txt" >
 <section> 
 <heading id="title">
 <text> Title
 </text>
 </heading>
-<directive domain="mongodb" name="instruqt">
+<directive domain="mongodb" name="instruqt" title= "Test Lab">
 </directive>
 </section>
 </root>


### PR DESCRIPTION
[DOP-4319](https://jira.mongodb.org/browse/DOP-4319)

`Drawer` option has been created for an Instruqt directive; the page-level `Instruqt` option will now be set based on the value of the Instruqt directive's drawer option, rather than entirely on whether an Instruqt directive exists on a page.

### Notes
The `drawer` option is currently not required and the page level Instruqt option defaults to false if there a page's Instruqt lab doesn't have a drawer option set. This can be easily changed if desired