### PR TITLE
DOP-4983: controlled sections and refs for collapsibles

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -485,6 +485,7 @@ class JSONVisitor:
 
         popped = self.state.pop()
         top_of_state = self.state[-1]
+        DIR_NAMES_WITH_SECTIONED_CHILDREN = ["step", "collapsible"]
 
         if isinstance(popped, _DefinitionListTerm):
             assert isinstance(
@@ -560,7 +561,7 @@ class JSONVisitor:
                 target.children = [identifier]
                 item.term.append(target)
 
-        elif isinstance(popped, n.Directive) and popped.name == "step":
+        elif isinstance(popped, n.Directive) and (popped.name in DIR_NAMES_WITH_SECTIONED_CHILDREN):
             popped.children = [n.Section((node.get_line(),), popped.children)]
 
         elif isinstance(popped, n.Directive) and popped.name == "wayfinding":

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3860,8 +3860,10 @@ def test_collapsible() -> None:
         """
 <root fileid="test.rst">
     <directive name="collapsible" heading="This is a heading" sub_heading="This is a subheading" domain="mongodb">
-        <paragraph><text>This is collapsible content</text></paragraph>
-        <code lang="javascript" copyable="True">This is code within collapsible content</code>
+        <section>
+            <paragraph><text>This is collapsible content</text></paragraph>
+            <code lang="javascript" copyable="True">This is code within collapsible content</code>
+        </section>
     </directive>
 </root>""",
     )

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3478,31 +3478,133 @@ def test_collapsible_headings() -> None:
                 "source/index.txt"
             ): """
 .. contents::
-   :depth: 2
+   :depth: 3
 
+-------------------
+Heading of the page
+-------------------
+
+===================
+Subsection heading
+===================
 
 .. collapsible::
-    :heading: Heading goes here
+    :heading: Collapsible heading
     :sub_heading: Subheading
 
+    ~~~~~~~~~~~~~~~
     This is content
+    ~~~~~~~~~~~~~~~
             """,
         }
     ) as result:
         page = result.pages[FileId("index.txt")]
         assert page.ast.options.get("headings") == [
             {
-                "depth": 0,
-                "id": "heading-goes-here",
+                "depth": 2,
+                "id": "subsection-heading",
                 "title": [
                     {
-                        "position": {"start": {"line": 5}},
                         "type": "text",
-                        "value": "Heading goes here",
-                    },
+                        "position": {"start": {"line": 10}},
+                        "value": "Subsection heading",
+                    }
+                ],
+            },
+            {
+                "depth": 2,
+                "id": "collapsible-heading",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 12}},
+                        "value": "Collapsible heading",
+                    }
+                ],
+            },
+            {
+                "depth": 4,
+                "id": "this-is-content",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 18}},
+                        "value": "This is content",
+                    }
                 ],
             },
         ]
+
+
+def test_collapsible_ref() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+
+This is a page heading
+======================
+
+.. _ref_to_heading:
+
+Section heading
+---------------
+            
+
+.. _ref_to_collapsible:
+
+.. collapsible::
+    :heading: Collapsible heading
+
+    This is a child paragraph of collapsible
+
+There should be a link to collapsible :ref:`ref_to_collapsible`.
+
+There should be a link to section heading :ref:`ref-to-heading`.
+
+"""
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="index.txt">
+   <section>
+      <heading id="this-is-a-page-heading"><text>This is a page heading</text></heading>
+      <target domain="std" name="label" html_id="std-label-ref_to_heading">
+         <target_identifier ids="['ref_to_heading']"><text>Section heading</text></target_identifier>
+      </target>
+      <section>
+         <heading id="section-heading"><text>Section heading</text></heading>
+         <target domain="std" name="label" html_id="std-label-ref_to_collapsible">
+            <target_identifier ids="['ref_to_collapsible']"><text>Collapsible heading</text></target_identifier>
+         </target>
+         <directive domain="mongodb" name="collapsible" heading="Collapsible heading" id="collapsible-heading">
+            <section>
+               <paragraph><text>This is a child paragraph of collapsible</text></paragraph>
+            </section>
+         </directive>
+         <paragraph><text>There should be a link to collapsible </text>
+            <ref_role domain="std" name="label" target="ref_to_collapsible"
+               fileid="['index', 'std-label-ref_to_collapsible']"><text>Collapsible heading</text></ref_role>
+            <text>.</text>
+         </paragraph>
+         <paragraph><text>There should be a link to section heading </text>
+            <ref_role domain="std" name="label" target="ref-to-heading"><text>ref-to-heading</text></ref_role>
+            <text>.</text>
+         </paragraph>
+      </section>
+   </section>
+</root>
+""",
+        )
+        print(
+            ast_to_testing_string(
+                page.ast,
+            )
+        )
 
 
 def test_wayfinding() -> None:


### PR DESCRIPTION
### Ticket

DOP-4983

### Notes
- This PR updates sectioning logic for collapsibles: the `heading` option will be at the same level as the sibling content above, and content within collapsibles should be considered another level down.
- Also addressed the third point in the issue, where refs that were pointing to collapsibles were not pulling the content from the heading option.


### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
