### PR TITLE
DOP-4745: Fix IndexError in tinydocutils

### DIFF
--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -531,7 +531,7 @@ class BaseDocutilsDirective(tinydocutils.directives.Directive):
                 tinydocutils.statemachine.StringList(
                     content_lines, source=self.arguments[0]
                 ),
-                self.content_offset,
+                self.lineno,
                 node,
                 match_titles=True,
             )

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3826,3 +3826,30 @@ Procedure
     )
     page.finish(diagnostics)
     assert not diagnostics
+
+
+def test_heading_immediately_after_directive_dop_4745() -> None:
+    path = FileId("test.rst")
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. note:: /somepath
+   {
+""",
+    )
+    page.finish(diagnostics)
+    assert not diagnostics
+
+    check_ast_testing_string(
+        page.ast,
+        """
+<root fileid="test.rst">
+    <directive name="note"><paragraph><text>/somepath
+{</text></paragraph>
+    </directive>
+</root>""",
+    )


### PR DESCRIPTION
### Ticket

DOP-4745

### Notes

This is obnoxious.

The trick here is that we're running `nested_parse()` on the *argument*, not the content, but have been passing `content_offset` to `nested_parse()`. As a result, `content_offset` is out of sync with the actual string list being passed in, and for unknowable reasons this causes an IndexError in the specific case we have here.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
