### PR TITLE
DOP-4430: Add diagnostic warning when a table has only 1 header row

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -715,8 +715,13 @@ class JSONVisitor:
                 expected_num_columns = len(widths)
             bullet_list = node.children[0]
             if "header-rows" in options:
-                if options['header-rows'] >= len(bullet_list.children):
-                    self.diagnostics.append(InvalidTableStructure("List-table cannot have only header rows", node.get_line() + len(node.children) - 1))
+                if options["header-rows"] >= len(bullet_list.children):
+                    self.diagnostics.append(
+                        InvalidTableStructure(
+                            "List-table cannot have only header rows",
+                            node.get_line() + len(node.children) - 1,
+                        )
+                    )
                     raise tinydocutils.nodes.SkipNode()
             for list_item in bullet_list.children:
                 if expected_num_columns == 0 and list_item.children:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -714,6 +714,10 @@ class JSONVisitor:
                 widths = re.split(r"[,\s][\s]?", options["widths"])
                 expected_num_columns = len(widths)
             bullet_list = node.children[0]
+            if "header-rows" in options:
+                if options['header-rows'] == len(bullet_list.children):
+                    self.diagnostics.append(InvalidTableStructure("List table cannot have only header rows", node.get_line() + len(node.children) - 1))
+                    return None
             for list_item in bullet_list.children:
                 if expected_num_columns == 0 and list_item.children:
                     expected_num_columns = len(list_item.children[0].children)

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -716,8 +716,11 @@ class JSONVisitor:
             bullet_list = node.children[0]
             if "header-rows" in options:
                 if options['header-rows'] == len(bullet_list.children):
-                    self.diagnostics.append(InvalidTableStructure("List table cannot have only header rows", node.get_line() + len(node.children) - 1))
-                    return None
+                    print("BULLET LIST CHILDREN FOR BAD ROW")
+                    for child in bullet_list.children:
+                        print(child)
+                    self.diagnostics.append(InvalidTableStructure("List-table cannot have only header rows", node.get_line() + len(node.children) - 1))
+                    raise tinydocutils.nodes.SkipNode()
             for list_item in bullet_list.children:
                 if expected_num_columns == 0 and list_item.children:
                     expected_num_columns = len(list_item.children[0].children)

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -715,10 +715,7 @@ class JSONVisitor:
                 expected_num_columns = len(widths)
             bullet_list = node.children[0]
             if "header-rows" in options:
-                if options['header-rows'] == len(bullet_list.children):
-                    print("BULLET LIST CHILDREN FOR BAD ROW")
-                    for child in bullet_list.children:
-                        print(child)
+                if options['header-rows'] >= len(bullet_list.children):
                     self.diagnostics.append(InvalidTableStructure("List-table cannot have only header rows", node.get_line() + len(node.children) - 1))
                     raise tinydocutils.nodes.SkipNode()
             for list_item in bullet_list.children:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -2631,6 +2631,10 @@ def test_list_table() -> None:
     )
     page.finish(diagnostics)
     assert [type(d) for d in diagnostics] == [InvalidTableStructure]
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst"></root>""",
+    )
 
 
 def test_footnote() -> None:

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -2616,6 +2616,22 @@ def test_list_table() -> None:
     print(ast_to_testing_string(page.ast))
     assert [type(x) for x in diagnostics] == [InvalidTableStructure]
 
+    # Only header rows
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. list-table::
+    :header-rows: 1
+
+    * - This is part of an invalid row and table
+      - This is also part of an invalid row and table
+      - This is the final part of the invalid row and table
+    """,
+    )
+    page.finish(diagnostics)
+    assert [type(d) for d in diagnostics] == [InvalidTableStructure]
+
 
 def test_footnote() -> None:
     path = FileId("test.rst")


### PR DESCRIPTION
### Ticket

DOP-4430

### Notes

This change ensures that the amount of `:header-rows:` specified for a `list-table` directive is less than the amount of total rows. If not, it throws the error: `ERROR(<file:line>): List-table cannot have only header rows` and does not add the table to the resulting AST.

[This is the resulting staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/compass/maya/main/editions/index.html) for [this example PR](https://github.com/mongodb/docs-compass/pull/626/files). The table does not get created ([same page in prod](https://www.mongodb.com/docs/compass/current/editions/)).

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
