### PR TITLE
DOP-4692: Implement wayfinding directives

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -968,12 +968,12 @@ class UnknownWayfindingOption(Diagnostic):
     def __init__(
         self,
         invalid_id: str,
-        valid_ids: AbstractSet[str],
+        valid_ids: List[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ):
         super().__init__(
-            f"Wayfinding option id {invalid_id} is not valid. Expected one of the following: {sorted(valid_ids)}",
+            f"Wayfinding option id {invalid_id} is not valid. Expected one of the following: {valid_ids}",
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -960,3 +960,19 @@ class NestedDirective(Diagnostic):
             start,
             end,
         )
+
+
+class UnknownWayfindingOption(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        invalid_id: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ):
+        super().__init__(
+            f"Wayfinding option id {invalid_id} is not valid.",
+            start,
+            end,
+        )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -968,11 +968,12 @@ class UnknownWayfindingOption(Diagnostic):
     def __init__(
         self,
         invalid_id: str,
+        valid_ids: AbstractSet[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ):
         super().__init__(
-            f"Wayfinding option id {invalid_id} is not valid.",
+            f"Wayfinding option id {invalid_id} is not valid. Expected one of the following: {sorted(valid_ids)}",
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -976,3 +976,19 @@ class UnknownWayfindingOption(Diagnostic):
             start,
             end,
         )
+
+
+class DuplicateWayfindingOption(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        invalid_id: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ):
+        super().__init__(
+            f"Wayfinding option id {invalid_id} is already used in current wayfinding context.",
+            start,
+            end,
+        )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -658,9 +658,9 @@ class JSONVisitor:
         expected_children_names = {expected_child_opt_name, expected_child_desc_name}
         wayfinding_name = "wayfinding"
 
-        valid_opts: list[n.Node] = []
+        valid_opts: List[n.Node] = []
         valid_desc: n.Node | None = None
-        used_ids: set[str] = set()
+        used_ids: Set[str] = set()
 
         # Validate children
         for child in node.children:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -698,8 +698,11 @@ class JSONVisitor:
                 continue
 
             if not option_id in expected_options_dict:
+                available_ids = set(expected_options_dict.keys())
                 self.diagnostics.append(
-                    UnknownWayfindingOption(option_id, child_line_start)
+                    UnknownWayfindingOption(
+                        option_id, available_ids, child_line_start
+                    )
                 )
                 continue
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -58,6 +58,7 @@ from .diagnostics import (
     FetchError,
     IconMustBeDefined,
     ImageSuggested,
+    InvalidChild,
     InvalidDirectiveStructure,
     InvalidField,
     InvalidLiteralInclude,
@@ -74,6 +75,7 @@ from .diagnostics import (
     UnexpectedIndentation,
     UnknownTabID,
     UnknownTabset,
+    UnknownWayfindingOption,
     UnmarshallingError,
 )
 from .icon_names import ICON_SET, LG_ICON_SET
@@ -553,6 +555,9 @@ class JSONVisitor:
 
         elif isinstance(popped, n.Directive) and popped.name == "step":
             popped.children = [n.Section((node.get_line(),), popped.children)]
+        
+        elif isinstance(popped, n.Directive) and popped.name == "wayfinding":
+            self.handle_wayfinding(popped)
 
     def handle_facet(self, node: rstparser.directive, line: int) -> None:
         if "values" not in node["options"] or "name" not in node["options"]:
@@ -643,6 +648,52 @@ class JSONVisitor:
             node.children,
             key=lambda x: tabid_list.index(cast(n.Directive, x).options["tabid"]),
         )
+    
+    def handle_wayfinding(self, node: n.Directive) -> None:
+        valid_options = specparser.Spec.get().wayfinding["options"]
+        valid_options_dict = {option.id: option for option in valid_options}
+        valid_children: List[n.Directive] = []
+        expected_child_name = "wayfinding-option"
+        wayfinding_name = "wayfinding"
+
+        if not node.children:
+            self.diagnostics.append(MissingChild(wayfinding_name, expected_child_name, node.start[0]))
+            return
+        
+        # Validate children
+        for child in node.children:
+            child_line_start = child.start[0]
+
+            invalid_child = None
+            if not isinstance(child, n.Directive):
+                # Catches additional unwanted types like Paragraph
+                invalid_child = child.type
+            elif child.name != expected_child_name:
+                invalid_child = child.name
+            if invalid_child:
+                self.diagnostics.append(InvalidChild(invalid_child, wayfinding_name, expected_child_name, child_line_start))
+                continue
+
+            option_id = child.options.get("id")
+
+            if not (child.argument and option_id):
+                # Don't append diagnostic since docutils should already 
+                # complain about missing argument and ID option
+                continue
+
+            if not option_id in valid_options_dict:
+                self.diagnostics.append(UnknownWayfindingOption(option_id, child_line_start))
+                continue
+        
+            valid_children.append(child)
+
+        def sort_key(node: n.Directive):
+            # Associate the child node with the actual wayfinding option
+            wayfinding_option = valid_options_dict[node.options["id"]]
+            return (not wayfinding_option.show_first, wayfinding_option.language, wayfinding_option.title)
+
+        new_children = sorted(valid_children, key=sort_key)
+        node.children = new_children
 
     def handle_directive(
         self, node: rstparser.directive, line: int

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -652,7 +652,7 @@ class JSONVisitor:
     def handle_wayfinding(self, node: n.Directive) -> None:
         valid_options = specparser.Spec.get().wayfinding["options"]
         valid_options_dict = {option.id: option for option in valid_options}
-        valid_children: List[n.Directive] = []
+        valid_children: list[n.Node] = []
         expected_child_name = "wayfinding-option"
         wayfinding_name = "wayfinding"
 
@@ -683,6 +683,8 @@ class JSONVisitor:
                 )
                 continue
 
+            # Type is ambiguous now despite if statements above
+            assert isinstance(child, n.Directive)
             option_id = child.options.get("id")
 
             if not (child.argument and option_id):
@@ -698,7 +700,9 @@ class JSONVisitor:
 
             valid_children.append(child)
 
-        def sort_key(node: n.Directive):
+        def sort_key(node: n.Node) -> tuple[bool, str, str]:
+            # All children should be directives; keeping Node type for type compatibility of new children
+            assert isinstance(node, n.Directive)
             # Associate the child node with the actual wayfinding option
             wayfinding_option = valid_options_dict[node.options["id"]]
             return (

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -698,11 +698,10 @@ class JSONVisitor:
                 continue
 
             if not option_id in expected_options_dict:
-                available_ids = set(expected_options_dict.keys())
+                available_ids = list(expected_options_dict.keys())
+                available_ids.sort()
                 self.diagnostics.append(
-                    UnknownWayfindingOption(
-                        option_id, available_ids, child_line_start
-                    )
+                    UnknownWayfindingOption(option_id, available_ids, child_line_start)
                 )
                 continue
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1905,7 +1905,7 @@ class WayfindingHandler(Handler):
         if node.name != self.wayfinding_name:
             self.nesting_level -= 1
 
-    def enter_page(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.nesting_level = 0
         self.wayfinding_detected = False
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1863,6 +1863,53 @@ class CollapsibleHandler(Handler):
             self.collapsible_detected = False
 
 
+class WayfindingHandler(Handler):
+    """Handles page-level validations for wayfinding directive."""
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self.wayfinding_name = "wayfinding"
+        self.include_names = {"include", "sharedinclude"}
+        self.wayfinding_detected = False
+        self.nesting_level = 0
+
+    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        # Skip include directives since they should be allowed to nest wayfinding in them
+        if not isinstance(node, n.Directive) or node.name in self.include_names:
+            return
+
+        # Track if node is nested deeper than intended
+        if node.name != self.wayfinding_name:
+            self.nesting_level += 1
+            return
+
+        line_start = node.span[0]
+
+        if self.wayfinding_detected:
+            self.context.diagnostics[fileid_stack.current].append(
+                DuplicateDirective(node.name, line_start)
+            )
+            return
+
+        if self.nesting_level > 0:
+            self.context.diagnostics[fileid_stack.current].append(
+                NestedDirective(node.name, line_start)
+            )
+            return
+
+        self.wayfinding_detected = True
+
+    def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if not isinstance(node, n.Directive) or node.name in self.include_names:
+            return
+        if node.name != self.wayfinding_name:
+            self.nesting_level -= 1
+
+    def enter_page(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        self.nesting_level = 0
+        self.wayfinding_detected = False
+
+
 class PostprocessorResult(NamedTuple):
     pages: Dict[FileId, Page]
     metadata: Dict[str, SerializableType]
@@ -1929,6 +1976,7 @@ class Postprocessor:
             FacetsHandler,
             ImageHandler,
             CollapsibleHandler,
+            WayfindingHandler
         ],
         [TargetHandler, IAHandler, NamedReferenceHandlerPass1],
         [RefsHandler, NamedReferenceHandlerPass2],

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1976,7 +1976,7 @@ class Postprocessor:
             FacetsHandler,
             ImageHandler,
             CollapsibleHandler,
-            WayfindingHandler
+            WayfindingHandler,
         ],
         [TargetHandler, IAHandler, NamedReferenceHandlerPass1],
         [RefsHandler, NamedReferenceHandlerPass2],

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -800,11 +800,16 @@ example = """.. collapsible::
 [directive."mongodb:wayfinding"]
 help = "Helps list out related URL pages for drivers."
 content_type = "block"
+argument_type = "string"
 example = """.. wayfinding::
    
    .. wayfinding-option:: https://www.mongodb.com/docs/drivers/node/current/usage-examples/findOne/
       :id: nodejs
 """
+
+[directive."mongodb:wayfinding-description"]
+help = "A description for wayfinding."
+content_type = "block"
 
 [directive."mongodb:wayfinding-option"]
 help = "An option for wayfinding."

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -797,6 +797,20 @@ example = """.. collapsible::
    ${3:collapsible content block.}
 """
 
+[directive."mongodb:wayfinding"]
+help = "Helps list out related URL pages for drivers."
+content_type = "block"
+example = """.. wayfinding::
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/drivers/node/current/usage-examples/findOne/
+      :id: nodejs
+"""
+
+[directive."mongodb:wayfinding-option"]
+help = "An option for wayfinding."
+argument_type = {type = "uri", required = true}
+options.id = {type = "string", required = true}
+
 ###### Misc.
 [directive.atf-image]
 help = "Path to the image to use for the above-the-fold header image"
@@ -1902,4 +1916,26 @@ realm-auth-providers = [
   {id = "api-key", title = "API Key"},
   {id = "custom-token", title = "Custom JWT"},
   {id = "custom-function", title = "Custom Function"},
+]
+
+[wayfinding]
+options = [
+   {id = "c", language = "c", title = "C"},
+   {id = "csharp", language = "c#", title = "C#", show_first = true},
+   {id = "cpp", language = "c++", title = "C++"},
+   {id = "go", language = "golang", title = "Go"},
+   {id = "java-rs", language = "java", title = "Reactive Streams"},
+   {id = "java-sync", language = "java", title = "Java Sync", show_first = true},
+   {id = "nodejs", language = "javascript", title = "Node.js", show_first = true},
+   {id = "kotlin-coroutine", language = "kotlin", title = "Kotlin Coroutine"},
+   {id = "kotlin-sync", language = "kotlin", title = "Kotlin Sync"},
+   {id = "php", language = "php", title = "PHP"},
+   {id = "motor", language = "python" , title = "Motor"},
+   {id = "pymongo", language = "python" , title = "Pymongo"},
+   {id = "python", language = "python" , title = "Python", show_first = true},
+   {id = "mongoid", language = "ruby" , title = "Mongoid"},
+   {id = "rust", language = "rust" , title = "Rust"},
+   {id = "scala", language = "scala" , title = "Scala"},
+   {id = "swift", language = "swift" , title = "Swift"},
+   {id = "typescript", language = "typescript" , title = "Typescript"},
 ]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1936,7 +1936,7 @@ options = [
    {id = "kotlin-sync", language = "kotlin", title = "Kotlin Sync"},
    {id = "php", language = "php", title = "PHP"},
    {id = "motor", language = "python" , title = "Motor"},
-   {id = "pymongo", language = "python" , title = "Pymongo"},
+   {id = "pymongo", language = "python" , title = "PyMongo"},
    {id = "python", language = "python" , title = "Python", show_first = true},
    {id = "mongoid", language = "ruby" , title = "Mongoid"},
    {id = "rust", language = "rust" , title = "Rust"},

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1929,7 +1929,7 @@ options = [
    {id = "csharp", language = "c#", title = "C#", show_first = true},
    {id = "cpp", language = "c++", title = "C++"},
    {id = "go", language = "golang", title = "Go"},
-   {id = "java-rs", language = "java", title = "Reactive Streams"},
+   {id = "java-rs", language = "java", title = "Java RS"},
    {id = "java-sync", language = "java", title = "Java Sync", show_first = true},
    {id = "nodejs", language = "javascript", title = "Node.js", show_first = true},
    {id = "kotlin-coroutine", language = "kotlin", title = "Kotlin Coroutine"},

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -119,6 +119,15 @@ class TabDefinition:
 
 @checked
 @dataclass
+class WayfindingOption:
+    id: str
+    language: str
+    title: str
+    show_first: bool = field(default=False)
+
+
+@checked
+@dataclass
 class LinkRoleType:
     """Configuration for a role which links to a specific URL template."""
 
@@ -275,6 +284,7 @@ class Spec:
     role: Dict[str, Role] = field(default_factory=dict)
     rstobject: Dict[str, RstObject] = field(default_factory=dict)
     tabs: Dict[str, List[TabDefinition]] = field(default_factory=dict)
+    wayfinding: Dict[str, List[WayfindingOption]] = field(default_factory=dict)
     data_fields: List[str] = field(default_factory=list)
 
     SPEC: ClassVar[Optional[Spec]] = None

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -13,6 +13,7 @@ from .diagnostics import (
     IconMustBeDefined,
     IncorrectLinkSyntax,
     IncorrectMonospaceSyntax,
+    InvalidChild,
     InvalidDirectiveStructure,
     InvalidField,
     InvalidLiteralInclude,
@@ -28,6 +29,7 @@ from .diagnostics import (
     UnexpectedIndentation,
     UnknownTabID,
     UnknownTabset,
+    UnknownWayfindingOption,
 )
 from .n import FileId
 from .parser import InlineJSONVisitor, JSONVisitor
@@ -3873,4 +3875,237 @@ def test_collapsible() -> None:
 """,
     )
     assert len(diagnostics) == 1
+    assert [type(d) for d in diagnostics] == [MissingChild]
+
+
+def test_wayfinding_sorted() -> None:
+    path = FileId("test.rst")
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. wayfinding::
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: php
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: c
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: java-sync
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: scala
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: csharp
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: kotlin-coroutine
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: pymongo
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: mongoid
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: motor
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: python
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: nodejs
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: kotlin-sync
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: rust
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: java-rs
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: go
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: cpp
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: swift
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: typescript
+
+    """,
+    )
+    page.finish(diagnostics)
+    assert not diagnostics
+
+    ast_to_testing_string(page.ast)
+    check_ast_testing_string(
+        page.ast,
+        """
+<root fileid="test.rst">
+	<directive domain="mongodb" name="wayfinding">
+		<directive domain="mongodb" name="wayfinding-option" id="csharp">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="java-sync">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="nodejs">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="python">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="c">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="cpp">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="go">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="java-rs">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="kotlin-coroutine">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="kotlin-sync">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="php">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="motor">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="pymongo">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="mongoid">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="rust">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="scala">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="swift">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+		<directive domain="mongodb" name="wayfinding-option" id="typescript">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+	</directive>
+</root>
+""",
+    )
+
+
+def test_wayfinding_errors() -> None:
+    path = FileId("test.rst")
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    # Test invalid syntax
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. wayfinding::
+
+   Hello this is text
+   
+   .. wayfinding-option::
+      :id: php
+    
+   .. note::
+
+      This is an admonition that does not belong!
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: c
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: java-sync
+    
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: bad-id
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+
+    """,
+    )
+    page.finish(diagnostics)
+    assert [type(d) for d in diagnostics] == [
+        # Missing argument
+        DocUtilsParseError,
+        # Missing option
+        DocUtilsParseError,
+        # Paragraph
+        InvalidChild,
+        # Note
+        InvalidChild,
+        # bad-id
+        UnknownWayfindingOption,
+    ]
+
+    # Test missing children
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. wayfinding::
+
+    """,
+    )
+    page.finish(diagnostics)
     assert [type(d) for d in diagnostics] == [MissingChild]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -6,6 +6,7 @@ from .diagnostics import (
     CannotOpenFile,
     Diagnostic,
     DocUtilsParseError,
+    DuplicateWayfindingOption,
     ErrorParsingYAMLFile,
     ExpectedOption,
     ExpectedPathArg,
@@ -3887,7 +3888,7 @@ def test_wayfinding_sorted() -> None:
         parser,
         path,
         """
-.. wayfinding::
+.. wayfinding:: MongoDB for drivers
    
    .. wayfinding-option:: https://www.mongodb.com/docs/
       :id: php
@@ -3943,6 +3944,10 @@ def test_wayfinding_sorted() -> None:
    .. wayfinding-option:: https://www.mongodb.com/docs/
       :id: typescript
 
+      
+   .. wayfinding-description::
+
+      This page is for mongosh. For pages specific to a driver, see the following:
     """,
     )
     page.finish(diagnostics)
@@ -3954,92 +3959,96 @@ def test_wayfinding_sorted() -> None:
         """
 <root fileid="test.rst">
 	<directive domain="mongodb" name="wayfinding">
-		<directive domain="mongodb" name="wayfinding-option" id="csharp">
+        <text>MongoDB for drivers</text>
+        <directive domain="mongodb" name="wayfinding-description">
+            <paragraph><text>This page is for mongosh. For pages specific to a driver, see the following:</text></paragraph>
+        </directive>
+		<directive domain="mongodb" name="wayfinding-option" id="csharp" title="C#" language="c#">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="java-sync">
+		<directive domain="mongodb" name="wayfinding-option" id="java-sync" title="Java Sync" language="java">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="nodejs">
+		<directive domain="mongodb" name="wayfinding-option" id="nodejs" title="Node.js" language="javascript">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="python">
+		<directive domain="mongodb" name="wayfinding-option" id="python" title="Python" language="python">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="c">
+		<directive domain="mongodb" name="wayfinding-option" id="c" title="C" language="c">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="cpp">
+		<directive domain="mongodb" name="wayfinding-option" id="cpp" title="C++" language="c++">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="go">
+		<directive domain="mongodb" name="wayfinding-option" id="go" title="Go" language="golang">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="java-rs">
+		<directive domain="mongodb" name="wayfinding-option" id="java-rs" title="Reactive Streams" language="java">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="kotlin-coroutine">
+		<directive domain="mongodb" name="wayfinding-option" id="kotlin-coroutine" title="Kotlin Coroutine" language="kotlin">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="kotlin-sync">
+		<directive domain="mongodb" name="wayfinding-option" id="kotlin-sync" title="Kotlin Sync" language="kotlin">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="php">
+		<directive domain="mongodb" name="wayfinding-option" id="php" title="PHP" language="php">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="motor">
+		<directive domain="mongodb" name="wayfinding-option" id="motor" title="Motor" language="python">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="pymongo">
+		<directive domain="mongodb" name="wayfinding-option" id="pymongo" title="Pymongo" language="python">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="mongoid">
+		<directive domain="mongodb" name="wayfinding-option" id="mongoid" title="Mongoid" language="ruby">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="rust">
+		<directive domain="mongodb" name="wayfinding-option" id="rust" title="Rust" language="rust">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="scala">
+		<directive domain="mongodb" name="wayfinding-option" id="scala" title="Scala" language="scala">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="swift">
+		<directive domain="mongodb" name="wayfinding-option" id="swift" title="Swift" language="swift">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="typescript">
+		<directive domain="mongodb" name="wayfinding-option" id="typescript" title="Typescript" language="typescript">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
@@ -4082,6 +4091,12 @@ def test_wayfinding_errors() -> None:
    
    .. wayfinding-option:: https://www.mongodb.com/docs/
 
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: c
+    
+   .. wayfinding-description::
+
+      This is a description of the wayfinding component
     """,
     )
     page.finish(diagnostics)
@@ -4096,6 +4111,8 @@ def test_wayfinding_errors() -> None:
         InvalidChild,
         # bad-id
         UnknownWayfindingOption,
+        # Duplicate "c" id
+        DuplicateWayfindingOption,
     ]
 
     # Test missing children
@@ -4108,4 +4125,4 @@ def test_wayfinding_errors() -> None:
     """,
     )
     page.finish(diagnostics)
-    assert [type(d) for d in diagnostics] == [MissingChild]
+    assert [type(d) for d in diagnostics] == [MissingChild, MissingChild]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3998,7 +3998,7 @@ def test_wayfinding_sorted() -> None:
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="java-rs" title="Reactive Streams" language="java">
+		<directive domain="mongodb" name="wayfinding-option" id="java-rs" title="Java RS" language="java">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3952,8 +3952,6 @@ def test_wayfinding_sorted() -> None:
     )
     page.finish(diagnostics)
     assert not diagnostics
-
-    ast_to_testing_string(page.ast)
     check_ast_testing_string(
         page.ast,
         """

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4023,7 +4023,7 @@ def test_wayfinding_sorted() -> None:
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>
 		</directive>
-		<directive domain="mongodb" name="wayfinding-option" id="pymongo" title="Pymongo" language="python">
+		<directive domain="mongodb" name="wayfinding-option" id="pymongo" title="PyMongo" language="python">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3566,7 +3566,6 @@ Valid Wayfinding
 """,
         }
     ) as result:
-        print(result.diagnostics[FileId("index.txt")])
         assert [type(x) for x in result.diagnostics[FileId("index.txt")]] == [
             DuplicateDirective
         ]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3551,9 +3551,14 @@ Valid Wayfinding
 ================
 
 .. include:: /includes/included_wayfinding.rst
-"""
+""",
         }
     ) as result:
-        assert [type(x) for x in result.diagnostics[FileId("index.txt")]] == [DuplicateDirective]
-        assert [type(x) for x in result.diagnostics[FileId("includes/included_wayfinding.rst")]] == [NestedDirective]
+        assert [type(x) for x in result.diagnostics[FileId("index.txt")]] == [
+            DuplicateDirective
+        ]
+        assert [
+            type(x)
+            for x in result.diagnostics[FileId("includes/included_wayfinding.rst")]
+        ] == [NestedDirective]
         assert len(result.diagnostics[FileId("valid_wayfinding.txt")]) == 0

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3512,10 +3512,18 @@ def test_wayfinding() -> None:
             ): """
 .. wayfinding::
    
+   .. wayfinding-description::
+
+      Wayfinding for mongosh
+
    .. wayfinding-option:: https://www.mongodb.com/docs/
       :id: c
 
 .. wayfinding::
+
+   .. wayfinding-description::
+
+      Wayfinding for mongosh 2
 
    .. wayfinding-option:: https://www.mongodb.com/docs/
       :id: scala
@@ -3525,6 +3533,10 @@ def test_wayfinding() -> None:
             ): """
 .. wayfinding::
    
+   .. wayfinding-description::
+
+      Wayfinding for mongosh
+
    .. wayfinding-option:: https://www.mongodb.com/docs/
       :id: c
 """,
@@ -3554,6 +3566,7 @@ Valid Wayfinding
 """,
         }
     ) as result:
+        print(result.diagnostics[FileId("index.txt")])
         assert [type(x) for x in result.diagnostics[FileId("index.txt")]] == [
             DuplicateDirective
         ]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3502,3 +3502,58 @@ def test_collapsible_headings() -> None:
                 ],
             },
         ]
+
+
+def test_wayfinding() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. wayfinding::
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: c
+
+.. wayfinding::
+
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: scala
+""",
+            Path(
+                "source/includes/included_wayfinding.rst"
+            ): """
+.. wayfinding::
+   
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: c
+""",
+            Path(
+                "source/nested_wayfinding.txt"
+            ): """
+:orphan:
+
+=================
+Nested Wayfinding
+=================
+
+.. note::
+
+   .. include:: /includes/included_wayfinding.rst
+""",
+            Path(
+                "source/valid_wayfinding.txt"
+            ): """
+:orphan:
+
+================
+Valid Wayfinding
+================
+
+.. include:: /includes/included_wayfinding.rst
+"""
+        }
+    ) as result:
+        assert [type(x) for x in result.diagnostics[FileId("index.txt")]] == [DuplicateDirective]
+        assert [type(x) for x in result.diagnostics[FileId("includes/included_wayfinding.rst")]] == [NestedDirective]
+        assert len(result.diagnostics[FileId("valid_wayfinding.txt")]) == 0


### PR DESCRIPTION
### Ticket

DOP-4692
[Related frontend PR](https://github.com/mongodb/snooty/pull/1192)
[Designs](https://www.figma.com/design/7cR6eWtFvKTnJIPL8ZsTaB/Content-Template-Projects?node-id=3147-3388&t=PnibGktO5uVkJEtU-0)
[rST example](https://github.com/rayangler/cloud-docs/blob/test-wayfinding/source/testing-wayfinding.txt)

### Notes

* I opted to create a separate directive for the description inside of the `wayfinding` directive instead of using some `description` option because (1) it allows the component to be more flexible for different use cases and copy if needed, and (2) it allows the use of an `include` directive to make it easier to share copy for related instances of the directive.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
