### PR TITLE
DOP-4212: mms-icon-modify renders but causes a build error

### DIFF
--- a/snooty/icon_names.py
+++ b/snooty/icon_names.py
@@ -2074,7 +2074,7 @@ ICON_SET = {
     "mms-icon-ellipsis",
     "mms-icon-dragleft",
     "mms-icon-list-skinny",
-    "mms-icon-modify:",
+    "mms-icon-modify",
     "mms-icon-wrench",
     "mms-icon-grid",
     "mms-icon-ssl",


### PR DESCRIPTION
### Context
[DOP-4212](https://jira.mongodb.org/browse/DOP-4212)

### Notes

To test the fix, I added an instance of the `mms-icon-modify` to a branch `docs meta` [here](https://github.com/mongodb/docs-meta/compare/master...DOP-4212#diff-5d81d5a2b93d3c24f68335ed516e6197236ef99e0c9f2740a33d4a8c24025fafR8463-R8466). I then ran the parser on it once without the parser fix, and once with; without the fix, the error appears, with the fix, there's no error.
  
![Screenshot 2024-01-31 at 10 19 58 AM](https://github.com/mongodb/snooty-parser/assets/41971124/71d9b2bd-8abc-4961-9892-5f09ce73f420)

