### PR TITLE
DOP-4441: Improve snooty.clickInclude command in VSCode extension

### DIFF
--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -430,9 +430,9 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             return str(resolved_target_path)
         elif resolveType == "directive":
             filePath = str(self.project.config.source_path) + fileName
-            uwu = self.project.fileid_to_source_path(Path(filePath))
-            finalFile = self.project.config.source_path / uwu
-            return str(finalFile)
+            fileId = self.project.get_fileid(Path(filePath))
+            finalFileId = self.project.config.source_path / fileId
+            return str(finalFileId)
 
         else:
             logger.error("resolveType is not supported")

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -433,7 +433,7 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             a YAML file. We want to get its original file path in that case."""
 
             # Strip the first slash from fileName so the / operator doesn't mess up :|
-            stripped_file_name = fileName[1:]
+            stripped_file_name = fileName.lstrip("/")
             if fileName.endswith("rst"):
                 file_path = self.project.config.source_path / stripped_file_name
                 file_id = self.project.get_fileid_from_ast(file_path)

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -431,14 +431,16 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
         elif resolveType == "directive":
             """If the filename has a .rst extension, it might be converted from
             a YAML file. We want to get its original file path in that case."""
-            if ".rst" in fileName:
-                filePath = str(self.project.config.source_path) + fileName
-                fileId = self.project.get_fileid(Path(filePath))
-                finalFileId = self.project.config.source_path / fileId
-                return str(finalFileId)
-            else:
-                return str(self.project.config.source_path) + fileName
 
+            # Strip the first slash from fileName so the / operator doesn't mess up :|
+            stripped_file_name = fileName[1:]
+            if fileName.endswith("rst"):
+                file_path = self.project.config.source_path / stripped_file_name
+                file_id = self.project.get_fileid(file_path)
+                real_file_path = self.project.config.source_path / file_id
+                return str(real_file_path)
+            else:
+                return str(self.project.config.source_path / stripped_file_name)
         else:
             logger.error("resolveType is not supported")
             return fileName

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -429,7 +429,11 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             )
             return str(resolved_target_path)
         elif resolveType == "directive":
-            return str(self.project.config.source_path) + fileName
+            filePath = str(self.project.config.source_path) + fileName
+            uwu = self.project.fileid_to_source_path(Path(filePath))
+            finalFile = self.project.config.source_path / uwu
+            return str(finalFile)
+
         else:
             logger.error("resolveType is not supported")
             return fileName

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -436,7 +436,7 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             stripped_file_name = fileName[1:]
             if fileName.endswith("rst"):
                 file_path = self.project.config.source_path / stripped_file_name
-                file_id = self.project.get_fileid(file_path)
+                file_id = self.project.get_fileid_from_ast(file_path)
                 real_file_path = self.project.config.source_path / file_id
                 return str(real_file_path)
             else:

--- a/snooty/language_server.py
+++ b/snooty/language_server.py
@@ -429,10 +429,15 @@ class LanguageServer(pyls_jsonrpc.dispatchers.MethodDispatcher):
             )
             return str(resolved_target_path)
         elif resolveType == "directive":
-            filePath = str(self.project.config.source_path) + fileName
-            fileId = self.project.get_fileid(Path(filePath))
-            finalFileId = self.project.config.source_path / fileId
-            return str(finalFileId)
+            """If the filename has a .rst extension, it might be converted from
+            a YAML file. We want to get its original file path in that case."""
+            if ".rst" in fileName:
+                filePath = str(self.project.config.source_path) + fileName
+                fileId = self.project.get_fileid(Path(filePath))
+                finalFileId = self.project.config.source_path / fileId
+                return str(finalFileId)
+            else:
+                return str(self.project.config.source_path) + fileName
 
         else:
             logger.error("resolveType is not supported")

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1814,7 +1814,7 @@ class Project:
         with self._lock:
             return self._project.get_page_ast(path)
 
-    def get_fileid(self, path: Path) -> FileId:
+    def get_fileid_from_ast(self, path: Path) -> FileId:
         page_ast = self.get_page_ast(path)
         return page_ast.fileid
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1814,12 +1814,9 @@ class Project:
         with self._lock:
             return self._project.get_page_ast(path)
 
-    def fileid_to_source_path(self, path: Path) -> n.Node:
-        # could use config to get file with extension?
-        uwu = self.get_page_ast(path)
-        return uwu.fileid
-        #print(uwu)
-        #return str(uwu.fileid)
+    def get_fileid(self, path: Path) -> FileId:
+        ast = self.get_page_ast(path)
+        return ast.fileid
 
     def get_project_name(self) -> str:
         return self._project.get_project_name()

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1527,7 +1527,7 @@ class _Project:
         self.expensive_operation_cache: Cache[FileId] = Cache()
         self.backend.on_config(self.config, branch)
 
-    def get_page_ast(self, path: Path) -> n.Node:
+    def get_page_ast(self, path: Path) -> n.Root:
         """Update page file (.txt) with current text and return fully populated page AST"""
         # Get incomplete AST of page
         fileid = self.config.get_fileid(path)
@@ -1809,14 +1809,14 @@ class Project:
     def config(self) -> ProjectConfig:
         return self._project.config
 
-    def get_page_ast(self, path: Path) -> n.Node:
+    def get_page_ast(self, path: Path) -> n.Root:
         """Return complete AST of page with updated text"""
         with self._lock:
             return self._project.get_page_ast(path)
 
     def get_fileid(self, path: Path) -> FileId:
-        ast = self.get_page_ast(path)
-        return ast.fileid
+        page_ast = self.get_page_ast(path)
+        return page_ast.fileid
 
     def get_project_name(self) -> str:
         return self._project.get_project_name()

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1814,6 +1814,13 @@ class Project:
         with self._lock:
             return self._project.get_page_ast(path)
 
+    def fileid_to_source_path(self, path: Path) -> n.Node:
+        # could use config to get file with extension?
+        uwu = self.get_page_ast(path)
+        return uwu.fileid
+        #print(uwu)
+        #return str(uwu.fileid)
+
     def get_project_name(self) -> str:
         return self._project.get_project_name()
 

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -111,7 +111,9 @@ def test_text_doc_resolve() -> None:
     """Tests to see if m_text_document__resolve() returns the proper path combined with
     appropriate extension"""
     with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:
-        server.m_initialize(None, CWD_URL + "/test_data/test_project")
+        server.m_initialize(
+            None, CWD_URL + "/test_data/test_project_embedding_includes"
+        )
 
         assert server.project is not None
 
@@ -127,6 +129,16 @@ def test_text_doc_resolve() -> None:
         )
         expected_path = source_path.joinpath(test_file[1:])
 
+        assert resolve_path == expected_path
+
+        # Test YAML to RST converstion
+        test_file = "/includes/steps/migrate-compose-pr.rst"
+        
+        resolve_path = Path(
+            server.m_text_document__resolve(test_file, docpath_str, resolve_type)
+        )
+
+        expected_path = source_path.joinpath("includes/steps-migrate-compose-pr.yaml")
         assert resolve_path == expected_path
 
         # Resolve arguments for testing doc role target file
@@ -262,7 +274,6 @@ def test_text_doc_get_page_fileid() -> None:
         assert (
             server.m_text_document__get_page_fileid(test_file_path) == expected_fileid
         )
-
 
 def test_reporting_config_error() -> None:
     with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:

--- a/snooty/test_language_server.py
+++ b/snooty/test_language_server.py
@@ -133,7 +133,7 @@ def test_text_doc_resolve() -> None:
 
         # Test YAML to RST converstion
         test_file = "/includes/steps/migrate-compose-pr.rst"
-        
+
         resolve_path = Path(
             server.m_text_document__resolve(test_file, docpath_str, resolve_type)
         )
@@ -274,6 +274,7 @@ def test_text_doc_get_page_fileid() -> None:
         assert (
             server.m_text_document__get_page_fileid(test_file_path) == expected_fileid
         )
+
 
 def test_reporting_config_error() -> None:
     with language_server.LanguageServer(sys.stdin.buffer, sys.stdout.buffer) as server:


### PR DESCRIPTION
### Ticket

DOP-4441

### Notes

Adds a method to get original YAML file paths for rST files that have been converted from YAML files to support the [clickInclude](https://github.com/mongodb/snooty-vscode/blob/main/src/extension.ts#L102) function in the VSCode extension.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
