### PR TITLE
DOP-4300: Enabling IA directives to support nested content for homepage redesign purposes

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2021,7 +2021,6 @@ class Postprocessor:
             "slug": "/",
             "children": [],
         }
-        
         iterate_ia(starting_page, root)
         return root
 


### PR DESCRIPTION
[DOP-4300](https://jira.mongodb.org/browse/DOP-4300)

Currently, `.. ia::` directive cannot support nested directives. This PR changes it so IA `.. entry::` directives can support nested directives, enabling the updated homepage design.

[Staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4300/landing/maya/DOP-4300/) (I'm not sure why the header is a bit messed up, but I don't believe that has anything to do with these changes).

[New draft `docs-landing` homepage RST](https://github.com/mayaraman19/docs-landing-DOP-4300/blob/DOP-4300/source/index.txt)