### PR TITLE
DOP-4685: Implement method-selector

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -962,34 +962,36 @@ class NestedDirective(Diagnostic):
         )
 
 
-class UnknownWayfindingOption(Diagnostic):
+class UnknownOptionId(Diagnostic):
     severity = Diagnostic.Level.error
 
     def __init__(
         self,
+        directive_name: str,
         invalid_id: str,
         valid_ids: List[str],
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ):
         super().__init__(
-            f"Wayfinding option id {invalid_id} is not valid. Expected one of the following: {valid_ids}",
+            f"{directive_name} id {invalid_id} is not valid. Expected one of the following: {valid_ids}",
             start,
             end,
         )
 
 
-class DuplicateWayfindingOption(Diagnostic):
+class DuplicateOptionId(Diagnostic):
     severity = Diagnostic.Level.error
 
     def __init__(
         self,
+        directive_name: str,
         invalid_id: str,
         start: Union[int, Tuple[int, int]],
         end: Union[None, int, Tuple[int, int]] = None,
     ):
         super().__init__(
-            f"Wayfinding option id {invalid_id} is already used in current wayfinding context.",
+            f"{directive_name} option id {invalid_id} is already used in current context.",
             start,
             end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -1002,15 +1002,11 @@ class UnexpectedDirectiveOrder(Diagnostic):
 
     def __init__(
         self,
-        message: str, 
+        message: str,
         start: Union[int, Tuple[int, int]],
-        end: Union[None, int, Tuple[int, int]] = None
+        end: Union[None, int, Tuple[int, int]] = None,
     ):
-        super().__init__(
-            f"Unexpected directive order. Expected: {message}",
-            start,
-            end
-        )
+        super().__init__(f"Unexpected directive order. Expected: {message}", start, end)
 
 
 class InvalidChildCount(Diagnostic):
@@ -1020,12 +1016,12 @@ class InvalidChildCount(Diagnostic):
         self,
         parent_name: str,
         child_name: str,
-        expected: str, 
+        expected: str,
         start: Union[int, Tuple[int, int]],
-        end: Union[None, int, Tuple[int, int]] = None
+        end: Union[None, int, Tuple[int, int]] = None,
     ):
         super().__init__(
             f"Unexpected number of {child_name} in {parent_name}. Expected: {expected}",
             start,
-            end
+            end,
         )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -1011,3 +1011,21 @@ class UnexpectedDirectiveOrder(Diagnostic):
             start,
             end
         )
+
+
+class InvalidChildCount(Diagnostic):
+    severity = Diagnostic.Level.error
+
+    def __init__(
+        self,
+        parent_name: str,
+        child_name: str,
+        expected: str, 
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None
+    ):
+        super().__init__(
+            f"Unexpected number of {child_name} in {parent_name}. Expected: {expected}",
+            start,
+            end
+        )

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -995,3 +995,19 @@ class DuplicateOptionId(Diagnostic):
             start,
             end,
         )
+
+
+class UnexpectedDirectiveOrder(Diagnostic):
+    severity = Diagnostic.Level.warning
+
+    def __init__(
+        self,
+        message: str, 
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None
+    ):
+        super().__init__(
+            f"Unexpected directive order. Expected: {message}",
+            start,
+            end
+        )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -562,6 +562,12 @@ class JSONVisitor:
         elif isinstance(popped, n.Directive) and popped.name == "wayfinding":
             self.handle_wayfinding(popped)
 
+        elif isinstance(popped, n.Directive) and popped.name == "method-selector":
+            self.handle_method_selector(popped)
+
+        elif isinstance(popped, n.Directive) and popped.name == "method-option":
+            self.handle_method_option(popped)
+
     def handle_facet(self, node: rstparser.directive, line: int) -> None:
         if "values" not in node["options"] or "name" not in node["options"]:
             return

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -110,8 +110,6 @@ class ProjectLoadError(Exception):
 
 
 class ChildValidationError(Exception):
-    """Empty exception expected to continue"""
-
     pass
 
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -813,7 +813,10 @@ class JSONVisitor:
             # The Drivers option should be encouraged to be first
             if option_id == "drivers" and valid_children:
                 self.diagnostics.append(
-                    UnexpectedDirectiveOrder(f"{child.name} with id \"{option_id}\" should be the first child of {node.name}", child_line_start)
+                    UnexpectedDirectiveOrder(
+                        f'{child.name} with id "{option_id}" should be the first child of {node.name}',
+                        child_line_start,
+                    )
                 )
 
             option_details = expected_options_dict[option_id]
@@ -823,11 +826,13 @@ class JSONVisitor:
 
         if len(valid_children) < 2 or len(valid_children) > 6:
             self.diagnostics.append(
-                InvalidChildCount(node.name, expected_child_name, "2-6 options", node.start[0])
+                InvalidChildCount(
+                    node.name, expected_child_name, "2-6 options", node.start[0]
+                )
             )
 
         node.children = cast(List[n.Node], valid_children)
-    
+
     def handle_method_option(self, node: n.Directive) -> None:
         """Moves method-description as the first child of the option to help enforce order."""
 
@@ -840,7 +845,10 @@ class JSONVisitor:
 
                 if idx != 0:
                     self.diagnostics.append(
-                        UnexpectedDirectiveOrder(f"{expected_desc_name} should be the first child of {node.name}", child.start[0])
+                        UnexpectedDirectiveOrder(
+                            f"{expected_desc_name} should be the first child of {node.name}",
+                            child.start[0],
+                        )
                     )
 
                 break

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -60,6 +60,7 @@ from .diagnostics import (
     IconMustBeDefined,
     ImageSuggested,
     InvalidChild,
+    InvalidChildCount,
     InvalidDirectiveStructure,
     InvalidField,
     InvalidLiteralInclude,
@@ -819,6 +820,11 @@ class JSONVisitor:
             child.options["title"] = option_details.title
             valid_children.append(child)
             used_ids.add(option_id)
+
+        if len(valid_children) < 2 or len(valid_children) > 6:
+            self.diagnostics.append(
+                InvalidChildCount(node.name, expected_child_name, "2-6 options", node.start[0])
+            )
 
         node.children = cast(List[n.Node], valid_children)
     

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -743,6 +743,9 @@ class JSONVisitor:
 
         node.children = cast(List[n.Node], valid_children)
 
+    def handle_method_selector(self, node: n.Directive):
+        pass
+
     def handle_directive(
         self, node: rstparser.directive, line: int
     ) -> Optional[n.Node]:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -794,7 +794,7 @@ class JSONVisitor:
 
             # The Drivers option should be encouraged to be first
             option_id = child.options.get("id", "")
-            if option_id == "drivers" and valid_children:
+            if option_id == "driver" and valid_children:
                 self.diagnostics.append(
                     UnexpectedDirectiveOrder(
                         f'{child.name} with id "{option_id}" should be the first child of {node.name}',

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -680,6 +680,7 @@ class JSONVisitor:
         for child in node.children:
             try:
                 self.check_valid_child(node, child, expected_children_names)
+                # check_valid_child verifies that the child is a directive
                 assert isinstance(child, n.Directive)
                 if child.name == expected_child_desc_name:
                     valid_desc = child
@@ -727,6 +728,11 @@ class JSONVisitor:
         child: n.Node,
         expected_children_names: Set[str],
     ) -> None:
+        """
+        Ensures that a child node matches a name that a parent directive expects. Valid
+        children are expected to be directives.
+        """
+
         invalid_child = None
         if not isinstance(child, n.Directive):
             # Catches additional unwanted types like Paragraph
@@ -753,13 +759,15 @@ class JSONVisitor:
     def check_valid_option_id(
         self,
         child: n.Directive,
-        expected_options: dict[str, Any],
+        expected_options: Dict[str, Any],
         used_ids: Set[str],
     ) -> None:
+        """Ensures that a child directive has a unique option "id" that is correctly defined."""
+
         option_id = child.options.get("id")
         if not option_id:
             # Don't append diagnostic since docutils should already
-            # complain about missing argument and ID option
+            # complain about missing ID option
             raise ChildValidationError()
 
         if not option_id in expected_options:
@@ -774,6 +782,7 @@ class JSONVisitor:
             self.diagnostics.append(
                 DuplicateOptionId(child.name, option_id, child.start[0])
             )
+            raise ChildValidationError()
 
     def handle_method_selector(self, node: n.Directive) -> None:
         expected_options = specparser.Spec.get().method_selector["options"]
@@ -787,6 +796,7 @@ class JSONVisitor:
         for child in node.children:
             try:
                 self.check_valid_child(node, child, {expected_child_name})
+                # check_valid_child verifies that the child is a directive
                 assert isinstance(child, n.Directive)
                 self.check_valid_option_id(child, expected_options_dict, used_ids)
             except ChildValidationError:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1913,7 +1913,7 @@ class NestedDirectiveHandler(Handler):
 
 
 class WayfindingHandler(NestedDirectiveHandler):
-    """Handles page-level validations for method-selector directive and its children."""
+    """Handles page-level validations for wayfinding directive and its children."""
 
     def __init__(self, context: Context) -> None:
         super().__init__(context, "wayfinding", {"include", "sharedinclude"})

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1876,6 +1876,10 @@ class NestedDirectiveHandler(Handler):
         self.directive_detected = False
         self.nesting_level = 0
 
+    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
+        self.nesting_level = 0
+        self.directive_detected = False
+
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name in self.skippable_directives:
             return
@@ -1906,10 +1910,6 @@ class NestedDirectiveHandler(Handler):
             return
         if node.name != self.directive_name:
             self.nesting_level -= 1
-
-    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        self.nesting_level = 0
-        self.directive_detected = False
 
 
 class WayfindingHandler(NestedDirectiveHandler):

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -816,6 +816,19 @@ help = "An option for wayfinding."
 argument_type = {type = "uri", required = true}
 options.id = {type = "string", required = true}
 
+[directive."mongodb:method-selector"]
+help = "Top-level selector for methods a user may choose from for content. Only a single one should be used on a page."
+content_type = "block"
+
+[directive."mongodb:method-option"]
+help = "An option to be used for the method-selector directive."
+content_type = "block"
+options.id = {type = "string", required = true}
+
+[directive."mongodb:method-description"]
+help = "An optional description to be used for a method option."
+content_type = "block"
+
 ###### Misc.
 [directive.atf-image]
 help = "Path to the image to use for the above-the-fold header image"
@@ -1790,7 +1803,7 @@ prefix = "autoencryptkeyword"
 [rstobject."mongodb:c2cstate"]
 help = """mongosync State"""
 
-[method-selector]
+[method_selector]
 options = [
   {id = "driver", title = "Driver"},
   {id = "cli", title = "CLI"},

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1790,6 +1790,16 @@ prefix = "autoencryptkeyword"
 [rstobject."mongodb:c2cstate"]
 help = """mongosync State"""
 
+[method-selector]
+options = [
+  {id = "driver", title = "Driver"},
+  {id = "cli", title = "CLI"},
+  {id = "api", title = "API"},
+  {id = "mongosh", title = "Mongosh"},
+  {id = "ui", title = "UI"},
+  {id = "compass", title = "Compass"},
+]
+
 [tabs]
 cloud-providers = [
   {id = "aws", title = "AWS"},

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -112,6 +112,13 @@ class DirectiveOption:
 
 @checked
 @dataclass
+class WayfindingOption:
+    id: str
+    title: str
+
+
+@checked
+@dataclass
 class TabDefinition:
     id: str
     title: str
@@ -283,6 +290,7 @@ class Spec:
     directive: Dict[str, Directive] = field(default_factory=dict)
     role: Dict[str, Role] = field(default_factory=dict)
     rstobject: Dict[str, RstObject] = field(default_factory=dict)
+    method_selector: Dict[str, List[MethodSelectorOption]] = field(default_factory=dict)
     tabs: Dict[str, List[TabDefinition]] = field(default_factory=dict)
     wayfinding: Dict[str, List[WayfindingOption]] = field(default_factory=dict)
     data_fields: List[str] = field(default_factory=list)

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -112,7 +112,7 @@ class DirectiveOption:
 
 @checked
 @dataclass
-class WayfindingOption:
+class MethodSelectorOption:
     id: str
     title: str
 

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4124,3 +4124,7 @@ def test_wayfinding_errors() -> None:
     )
     page.finish(diagnostics)
     assert [type(d) for d in diagnostics] == [MissingChild, MissingChild]
+
+
+def test_method_selector() -> None:
+    pass

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4124,3 +4124,195 @@ def test_wayfinding_errors() -> None:
     )
     page.finish(diagnostics)
     assert [type(d) for d in diagnostics] == [MissingChild, MissingChild]
+
+
+def test_method_selector() -> None:
+    path = FileId("test.txt")
+    project_config = ProjectConfig(ROOT_PATH, "")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    # Valid case
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+=========
+Test Page
+=========
+
+.. method-selector::
+   
+   .. method-option::
+      :id: driver
+
+      .. method-description::
+         
+         This is an optional description for drivers. Go to the `docs homepage <https://mongodb.com/docs/>`__ for more info.
+
+      This only shows when driver is selected.
+
+   .. method-option::
+      :id: cli
+
+      This only shows when cli is selected.
+
+   .. method-option::
+      :id: api
+
+      This only shows when cli is selected.
+
+   .. method-option::
+      :id: mongosh
+
+      This only shows when cli is selected.
+
+   .. method-option::
+      :id: compass
+
+      .. method-description::
+         
+         This is an optional description for compass. Compass is a tool to interact with MongoDB data.
+
+      This only shows when compass is selected.
+
+   .. method-option::
+      :id: ui
+
+      This only shows when ui is selected.
+    """,
+    )
+    page.finish(diagnostics)
+    assert not diagnostics
+    check_ast_testing_string(
+        page.ast,
+        """
+<root fileid="test.txt">
+    <section>
+        <heading id="test-page">
+            <text>Test Page</text>
+        </heading>
+        <directive domain="mongodb" name="method-selector">
+            <directive domain="mongodb" name="method-option" id="driver" title="Driver">
+                <directive domain="mongodb" name="method-description">
+                    <paragraph>
+                        <text>This is an optional description for drivers. Go to the </text>
+                        <reference refuri="https://mongodb.com/docs/">
+                            <text>docs homepage</text>
+                        </reference>
+                        <text> for more info.</text>
+                    </paragraph>
+                </directive>
+                <paragraph>
+                    <text>This only shows when driver is selected.</text>
+                </paragraph>
+            </directive>
+            <directive domain="mongodb" name="method-option" id="cli" title="CLI">
+                <paragraph>
+                    <text>This only shows when cli is selected.</text>
+                </paragraph>
+            </directive>
+            <directive domain="mongodb" name="method-option" id="api" title="API">
+                <paragraph>
+                    <text>This only shows when cli is selected.</text>
+                </paragraph>
+            </directive>
+            <directive domain="mongodb" name="method-option" id="mongosh" title="Mongosh">
+                <paragraph>
+                    <text>This only shows when cli is selected.</text>
+                </paragraph>
+            </directive>
+            <directive domain="mongodb" name="method-option" id="compass" title="Compass">
+                <directive domain="mongodb" name="method-description">
+                    <paragraph>
+                        <text>This is an optional description for compass. Compass is a tool to interact with MongoDB data.</text>
+                    </paragraph>
+                </directive>
+                <paragraph>
+                    <text>This only shows when compass is selected.</text>
+                </paragraph>
+            </directive>
+            <directive domain="mongodb" name="method-option" id="ui" title="UI">
+                <paragraph>
+                    <text>This only shows when ui is selected.</text>
+                </paragraph>
+            </directive>
+        </directive>
+    </section>
+</root>
+""",
+    )
+
+    # Valid case
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+=========
+Test Page
+=========
+
+.. method-selector::
+
+   .. method-option::
+
+      Missing option id.
+
+   .. method-description::
+      
+      This does not belong here.
+
+   .. method-option::
+      :id: cli
+
+      This only shows when cli is selected.
+
+   .. method-option::
+      :id: not-valid
+
+      This only shows when cli is selected.
+
+   .. method-option::
+      :id: mongosh
+
+      This only shows when cli is selected.
+    
+   .. method-option::
+      :id: driver
+
+      .. method-description::
+         
+         This is an optional description for drivers. Go to the `docs homepage <https://mongodb.com/docs/>`__ for more info.
+
+      This only shows when driver is selected.
+
+   .. method-option::
+      :id: compass
+
+      .. method-description::
+         
+         This is an optional description for compass. Compass is a tool to interact with MongoDB data.
+
+      This only shows when compass is selected.
+
+   .. method-option::
+      :id: ui
+
+      This only shows when ui is selected.
+
+   .. method-option::
+      :id: cli
+
+      This only shows when cli is selected.
+    """,
+    )
+    page.finish(diagnostics)
+    assert [type(d) for d in diagnostics] == [
+        # Missing option id
+        DocUtilsParseError,
+        # Extra method-description in method-selector
+        InvalidChild,
+        # not-valid option id
+        UnknownOptionId,
+        # Duplicate "cli" id
+        DuplicateOptionId,
+    ]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -27,6 +27,7 @@ from .diagnostics import (
     MissingFacet,
     RemovedLiteralBlockSyntax,
     TabMustBeDirective,
+    UnexpectedDirectiveOrder,
     UnexpectedIndentation,
     UnknownOptionId,
     UnknownTabID,
@@ -4242,7 +4243,7 @@ Test Page
 """,
     )
 
-    # Valid case
+    # Errors case
     page, diagnostics = parse_rst(
         parser,
         path,
@@ -4313,6 +4314,8 @@ Test Page
         InvalidChild,
         # not-valid option id
         UnknownOptionId,
+        # driver option is not first
+        UnexpectedDirectiveOrder,
         # Duplicate "cli" id
         DuplicateOptionId,
     ]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -6,7 +6,7 @@ from .diagnostics import (
     CannotOpenFile,
     Diagnostic,
     DocUtilsParseError,
-    DuplicateWayfindingOption,
+    DuplicateOptionId,
     ErrorParsingYAMLFile,
     ExpectedOption,
     ExpectedPathArg,
@@ -28,9 +28,9 @@ from .diagnostics import (
     RemovedLiteralBlockSyntax,
     TabMustBeDirective,
     UnexpectedIndentation,
+    UnknownOptionId,
     UnknownTabID,
     UnknownTabset,
-    UnknownWayfindingOption,
 )
 from .n import FileId
 from .parser import InlineJSONVisitor, JSONVisitor
@@ -4108,9 +4108,9 @@ def test_wayfinding_errors() -> None:
         # Note
         InvalidChild,
         # bad-id
-        UnknownWayfindingOption,
+        UnknownOptionId,
         # Duplicate "c" id
-        DuplicateWayfindingOption,
+        DuplicateOptionId,
     ]
 
     # Test missing children
@@ -4124,7 +4124,3 @@ def test_wayfinding_errors() -> None:
     )
     page.finish(diagnostics)
     assert [type(d) for d in diagnostics] == [MissingChild, MissingChild]
-
-
-def test_method_selector() -> None:
-    pass

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3574,3 +3574,157 @@ Valid Wayfinding
             for x in result.diagnostics[FileId("includes/included_wayfinding.rst")]
         ] == [NestedDirective]
         assert len(result.diagnostics[FileId("valid_wayfinding.txt")]) == 0
+
+
+def test_method_selector() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+============
+Landing page
+============
+            
+.. include:: /includes/included_method_selector.rst
+         
+.. method-selector::
+
+   .. method-option::
+      :id: cli
+
+      .. collapsible::
+         :heading: Collapsible 1
+         :sub_heading: Subheading 1
+      
+         Collapsible 1 content.
+
+      .. collapsible::
+         :heading: Collapsible 2
+         :sub_heading: Subheading 2
+
+         Collapsible 2 content.
+   
+   .. method-option::
+      :id: mongosh
+
+      .. collapsible::
+         :heading: Collapsible 1
+         :sub_heading: Subheading 1
+      
+         Collapsible 1 content.
+
+      .. collapsible::
+         :heading: Collapsible 2
+         :sub_heading: Subheading 2
+
+         Collapsible 2 content.
+""",
+            Path(
+                "source/includes/included_method_selector.rst"
+            ): """
+.. method-selector::
+   
+   .. method-option::
+      :id: driver
+
+      .. method-description::
+         
+         This is an optional description for drivers. Go to the `docs homepage <https://mongodb.com/docs/>`__ for more info.
+      
+         .. tabs-selector:: drivers
+
+      .. collapsible::
+         :heading: Collapsible 1
+         :sub_heading: Subheading 1
+      
+         Collapsible 1 content.
+
+      .. collapsible::
+         :heading: Collapsible 2
+         :sub_heading: Subheading 2
+
+         Collapsible 2 content.
+
+         .. tabs-drivers::
+         
+            .. tab::
+               :tabid: c
+
+               C tab content.
+            
+            .. tab::
+               :tabid: cpp
+
+               C++ tab content.
+    
+   .. method-option::
+      :id: ui
+
+      .. collapsible::
+         :heading: Collapsible 1
+         :sub_heading: Subheading 1
+      
+         Collapsible 1 content.
+
+      .. collapsible::
+         :heading: Collapsible 2
+         :sub_heading: Subheading 2
+
+         Collapsible 2 content.
+   
+   .. method-option::
+      :id: compass
+
+      .. collapsible::
+         :heading: Collapsible 1
+         :sub_heading: Subheading 1
+      
+         Collapsible 1 content.
+
+      .. collapsible::
+         :heading: Collapsible 2
+         :sub_heading: Subheading 2
+
+         Collapsible 2 content.
+""",
+            Path(
+                "source/nested_method_selector.txt"
+            ): """
+:orphan:
+
+======================
+Nested Method Selector
+======================
+
+.. note::
+
+   .. include:: /includes/included_method_selector.rst
+""",
+            Path(
+                "source/valid_method_selector.txt"
+            ): """
+:orphan:
+
+=====================
+Valid Method Selector
+=====================
+
+.. include:: /includes/included_method_selector.rst
+""",
+        }
+    ) as result:
+        assert [type(x) for x in result.diagnostics[FileId("index.txt")]] == [
+            DuplicateDirective
+        ]
+        assert result.pages[FileId("index.txt")].ast.options.get("has_method_selector")
+        assert [
+            type(x)
+            for x in result.diagnostics[FileId("includes/included_method_selector.rst")]
+        ] == [NestedDirective]
+        assert len(result.diagnostics[FileId("valid_method_selector.txt")]) == 0
+
+        target_option_field = "has_method_selector"
+        assert result.pages[FileId("index.txt")].ast.options.get(target_option_field, False)
+        assert not result.pages[FileId("nested_method_selector.txt")].ast.options.get(target_option_field, False)
+        assert result.pages[FileId("valid_method_selector.txt")].ast.options.get(target_option_field, False)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -31,6 +31,7 @@ from .diagnostics import (
     SubstitutionRefError,
     TabMustBeDirective,
     TargetNotFound,
+    UnexpectedDirectiveOrder,
 )
 from .n import FileId
 from .util_test import (
@@ -3712,6 +3713,45 @@ Valid Method Selector
 
 .. include:: /includes/included_method_selector.rst
 """,
+            Path(
+                "source/testing_tabs_selector.txt"
+            ): """
+:orphan:
+
+=====================
+Testing Tabs Selector
+=====================
+
+.. tabs-selector:: drivers
+
+.. method-selector::
+   
+   .. method-option::
+      :id: driver
+
+      .. method-description::
+         
+         This is an optional description for drivers. Go to the `docs homepage <https://mongodb.com/docs/>`__ for more info.
+
+      Foo
+
+      .. tabs-drivers::
+
+         .. tab::
+            :tabid: c
+
+            C tab
+
+         .. tab::
+            :tabid: cpp
+
+            C++ tab
+    
+   .. method-option::
+      :id: ui
+
+      Bar
+""",
         }
     ) as result:
         assert [type(x) for x in result.diagnostics[FileId("index.txt")]] == [
@@ -3722,6 +3762,9 @@ Valid Method Selector
             type(x)
             for x in result.diagnostics[FileId("includes/included_method_selector.rst")]
         ] == [NestedDirective]
+        assert [
+            type(x) for x in result.diagnostics[FileId("testing_tabs_selector.txt")]
+        ] == [UnexpectedDirectiveOrder]
         assert len(result.diagnostics[FileId("valid_method_selector.txt")]) == 0
 
         target_option_field = "has_method_selector"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3725,6 +3725,12 @@ Valid Method Selector
         assert len(result.diagnostics[FileId("valid_method_selector.txt")]) == 0
 
         target_option_field = "has_method_selector"
-        assert result.pages[FileId("index.txt")].ast.options.get(target_option_field, False)
-        assert not result.pages[FileId("nested_method_selector.txt")].ast.options.get(target_option_field, False)
-        assert result.pages[FileId("valid_method_selector.txt")].ast.options.get(target_option_field, False)
+        assert result.pages[FileId("index.txt")].ast.options.get(
+            target_option_field, False
+        )
+        assert not result.pages[FileId("nested_method_selector.txt")].ast.options.get(
+            target_option_field, False
+        )
+        assert result.pages[FileId("valid_method_selector.txt")].ast.options.get(
+            target_option_field, False
+        )


### PR DESCRIPTION
### Ticket

DOP-4685
[Example rST](https://github.com/rayangler/cloud-docs/blob/ace163b51c2f157f38a6d044d2a5faea63b287d3/source/testing-method-selector.txt)
[Designs](https://www.figma.com/design/7cR6eWtFvKTnJIPL8ZsTaB/Content-Template-Projects?node-id=3473-22389&t=RNnOtvg64NtvtUHi-0)
[Related frontend PR](https://github.com/mongodb/snooty/pull/1208)

### Notes

* There were a lot of similarities to the `wayfinding` directive, so I tried my best to make the logic more reusable. Let me know if there are any issues with anything.
* There's a weird bug where headings inside of this directive aren't captured in the `ContentsHandler` for some reason. I'm hoping to look into this as a separate ticket since it doesn't affect the component itself. I don't think this should be a blocker for this PR considering the "On This Page" component on the frontend will have the same issue with showing headings from unselected tabs, which is a less than ideal UX either way.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
