### PR TITLE
DOP-4408: include svg as part of deriving width/height

### DIFF
--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1933,6 +1933,9 @@ def test_figure() -> None:
 
 .. figure:: /test_parser/sample.jpg
    :alt: sample jpeg
+
+.. figure:: /test_project/source/general-features-tools.svg
+   :alt: sample svg
 """,
     )
     page.finish(diagnostics)
@@ -1946,6 +1949,9 @@ def test_figure() -> None:
     </directive>
     <directive name="figure" alt="sample jpeg" checksum="423345d0e4268d547aeaef46b74479f5df6e949d2b3288de1507f1f3082805ae" width="100.0" height="100.0">
         <text>/test_parser/sample.jpg</text>
+    </directive>
+    <directive name="figure" alt="sample svg" checksum="d769706e8087b6f08954b7f66d0cb167bc73f669c3d4b2ebb4af4de27e51c54f" width="56.0" height="56.0">
+        <text>/test_project/source/general-features-tools.svg</text>
     </directive>
 </root>""",
     )

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -38,7 +38,7 @@ from .n import FileId, SerializableType
 FileSource = Union[Path, str]
 PAT_VARIABLE = re.compile(r"{\+([\w-]+)\+}")
 PAT_GIT_MARKER = re.compile(r"^<<<<<<< .*?^=======\n.*?^>>>>>>>", re.M | re.S)
-IMAGE_SIZING_EXT = {".png", ".avif", ".jpg", ".jpeg", ".webp"}
+IMAGE_SIZING_EXT = {".png", ".avif", ".jpg", ".jpeg", ".webp", ".svg"}
 BuildIdentifierSet = Dict[str, Optional[str]]
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Ticket

DOP-4408

### Notes
- Minimal change to allow for SVG's to have calculated width/height attached to its AST node
- Included test to reflect size attributes being added


### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
