### PR TITLE
DOP-4592: Parse breadcrumb toc titles

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -744,9 +744,6 @@ class TocTitleHandler(Handler):
     def get_title(self, slug: str) -> Optional[str]:
         return self.slug_title_mapping.get(slug)
 
-    def __contains__(self, slug: str) -> bool:
-        return slug in self.slug_title_mapping
-
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.TocTreeDirective):
             return
@@ -1983,7 +1980,7 @@ class Postprocessor:
         }
         document["slugToBreadcrumbLabel"] = {
             k: (
-                context[TocTitleHandler].slug_title_mapping[f"/{k}"]
+                context[TocTitleHandler].get_title(f"/{k}")
                 if f"/{k}" in context[TocTitleHandler].slug_title_mapping
                 else v[0].get_text()
             )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -754,7 +754,7 @@ class TocTitleHandler(Handler):
         for entry in node.entries:
             slug = entry.slug
             # Save the first heading we encounter to the slug title mapping
-            if slug and slug not in self.slug_title_mapping:
+            if slug and entry.title and slug not in self.slug_title_mapping:
                 self.slug_title_mapping[slug] = entry.title
 
 
@@ -1982,7 +1982,11 @@ class Postprocessor:
             for k, v in context[HeadingHandler].slug_title_mapping.items()
         }
         document["slugToBreadcrumbLabel"] = {
-            k: (context[TocTitleHandler].slug_title_mapping[f"/{k}"] if f"/{k}" in context[TocTitleHandler].slug_title_mapping else v[0].get_text())
+            k: (
+                context[TocTitleHandler].slug_title_mapping[f"/{k}"]
+                if f"/{k}" in context[TocTitleHandler].slug_title_mapping
+                else v[0].get_text()
+            )
             for k, v in context[HeadingHandler].slug_title_mapping.items()
         }
         # Run postprocessing operations related to toctree and append to metadata document.

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -735,13 +735,10 @@ class HeadingHandler(Handler):
 
 
 class TocTitleHandler(Handler):
-    """Construct a slug-title mapping of all pages in property, and rewrite
-    heading IDs so as to be unique."""
+    """Construct a slug - toctree label mapping of all pages in property"""
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.heading_counter: typing.Counter[str] = collections.Counter()
-        self.targets = context[TargetDatabase]
         self.slug_title_mapping: Dict[str, str] = {}
 
     def get_title(self, slug: str) -> Optional[str]:
@@ -753,39 +750,12 @@ class TocTitleHandler(Handler):
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.TocTreeDirective):
             return
-        
-        # print('is toctree')
-
-        # if not isinstance(node, n.TocTreeDirectiveEntry):
-        #     return
-
-        # print('in enter node toctitle')
-        # slug = fileid_stack.root.without_known_suffix
 
         for entry in node.entries:
-
-
             slug = entry.slug
-
             # Save the first heading we encounter to the slug title mapping
             if slug and slug not in self.slug_title_mapping:
-                # self.targets.define_local_target(
-                #     "std",
-                #     "doc",
-                #     (slug,),
-                #     fileid_stack.root,
-                #     node.children,
-                #     util.make_html5_id(node.id),
-                # )
                 self.slug_title_mapping[slug] = entry.title
-                # self.targets.define_local_target(
-                #     "std",
-                #     "doc",
-                #     (fileid_stack.root.without_known_suffix,),
-                #     fileid_stack.root,
-                #     node.children,
-                #     util.make_html5_id(node.id),
-                # )
 
 
 class BannerHandler(Handler):
@@ -2011,11 +1981,10 @@ class Postprocessor:
             k: [node.serialize() for node in v]
             for k, v in context[HeadingHandler].slug_title_mapping.items()
         }
-        document["slugToTocTitle"] = {
-            k: v
-            for k, v in context[TocTitleHandler].slug_title_mapping.items()
+        document["slugToBreadcrumbLabel"] = {
+            k: (context[TocTitleHandler].slug_title_mapping[f"/{k}"] if f"/{k}" in context[TocTitleHandler].slug_title_mapping else v[0].get_text())
+            for k, v in context[HeadingHandler].slug_title_mapping.items()
         }
-        # document["slugToTocTitle"] = context[TocTitleHandler].slug_title_mapping
         # Run postprocessing operations related to toctree and append to metadata document.
         # If iatree is found, use it to generate breadcrumbs and parent paths and save it to metadata as well.
         iatree = cls.build_iatree(context)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3436,9 +3436,7 @@ Alrighty
         diagnostics = result.diagnostics[FileId("index.txt")]
         assert len(diagnostics) == 0
 
-        # Ensure the one IA entry that has linked data contains said linked data.
-        metadata = cast(Dict[str, Any], result.metadata)
-        slug_to_breadcrumb_label_entry = metadata["slugToBreadcrumbLabel"]
+        slug_to_breadcrumb_label_entry = result.metadata["slugToBreadcrumbLabel"]
         assert slug_to_breadcrumb_label_entry["page1"] == "Look at This"
         assert slug_to_breadcrumb_label_entry["page2"] == "Well, You Learned It"
         assert slug_to_breadcrumb_label_entry["ref/page3"] == "Page Three Title"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3436,7 +3436,9 @@ Alrighty
         diagnostics = result.diagnostics[FileId("index.txt")]
         assert len(diagnostics) == 0
 
-        slug_to_breadcrumb_label_entry = result.metadata["slugToBreadcrumbLabel"]
+        slug_to_breadcrumb_label_entry = cast(
+            Dict[str, str], result.metadata["slugToBreadcrumbLabel"]
+        )
         assert slug_to_breadcrumb_label_entry["page1"] == "Look at This"
         assert slug_to_breadcrumb_label_entry["page2"] == "Well, You Learned It"
         assert slug_to_breadcrumb_label_entry["ref/page3"] == "Page Three Title"


### PR DESCRIPTION
### Ticket

DOP-4592

### Notes

`slugToTitle` uses the full title fields of pages. Breadcrumbs and back/forward buttons in Snooty should use the condensed TOC labels. This creates a field `slugToBreadcrumbLabel` on the metadata as well and parses the TOC labels to have on hand if possible, and if not, uses the `title` field. 

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
