### PR TITLE
DOP-4495: Support pre and post in extracts

### DIFF
--- a/snooty/gizaparser/extracts.py
+++ b/snooty/gizaparser/extracts.py
@@ -15,15 +15,27 @@ from .parse import parse
 class Extract(Inheritable, HeadingMixin):
     content: Optional[str]
     only: Optional[str]
+    pre: Optional[str]
+    post: Optional[str]
 
     def render(self, page: Page, rst_parser: EmbeddedRstParser) -> List[n.Node]:
         if self.only is not None:
             raise NotImplementedError('extracts: "only" not implemented')
 
         children: List[n.Node] = []
+
+        if self.pre:
+            result = rst_parser.parse_block(self.pre, self.line)
+            children.extend(result)
+
         children.extend(self.render_heading(rst_parser))
+
         if self.content:
             children.extend(rst_parser.parse_block(self.content, self.line))
+
+        if self.post:
+            result = rst_parser.parse_block(self.post, self.line)
+            children.extend(result)
 
         return children
 

--- a/snooty/gizaparser/test_extracts.py
+++ b/snooty/gizaparser/test_extracts.py
@@ -28,7 +28,7 @@ def test_extract() -> None:
         category.add(fileid, text, extracts, [])
         assert len(parse_diagnostics) == 1
         assert parse_diagnostics[0].severity == Diagnostic.Level.error
-        assert parse_diagnostics[0].start == (21, 0)
+        assert parse_diagnostics[0].start == (25, 0)
         assert len(extracts) == 5
         return parse_diagnostics
 
@@ -62,12 +62,14 @@ def test_extract() -> None:
         pages[0].ast,
         """<root fileid="includes/extracts-test.yaml">
     <directive name="extract">
+        <paragraph><text>a pre note</text></paragraph>
         <paragraph>
             <text>By default, MongoDB stores its data files in</text>
             <literal><text>/var/lib/mongo</text></literal>
             <text> and its\nlog files in </text>
             <literal><text>/var/log/mongodb</text></literal><text>.</text>
         </paragraph>
+        <paragraph><text>a post note</text></paragraph>
     </directive>
 </root>""",
     )
@@ -83,7 +85,7 @@ def test_extract() -> None:
 
     # XXX: We need to track source file information for each property.
     # Line number 1 here should correspond to parent_path, not path.
-    assert set(d.start[0] for d in all_diagnostics[fileid]) == set((21, 13, 1))
+    assert set(d.start[0] for d in all_diagnostics[fileid]) == set((25, 17, 1))
 
 
 def test_inheritance() -> None:
@@ -162,7 +164,7 @@ inherit:
 replacement:
   role: ":method:`db.collection.aggregate()`"
   interface: "method"
-post: |
+invalid: |
   Document validation only occurs if you are using the
   :pipeline:`$out` operator in your aggregation operation.
 ---
@@ -193,7 +195,7 @@ inherit:
 replacement:
   role: ":method:`db.collection.aggregate()`"
   interface: "method"
-post: |
+invalid: |
   Document validation only occurs if you are using the
   :pipeline:`$out` operator in your aggregation operation.
 ...

--- a/test_data/test_gizaparser/source/includes/extracts-test.yaml
+++ b/test_data/test_gizaparser/source/includes/extracts-test.yaml
@@ -2,6 +2,10 @@ ref: _base
 content: |
   By default, MongoDB stores its data files in {{mongodDatadir}} and its
   log files in ``/var/log/mongodb``.
+pre: |
+  a pre note
+post: |
+  a post note
 ---
 ref: installation-directory-rhel
 inherit:


### PR DESCRIPTION
### Ticket

DOP-4495

### Notes

Giza extracts supported the pre/post keys we see in other types of YAML files. We neglected to support this when we implemented our Giza compatibility layer.

Add support for these keys.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
