### PR TITLE
DOCSP-39650 Add atlas admin api to the language dropdown

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1866,8 +1866,9 @@ platforms = [
   {id = "linux", title = "Linux"},
 ]
 drivers = [
+  {id = "atlas-api", title = "Atlas API"},
   {id = "atlas-cli", title = "Atlas CLI"},
-  {id = "atlas-ui", title = "MongoDB Atlas"},
+  {id = "atlas-ui", title = "Atlas UI"},
   {id = "shell", title = "MongoDB Shell"},
   {id = "compass", title = "Compass"},
   {id = "c", title = "C"},


### PR DESCRIPTION
### Ticket

[DOCSP-39650](https://jira.mongodb.org/browse/DOCSP-39650)

### Notes
Adds atlas admin api to the language dropdown. 

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
