### PR TITLE
DOP-4447: skip files that do not end with .txt 

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -42,14 +42,13 @@ from .n import FileId, SerializableType
 from .page import Page
 from .parser import Project, ProjectBackend, ProjectLoadError
 from .types import BuildIdentifierSet, ProjectConfig
-from .util import SOURCE_FILE_EXTENSIONS, HTTPCache, PerformanceLogger
+from .util import EXT_FOR_PAGE, SOURCE_FILE_EXTENSIONS, HTTPCache, PerformanceLogger
 
 PARANOID_MODE = os.environ.get("SNOOTY_PARANOID", "0") == "1"
 PATTERNS = ["*" + ext for ext in SOURCE_FILE_EXTENSIONS]
 logger = logging.getLogger(__name__)
 
 EXIT_STATUS_ERROR_DIAGNOSTICS = 2
-EXT_FOR_PAGE = ".txt"
 
 
 class ObserveHandler(watchdog.events.PatternMatchingEventHandler):

--- a/snooty/main.py
+++ b/snooty/main.py
@@ -20,6 +20,7 @@ Environment variables:
   SNOOTY_PERF_SUMMARY       0, 1 where 0 is default
 
 """
+
 import json
 import logging
 import multiprocessing
@@ -48,6 +49,7 @@ PATTERNS = ["*" + ext for ext in SOURCE_FILE_EXTENSIONS]
 logger = logging.getLogger(__name__)
 
 EXIT_STATUS_ERROR_DIAGNOSTICS = 2
+EXT_FOR_PAGE = ".txt"
 
 
 class ObserveHandler(watchdog.events.PatternMatchingEventHandler):
@@ -189,6 +191,8 @@ class Backend(ProjectBackend):
         fully_qualified_pageid: str,
         document: Dict[str, Any],
     ) -> None:
+        if page_id.suffix != EXT_FOR_PAGE:
+            return
         self.total_pages += 1
 
     def handle_asset(self, checksum: str, asset: Union[str, bytes]) -> None:
@@ -221,6 +225,8 @@ class ZipBackend(Backend):
         fully_qualified_pageid: str,
         document: Dict[str, Any],
     ) -> None:
+        if page_id.suffix != EXT_FOR_PAGE:
+            return
         super().handle_document(
             build_identifiers, page_id, fully_qualified_pageid, document
         )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -70,7 +70,7 @@ from .n import FileId, SerializableType
 from .page import Page
 from .target_database import TargetDatabase
 from .types import Facet, ProjectConfig
-from .util import SOURCE_FILE_EXTENSIONS, bundle
+from .util import EXT_FOR_PAGE, SOURCE_FILE_EXTENSIONS, bundle
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
@@ -782,7 +782,7 @@ class BannerHandler(Handler):
         self, targets: List[str], page: Page, fileid: FileId
     ) -> bool:
         """Check if page matches target specified, but assert to ensure this does not run on includes"""
-        assert fileid.suffix == ".txt"
+        assert fileid.suffix == EXT_FOR_PAGE
 
         for target in targets:
             if page.fileid.match(target):
@@ -1999,7 +1999,7 @@ class Postprocessor:
             event_parser.add_event_listener(event, page_listener)
 
         event_parser.consume(
-            (k, v) for k, v in self.pages.items() if k.suffix == ".txt"
+            (k, v) for k, v in self.pages.items() if k.suffix == EXT_FOR_PAGE
         )
 
     @staticmethod
@@ -2101,7 +2101,7 @@ class Postprocessor:
 
         # Locate orphaned files
         for fileid in context.pages:
-            if fileid.suffix != ".txt":
+            if fileid.suffix != EXT_FOR_PAGE:
                 continue
 
             if fileid not in visited_fileids:

--- a/snooty/test_main.py
+++ b/snooty/test_main.py
@@ -80,6 +80,17 @@ def test_backend() -> None:
         },
     ]
 
+    # test skipping non .txt files
+    backend = main.Backend()
+    backend.handle_document(
+        {}, FileId("foo/bar.txt"), "foo/bar.txt", {"page_id": "bar.txt"}
+    )
+    assert backend.total_pages == 1
+    backend.handle_document(
+        {}, FileId("foo/bar.rst"), "foo/bar.rst", {"page_id": "bar.rst"}
+    )
+    assert backend.total_pages == 1
+
 
 def test_parser_failure() -> None:
     return_code = subprocess.call(

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -63,6 +63,7 @@ PAT_INVALID_ID_CHARACTERS = re.compile(r"[^\w_\.\-]")
 PAT_URI = re.compile(r"^(?P<schema>[a-z]+)://")
 SOURCE_FILE_EXTENSIONS = {".txt", ".rst", ".yaml"}
 RST_EXTENSIONS = {".txt", ".rst"}
+EXT_FOR_PAGE = ".txt"
 EMPTY_BLAKE2B = hashlib.blake2b(b"").hexdigest()
 SNOOTY_TOML = "snooty.toml"
 PACKAGE_ROOT_STRING = sys.modules["snooty"].__file__


### PR DESCRIPTION
### Ticket

DOP-4447

### Notes
- This change adds a check for file extension, in which case the parser will not save a bson to the zip file, therefore not handed to search manifests or snooty


### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
