### PR TITLE
Dop 4623

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -850,6 +850,20 @@ class IconMustBeDefined(Diagnostic):
             end,
         )
 
+class CardIconString(Diagnostic):
+    severity = Diagnostic.Level.warning
+
+    def __init__(
+        self, 
+        image_argument: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None
+    ) -> None:
+        super().__init__(
+            f"""Card icons are migrating to strings instead of path names. If {image_argument} can be a string, use that instead.""",
+            start, 
+            end,
+        )
 
 class InvalidOpenApiResponse(Diagnostic):
     severity = Diagnostic.Level.error

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -662,7 +662,8 @@ content_type = "block"
 options.headline = "string"
 options.cta = "string"
 options.url = "uri"
-options.icon = ["path", "uri"]
+options.icon = ["path", "uri", "string"]
+options.icon-dark = ["path", "uri"]
 options.icon-alt = "string"
 options.tag = "string"
 


### PR DESCRIPTION
### Ticket

DOP-4623

### Notes

Ugh, there's a lot going on in my brain for this but hopefully I get everything. 

- in addition to Snooty's changes, this adds support for getting card icons from their names in the list [here](https://mongodbcom.website.prod.corp.mongodb.com/cms/icons) rather than having to store them in the content repo. This makes it easier to get images in their dark mode version, since we don't have to store both versions and can instead access them via a URL.
- If, however, we can't access the necessary image from the above list, the `icon-dark` option has been added to cards, as well as a warning if `icon` comes from an image stored in the content repo but `icon-dark` is not given.

Example parser output now looks like this:
<img width="1017" alt="image" src="https://github.com/mongodb/snooty-parser/assets/41043008/2554bf08-4f2e-4a7b-8679-2d1442de6158">

Relevant Snooty PR: <WILL BE LINKED HERE LATER>

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
