### PR TITLE
:loud_sound: DOP-4320 switches from warning to info to help filter output

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -286,7 +286,7 @@ class InvalidTableStructure(Diagnostic):
 
 
 class InvalidNestedTabStructure(Diagnostic):
-    severity = Diagnostic.Level.warning
+    severity = Diagnostic.Level.info
 
     def __init__(
         self,


### PR DESCRIPTION
### Ticket

DOP-4320

### Notes

Converting the nested tab output from a warning to an info.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
