### PR TITLE
DOP-4690: prepare parser for new collapsible directive

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -944,3 +944,19 @@ class OrphanedPage(Diagnostic):
             0,
             None,
         )
+
+
+class NestedDirective(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        nested_directive: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ):
+        super().__init__(
+            f"""Nested directive detected: {nested_directive}.""",
+            start,
+            end,
+        )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -956,7 +956,7 @@ class NestedDirective(Diagnostic):
         end: Union[None, int, Tuple[int, int]] = None,
     ):
         super().__init__(
-            f"""Nested directive detected: {nested_directive}.""",
+            f"""Nesting of {nested_directive} directives prohibited""",
             start,
             end,
         )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1059,6 +1059,12 @@ class JSONVisitor:
             elif image_argument:
                 self.validate_and_add_asset(doc, image_argument, line)
 
+        elif key in {"mongodb:collapsible"}:
+            if not node.children or len(node.children) == 0:
+                self.diagnostics.append(
+                    MissingChild("mongodb:card", "content block", line)
+                )
+
         elif name == "facet":
             self.handle_facet(node, line)
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1059,8 +1059,8 @@ class JSONVisitor:
             elif image_argument:
                 self.validate_and_add_asset(doc, image_argument, line)
 
-        elif key in {"mongodb:collapsible"}:
-            if not node.children or len(node.children) == 0:
+        elif key == "mongodb:collapsible":
+            if not node.children:
                 self.diagnostics.append(
                     MissingChild("mongodb:card", "content block", line)
                 )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -58,6 +58,7 @@ from .diagnostics import (
     MissingOption,
     MissingTab,
     MissingTocTreeEntry,
+    NestedDirective,
     OrphanedPage,
     SubstitutionRefError,
     TargetNotFound,
@@ -1829,6 +1830,27 @@ class ImageHandler(Handler):
             self.current_img_index += 1
 
 
+class CollapsibleHandler(Handler):
+    """ """
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self.collapsible_detected = False
+
+    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if not isinstance(node, n.Directive) or node.name != "collapsible":
+            return
+        if self.collapsible_detected:
+            self.context.diagnostics[fileid_stack.current].append(
+                NestedDirective("collapsible", node.span[0])
+            )
+        self.collapsible_detected = True
+
+    def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if isinstance(node, n.Directive) and node.name == "collapsible":
+            self.collapsible_detected = False
+
+
 class PostprocessorResult(NamedTuple):
     pages: Dict[FileId, Page]
     metadata: Dict[str, SerializableType]
@@ -1894,6 +1916,7 @@ class Postprocessor:
             OpenAPIChangelogHandler,
             FacetsHandler,
             ImageHandler,
+            CollapsibleHandler,
         ],
         [TargetHandler, IAHandler, NamedReferenceHandlerPass1],
         [RefsHandler, NamedReferenceHandlerPass2],

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -468,7 +468,7 @@ class ContentsHandler(Handler):
     class HeadingData(NamedTuple):
         depth: int
         id: str
-        title: Sequence[Union[n.InlineNode, n.Heading]]
+        title: Sequence[n.InlineNode]
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
@@ -532,13 +532,7 @@ class ContentsHandler(Handler):
                 ContentsHandler.HeadingData(
                     self.current_depth,
                     html5_id,
-                    [
-                        n.Heading(
-                            node.span,
-                            [n.Text(node.span, node.options["heading"])],
-                            html5_id,
-                        )
-                    ],
+                    [n.Text(node.span, node.options["heading"])],
                 )
             )
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1845,7 +1845,8 @@ class ImageHandler(Handler):
 
 
 class CollapsibleHandler(Handler):
-    """ """
+    """Handles nested collapsible directives on a single page.
+    If a page has multiple collapsibles, raise a diagnostic"""
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -71,7 +71,7 @@ from .n import FileId, SerializableType
 from .page import Page
 from .target_database import TargetDatabase
 from .types import Facet, ProjectConfig
-from .util import EXT_FOR_PAGE, SOURCE_FILE_EXTENSIONS, bundle
+from .util import EXT_FOR_PAGE, SOURCE_FILE_EXTENSIONS, bundle, make_html5_id
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
@@ -468,7 +468,7 @@ class ContentsHandler(Handler):
     class HeadingData(NamedTuple):
         depth: int
         id: str
-        title: Sequence[n.InlineNode]
+        title: Sequence[Union[n.InlineNode, str]]
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
@@ -492,7 +492,10 @@ class ContentsHandler(Handler):
                 {
                     "depth": h.depth,
                     "id": h.id,
-                    "title": [node.serialize() for node in h.title],
+                    "title": [
+                        node.serialize() if isinstance(node, n.InlineNode) else node
+                        for node in h.title
+                    ],
                 }
                 for h in self.headings
                 if h.depth - 1 <= self.contents_depth
@@ -523,6 +526,17 @@ class ContentsHandler(Handler):
         if isinstance(node, n.Heading) and self.current_depth > 1:
             self.headings.append(
                 ContentsHandler.HeadingData(self.current_depth, node.id, node.children)
+            )
+
+        if isinstance(node, n.Directive) and node.name == "collapsible":
+            html5_id = make_html5_id(node.options["heading"])
+            node.options["id"] = html5_id
+            self.headings.append(
+                ContentsHandler.HeadingData(
+                    self.current_depth,
+                    html5_id,
+                    [node.options["heading"]],
+                )
             )
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -861,6 +861,18 @@ example = """.. facet::
    :values: ${2:value1, value2, value3}
 """
 
+[directive."mongodb:collapsible"]
+help = """Card in a card-group. Each card links to the specified URI, and can include an icon, as well as a call-to-action string"""
+options.heading = {type = "string", required = true}
+options.sub_heading = "string"
+content_type = "block"
+example = """.. collapsible::
+   :heading: ${1:Procdure}
+   :sub_heading: ${2:Description of what is inside the collapsible section}
+
+   ${3:collapsible content block.}
+"""
+
 ###### Misc.
 [directive.atf-image]
 help = "Path to the image to use for the above-the-fold header image"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3490,5 +3490,22 @@ def test_collapsible_headings() -> None:
     ) as result:
         page = result.pages[FileId("index.txt")]
         assert page.ast.options.get("headings") == [
-            {"depth": 0, "id": "Heading-goes-here", "title": ["Heading goes here"]}
+            {
+                "depth": 0,
+                "id": "heading-goes-here",
+                "title": [
+                    {
+                        "children": [
+                            {
+                                "position": {"start": {"line": 5}},
+                                "type": "text",
+                                "value": "Heading goes here",
+                            },
+                        ],
+                        "id": "heading-goes-here",
+                        "position": {"start": {"line": 5}},
+                        "type": "heading",
+                    },
+                ],
+            },
         ]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3489,5 +3489,6 @@ def test_collapsible_headings() -> None:
         }
     ) as result:
         page = result.pages[FileId("index.txt")]
-        assert len(page.ast.options.get("headings")) == 1
-        assert page.ast.options.get("headings")[0]["title"] == ["Heading goes here"]
+        assert page.ast.options.get("headings") == [
+            {"depth": 0, "id": "Heading-goes-here", "title": ["Heading goes here"]}
+        ]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -26,6 +26,7 @@ from .diagnostics import (
     MissingChild,
     MissingTab,
     MissingTocTreeEntry,
+    NestedDirective,
     OrphanedPage,
     SubstitutionRefError,
     TabMustBeDirective,
@@ -3442,3 +3443,29 @@ Alrighty
         assert slug_to_breadcrumb_label_entry["page1"] == "Look at This"
         assert slug_to_breadcrumb_label_entry["page2"] == "Well, You Learned It"
         assert slug_to_breadcrumb_label_entry["ref/page3"] == "Page Three Title"
+
+
+def test_nested_collapsibles() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. collapsible::
+    :heading: Heading
+    :sub_heading: Subheading
+
+    This is a parent 
+
+    .. collapsible::
+        :heading: Heading 2
+        :sub_heading: Subheading 2
+
+        This is a nested 
+            """,
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        print(result.diagnostics)
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], NestedDirective)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3466,6 +3466,28 @@ def test_nested_collapsibles() -> None:
         }
     ) as result:
         diagnostics = result.diagnostics[FileId("index.txt")]
-        print(result.diagnostics)
         assert len(diagnostics) == 1
         assert isinstance(diagnostics[0], NestedDirective)
+
+
+def test_collapsible_headings() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. contents::
+   :depth: 2
+
+
+.. collapsible::
+    :heading: Heading goes here
+    :sub_heading: Subheading
+
+    This is content
+            """,
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        assert len(page.ast.options.get("headings")) == 1
+        assert page.ast.options.get("headings")[0]["title"] == ["Heading goes here"]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3495,16 +3495,9 @@ def test_collapsible_headings() -> None:
                 "id": "heading-goes-here",
                 "title": [
                     {
-                        "children": [
-                            {
-                                "position": {"start": {"line": 5}},
-                                "type": "text",
-                                "value": "Heading goes here",
-                            },
-                        ],
-                        "id": "heading-goes-here",
                         "position": {"start": {"line": 5}},
-                        "type": "heading",
+                        "type": "text",
+                        "value": "Heading goes here",
                     },
                 ],
             },


### PR DESCRIPTION
### Ticket

DOP-4690

### Notes

**Changes from this PR**
- Adds `.. collapsible:: ` directive into our rstspec, and handles new ReSTructured text into expected AST
has `heading:string (required)` and `sub_heading.string` options, along with a required `content_type:block` 
- Adds Error level Diagnostics for missing content block within collapsible directive
- Adds Error level Diagnostics for nested collapsibles
- Inserts the `heading` option from new directive into `page.ast.options.headings[]` during postprocess so that this can be included in the right column for `On this page`. Discussed offline with @i80and that the alternative to this would be to enforce a heading and subheading structure within the `content_type`, but no strong opinions here

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
