### PR TITLE
DOP-4972: Add ruby driver to wayfinding component

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1962,6 +1962,7 @@ options = [
    {id = "pymongo", language = "python" , title = "PyMongo"},
    {id = "python", language = "python" , title = "Python", show_first = true},
    {id = "mongoid", language = "ruby" , title = "Mongoid"},
+   {id = "ruby", language = "ruby", title = "Ruby"},
    {id = "rust", language = "rust" , title = "Rust"},
    {id = "scala", language = "scala" , title = "Scala"},
    {id = "swift", language = "swift" , title = "Swift"},

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3945,6 +3945,9 @@ def test_wayfinding_sorted() -> None:
    .. wayfinding-option:: https://www.mongodb.com/docs/
       :id: typescript
 
+   .. wayfinding-option:: https://www.mongodb.com/docs/
+      :id: ruby 
+
       
    .. wayfinding-description::
 
@@ -4028,6 +4031,11 @@ def test_wayfinding_sorted() -> None:
 			</reference>
 		</directive>
 		<directive domain="mongodb" name="wayfinding-option" id="mongoid" title="Mongoid" language="ruby">
+			<reference refuri="https://www.mongodb.com/docs/">
+				<text>https://www.mongodb.com/docs/</text>
+			</reference>
+		</directive>
+        <directive domain="mongodb" name="wayfinding-option" id="ruby" title="Ruby" language="ruby">
 			<reference refuri="https://www.mongodb.com/docs/">
 				<text>https://www.mongodb.com/docs/</text>
 			</reference>


### PR DESCRIPTION
### Ticket

DOP-4972

[Staging link example](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/dark-mode-enable/DOP-4683/cloud-docs/maya/DOP-4972/testing-wayfinding/index.html)

### Notes

Adding Ruby driver to wayfinding options.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
