### PR TITLE
DOP-4723: Detect include loops

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -3,7 +3,7 @@ from pathlib import Path, PurePath
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from . import n
-from .n import SerializableType
+from .n import FileId, SerializableType
 
 
 class MakeCorrectionMixin:
@@ -941,5 +941,18 @@ class OrphanedPage(Diagnostic):
         super().__init__(
             "Page not included in any toctree and not marked :orphan:",
             0,
+            None,
+        )
+
+
+class IncludeLoop(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self, include_list: Sequence[FileId], start: Union[int, Tuple[int, int]]
+    ) -> None:
+        super().__init__(
+            f"Includes loop: {' -> '.join(str(x) for x in include_list)}",
+            start,
             None,
         )

--- a/snooty/eventparser.py
+++ b/snooty/eventparser.py
@@ -1,6 +1,6 @@
 import threading
 from collections import defaultdict
-from typing import Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
 from . import n
 from .n import FileId
@@ -17,6 +17,12 @@ class FileIdStack:
 
     def __init__(self, initial_stack: Optional[List[FileId]] = None) -> None:
         self._stack: List[FileId] = initial_stack if initial_stack is not None else []
+
+    def __iter__(self) -> Iterator[FileId]:
+        return iter(self._stack)
+
+    def __len__(self) -> int:
+        return len(self._stack)
 
     def pop(self) -> None:
         self._stack.pop()

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -44,6 +44,7 @@ from .diagnostics import (
     ExpectedTabs,
     FetchError,
     GuideAlreadyHasChapter,
+    IncludeLoop,
     InvalidChapter,
     InvalidChild,
     InvalidContextError,
@@ -364,6 +365,13 @@ class IncludeHandler(Handler):
                         )
                     )
                 return
+
+        # Check for duplicate inclusions in this root page context.
+        if collections.Counter(fileid_stack).most_common(1)[0][1] > 1:
+            self.context.diagnostics[fileid_stack.current].append(
+                IncludeLoop(list(fileid_stack), node.span[0])
+            )
+            return
 
         include_page = self.pages.get(include_fileid)
         assert include_page is not None

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -16,6 +16,7 @@ from .diagnostics import (
     ExpectedPathArg,
     ExpectedTabs,
     GuideAlreadyHasChapter,
+    IncludeLoop,
     InvalidChapter,
     InvalidChild,
     InvalidContextError,
@@ -3442,3 +3443,39 @@ Alrighty
         assert slug_to_breadcrumb_label_entry["page1"] == "Look at This"
         assert slug_to_breadcrumb_label_entry["page2"] == "Well, You Learned It"
         assert slug_to_breadcrumb_label_entry["ref/page3"] == "Page Three Title"
+
+
+def test_include_loop() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. include:: index.txt
+"""
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        assert [(type(d), d.message) for d in diagnostics] == [
+            (IncludeLoop, "Includes loop: index.txt -> index.txt")
+        ]
+
+    # A more complicated case where A includes B which includes A
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. include:: foo.rst
+""",
+            Path(
+                "source/foo.rst"
+            ): """
+.. include:: index.txt
+""",
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        assert [(type(d), d.message) for d in diagnostics] == [
+            (IncludeLoop, "Includes loop: index.txt -> foo.rst -> index.txt")
+        ]


### PR DESCRIPTION
### Ticket

DOP-4723

### Notes

It struck me by chance that we don't have cycle detection in our include logic. It hasn't come up, but let's make sure we handle that situation gracefully before it does.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
