### PR TITLE
Exclude Python 3.8 on macOS from the action matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         platform: [ubuntu-20.04, macos-latest]
         python-version: ['3.8', '3.11']
+        # Python 3.8 is only used for Pyston on Linux x86_64
+        exclude:
+          - platform: macos-latest
+            python-version: '3.8'
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### Notes

Python 3.8 is hitting EOL this October, but for now we want to retain Pyston, which is stuck at version 3.8.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
