### PR TITLE
DOP-4511: make comm driver a directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -994,6 +994,14 @@ example = """.. entry:: ${0: string}
    :primary: (optional)}
 """
 
+[directive.community-driver]
+help = """Specify a community-built driver or library and include a pill badge"""
+argument_type = "string"
+options.url = "string"
+example = """.. community-driver:: ${0: driver (string)}
+   :url: ${1: https://example.com}
+"""
+
 ###### Roles
 [role.kbd]
 help = """Mark a sequence of keystrokes."""
@@ -1036,10 +1044,6 @@ type = "text"
 
 [role.abbr]
 help = """Abbreviation with hover text."""
-type = "text"
-
-[role.community-pill-link]
-help = """Link to a community-built driver or library and include a pill badge"""
 type = "text"
 
 [role.file]


### PR DESCRIPTION
### Ticket

DOP-4511

### Notes
The role approach would make sense, except the badge LG component renders with a `<div>` which doesn't work for an inline paragraph-y element. Accordingly, changing this to a directive to reduce invalid HTML sadness.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
