### PR TITLE
DOP-4689: Implement multi-page tutorials

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2083,7 +2083,9 @@ class Postprocessor:
                 "toctree": toctree,
                 "toctreeOrder": cls.toctree_order(tree),
                 "parentPaths": cls.breadcrumbs(tree),
-                "multiPageTutorials": cls.multi_page_tutorials(tree, multi_pages_tutorials),
+                "multiPageTutorials": cls.multi_page_tutorials(
+                    tree, multi_pages_tutorials
+                ),
             }
         )
 
@@ -2304,7 +2306,7 @@ class Postprocessor:
                             if title_nodes
                             else None
                         )
-                    
+
                     # print("slug", slug)
 
                     toctree_node_options: Dict[str, Any] = {
@@ -2352,8 +2354,6 @@ class Postprocessor:
 
                 if toctree_node:
                     node["children"].append(toctree_node)
-                
-
 
         # Locate the correct directive object containing the toctree within this AST
         for child_ast in ast.children:
@@ -2368,9 +2368,10 @@ class Postprocessor:
                 visited_file_ids,
             )
 
-
     @staticmethod
-    def multi_page_tutorials(tree: Dict[str, SerializableType], multi_page_tutorials: List[str]) -> Dict[str, List[str]]:
+    def multi_page_tutorials(
+        tree: Dict[str, SerializableType], multi_page_tutorials: List[str]
+    ) -> Dict[str, List[str]]:
         """Generate steps for multi page tutorials for each parent listed in the multi_page_tutorials array"""
         result = {}
 
@@ -2381,9 +2382,8 @@ class Postprocessor:
             assert isinstance(tree["children"], List)
             for node in tree["children"]:
                 find_and_count_children(node, multi_page_tutorials, result)
-        
-        return result
 
+        return result
 
     @staticmethod
     def breadcrumbs(tree: Dict[str, SerializableType]) -> Dict[str, List[str]]:
@@ -2398,7 +2398,7 @@ class Postprocessor:
                 paths: List[str] = []
                 get_paths(node, [], paths)
                 all_paths.extend(paths)
-        
+
         # print("all_paths", all_paths)
 
         # Populate page_dict with a list of parent paths for each slug
@@ -2447,14 +2447,18 @@ def get_paths(node: Dict[str, Any], path: List[str], all_paths: List[Any]) -> No
             get_paths(child, subpath, all_paths)
 
 
-def find_and_count_children(node: Dict[str, SerializableType], multi_page_tutorials: List[str], result: Dict[str, List[str]]) -> None:
+def find_and_count_children(
+    node: Dict[str, SerializableType],
+    multi_page_tutorials: List[str],
+    result: Dict[str, List[str]],
+) -> None:
     if "slug" in node:
         slug = node["slug"]
         formatted_slug = f"/{slug}"
         if formatted_slug in multi_page_tutorials:
             result[slug] = {
                 "total_steps": len(node.get("children", [])),
-                "slugs": [child["slug"] for child in node.get("children", [])]
+                "slugs": [child["slug"] for child in node.get("children", [])],
             }
 
         for child in node.get("children", []):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2069,6 +2069,7 @@ class Postprocessor:
             )
             for k, v in context[HeadingHandler].slug_title_mapping.items()
         }
+        multi_pages_tutorials = context[ProjectConfig].multi_page_tutorials
         # Run postprocessing operations related to toctree and append to metadata document.
         # If iatree is found, use it to generate breadcrumbs and parent paths and save it to metadata as well.
         iatree = cls.build_iatree(context)
@@ -2082,6 +2083,7 @@ class Postprocessor:
                 "toctree": toctree,
                 "toctreeOrder": cls.toctree_order(tree),
                 "parentPaths": cls.breadcrumbs(tree),
+                "multiPageTutorials": cls.multi_page_tutorials(tree, multi_pages_tutorials),
             }
         )
 
@@ -2302,6 +2304,8 @@ class Postprocessor:
                             if title_nodes
                             else None
                         )
+                    
+                    # print("slug", slug)
 
                     toctree_node_options: Dict[str, Any] = {
                         "drawer": slug not in toc_landing_pages
@@ -2348,6 +2352,8 @@ class Postprocessor:
 
                 if toctree_node:
                     node["children"].append(toctree_node)
+                
+
 
         # Locate the correct directive object containing the toctree within this AST
         for child_ast in ast.children:
@@ -2362,6 +2368,23 @@ class Postprocessor:
                 visited_file_ids,
             )
 
+
+    @staticmethod
+    def multi_page_tutorials(tree: Dict[str, SerializableType], multi_page_tutorials: List[str]) -> Dict[str, List[str]]:
+        """Generate steps for multi page tutorials for each parent listed in the multi_page_tutorials array"""
+        result = {}
+
+        if not multi_page_tutorials:
+            return result
+
+        if "children" in tree:
+            assert isinstance(tree["children"], List)
+            for node in tree["children"]:
+                find_and_count_children(node, multi_page_tutorials, result)
+        
+        return result
+
+
     @staticmethod
     def breadcrumbs(tree: Dict[str, SerializableType]) -> Dict[str, List[str]]:
         """Generate breadcrumbs for each page represented in the provided toctree"""
@@ -2375,6 +2398,8 @@ class Postprocessor:
                 paths: List[str] = []
                 get_paths(node, [], paths)
                 all_paths.extend(paths)
+        
+        # print("all_paths", all_paths)
 
         # Populate page_dict with a list of parent paths for each slug
         for path in all_paths:
@@ -2420,6 +2445,20 @@ def get_paths(node: Dict[str, Any], path: List[str], all_paths: List[Any]) -> No
             subpath = path[:]
             subpath.append(clean_slug(node["slug"]))
             get_paths(child, subpath, all_paths)
+
+
+def find_and_count_children(node: Dict[str, SerializableType], multi_page_tutorials: List[str], result: Dict[str, List[str]]) -> None:
+    if "slug" in node:
+        slug = node["slug"]
+        formatted_slug = f"/{slug}"
+        if formatted_slug in multi_page_tutorials:
+            result[slug] = {
+                "total_steps": len(node.get("children", [])),
+                "slugs": [child["slug"] for child in node.get("children", [])]
+            }
+
+        for child in node.get("children", []):
+            find_and_count_children(child, multi_page_tutorials, result)
 
 
 def clean_slug(slug: str) -> str:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2188,7 +2188,7 @@ class Postprocessor:
                 "toctree": toctree,
                 "toctreeOrder": cls.toctree_order(tree),
                 "parentPaths": cls.breadcrumbs(tree),
-                "multiPageTutorials": cls.multi_page_tutorials(
+                "multiPageTutorials": cls.generate_multi_page_tutorials(
                     tree, multi_pages_tutorials
                 ),
             }
@@ -2472,7 +2472,7 @@ class Postprocessor:
             )
 
     @staticmethod
-    def multi_page_tutorials(
+    def generate_multi_page_tutorials(
         tree: Dict[str, SerializableType], multi_page_tutorials: List[str]
     ) -> Dict[str, n.SerializedNode]:
         """Generate steps for multi page tutorials for each parent listed in the multi_page_tutorials array"""

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -77,19 +77,6 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-@dataclass
-class MultiPageTutorial:
-    slugs: List[str]
-    total_steps: int
-
-    def serialize(self) -> n.SerializedNode:
-        result: n.SerializedNode = {
-            "slugs": self.slugs,
-            "total_steps": self.total_steps,
-        }
-        return result
-
-
 # XXX: The following two functions should probably be combined at some point
 def get_title_injection_candidate(node: n.Node) -> Optional[n.Parent[n.Node]]:
     """Dive into a tree of nodes, and return the deepest non-inline node if and only if the tree is linear."""
@@ -2391,7 +2378,7 @@ class Postprocessor:
 
         if "children" in tree and isinstance(tree["children"], List):
             for node in tree["children"]:
-                find_and_count_children(node, multi_page_tutorials, result)
+                find_multi_page_tutorial_children(node, multi_page_tutorials, result)
 
         return result
 
@@ -2455,7 +2442,7 @@ def get_paths(node: Dict[str, Any], path: List[str], all_paths: List[Any]) -> No
             get_paths(child, subpath, all_paths)
 
 
-def find_and_count_children(
+def find_multi_page_tutorial_children(
     node: Dict[str, SerializableType],
     multi_page_tutorials: List[str],
     result: Dict[str, n.SerializedNode],
@@ -2476,7 +2463,7 @@ def find_and_count_children(
         }
 
     for child in children:
-        find_and_count_children(child, multi_page_tutorials, result)        
+        find_multi_page_tutorial_children(child, multi_page_tutorials, result)        
 
 
 def clean_slug(slug: str) -> str:

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -829,6 +829,15 @@ options.id = {type = "string", required = true}
 help = "An optional description to be used for a method option."
 content_type = "block"
 
+[directive."mongodb:multi-page-tutorial"]
+help = "Configure settings for a multi-page tutorial page, if it is one."
+options.time-required = {type = "nonnegative_integer", required = true}
+options.show-next-top = "flag"
+example = """.. multi-page-tutorial::
+   :time-required: 5
+   :show-next-top:
+"""
+
 ###### Misc.
 [directive.atf-image]
 help = "Path to the image to use for the above-the-fold header image"

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3844,7 +3844,9 @@ Words!!!
 """
 
     # Handles nested TOC case
-    mock_files[PurePath("source/create-connect-deployments.txt")] = """
+    mock_files[
+        PurePath("source/create-connect-deployments.txt")
+    ] = """
 ==============================
 Create and Connect Deployments
 ==============================

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -1,7 +1,7 @@
 """An alternative and more granular approach to writing postprocessing tests.
    Eventually most postprocessor tests should probably be moved into this format."""
 
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Dict, cast
 
 from snooty.types import Facet
@@ -3777,3 +3777,168 @@ Testing Tabs Selector
         assert result.pages[FileId("valid_method_selector.txt")].ast.options.get(
             target_option_field, False
         )
+
+
+def test_multi_page_tutorials() -> None:
+    test_page_template = """
+.. multi-page-tutorial::
+   :time-required: 3
+   :show-next-top:
+
+=========
+Test Page
+=========
+
+Words.
+
+"""
+
+    mock_filenames = [
+        "tutorial/create-new-cluster.txt",
+        "tutorial/create-serverless-instance.txt",
+        "tutorial/create-global-cluster.txt",
+        "tutorial/create-atlas-account.txt",
+        "tutorial/deploy-free-tier-cluster.txt",
+        "tutorial/create-mongodb-user-for-cluster.txt",
+        "tutorial/connect-to-your-cluster.txt",
+        "tutorial/insert-data-into-your-cluster.txt",
+    ]
+    mock_files: Dict[PurePath, Any] = {}
+    for filename in mock_filenames:
+        mock_files[PurePath(f"source/{filename}")] = test_page_template
+
+    mock_files[
+        PurePath("snooty.toml")
+    ] = """
+name = "test_multi_page_tutorials"
+title = "MongoDB title"
+
+toc_landing_pages = [
+    "/create-connect-deployments",
+    "/create-database-deployment",
+    "/getting-started",
+    "/foo",
+]
+
+multi_page_tutorials = [
+    "/create-database-deployment",
+    "/getting-started",
+]
+"""
+    mock_files[
+        PurePath("source/index.txt")
+    ] = """
+========
+Homepage
+========
+
+Words!!!
+
+.. toctree::
+   :titlesonly:
+      
+   Getting Started </getting-started>
+   Create & Connect Deployments </create-connect-deployments>
+   Foo </foo>
+
+"""
+
+    # Handles nested TOC case
+    mock_files[PurePath("source/create-connect-deployments.txt")] = """
+==============================
+Create and Connect Deployments
+==============================
+
+Words.
+
+.. toctree::
+   :titlesonly:
+
+   Create a Cluster </create-database-deployment>
+
+"""
+    mock_files[
+        PurePath("source/create-database-deployment.txt")
+    ] = """
+.. toctree::
+   :titlesonly:
+      
+   Cluster </tutorial/create-new-cluster>
+   Serverless Instance </tutorial/create-serverless-instance>
+   Global Cluster </tutorial/create-global-cluster>
+
+==========================
+Create Database Deployment
+==========================
+
+Words.
+
+"""
+
+    # Handles root TOC case
+    mock_files[
+        PurePath("source/getting-started.txt")
+    ] = """
+===============
+Getting Started
+===============
+
+Words.
+
+.. toctree::
+   :titlesonly:
+
+   Create an Account </tutorial/create-atlas-account>
+   Deploy a Free Cluster </tutorial/deploy-free-tier-cluster>
+   Manage Database Users </tutorial/create-mongodb-user-for-cluster>
+   Connect to the Cluster </tutorial/connect-to-your-cluster>
+   Insert and View a Document </tutorial/insert-data-into-your-cluster>
+
+"""
+
+    # Control; not intended to be included as MTP
+    mock_files[
+        PurePath("source/foo.txt")
+    ] = """
+===
+Foo
+===
+
+Words!
+
+"""
+
+    with make_test(mock_files) as result:
+        # Ensure handler adds settings to page options
+        for filename in mock_filenames:
+            mtp_options = result.pages[FileId(filename)].ast.options.get(
+                "multi_page_tutorial_settings", None
+            )
+            assert isinstance(mtp_options, Dict)
+            assert mtp_options.get("time_required", 0) > 0
+            assert mtp_options.get("show_next_top", False)
+
+        # Ensure metadata has a record of all multi-page tutorials
+        multi_page_tutorials = result.metadata.get("multiPageTutorials", None)
+        assert isinstance(multi_page_tutorials, Dict)
+        print(multi_page_tutorials)
+        assert multi_page_tutorials == {
+            "getting-started": {
+                "total_steps": 5,
+                "slugs": [
+                    "tutorial/create-atlas-account",
+                    "tutorial/deploy-free-tier-cluster",
+                    "tutorial/create-mongodb-user-for-cluster",
+                    "tutorial/connect-to-your-cluster",
+                    "tutorial/insert-data-into-your-cluster",
+                ],
+            },
+            "create-database-deployment": {
+                "total_steps": 3,
+                "slugs": [
+                    "tutorial/create-new-cluster",
+                    "tutorial/create-serverless-instance",
+                    "tutorial/create-global-cluster",
+                ],
+            },
+        }

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3923,7 +3923,6 @@ Words!
         # Ensure metadata has a record of all multi-page tutorials
         multi_page_tutorials = result.metadata.get("multiPageTutorials", None)
         assert isinstance(multi_page_tutorials, Dict)
-        print(multi_page_tutorials)
         assert multi_page_tutorials == {
             "getting-started": {
                 "total_steps": 5,

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -210,6 +210,7 @@ class ProjectConfig:
     sharedinclude_root: Optional[str] = field(default=None)
     substitutions: Dict[str, str] = field(default_factory=dict)
     toc_landing_pages: List[str] = field(default_factory=list)
+    multi_page_tutorials: List[str] = field(default_factory=list)
     page_groups: Dict[str, List[str]] = field(default_factory=dict)
     manpages: Dict[str, ManPageConfig] = field(default_factory=dict)
     bundle: BundleConfig = field(default_factory=BundleConfig)


### PR DESCRIPTION
### Ticket

DOP-4689
[Design](https://www.figma.com/design/7cR6eWtFvKTnJIPL8ZsTaB/Content-Template-Projects?node-id=3479-1567&node-type=FRAME&t=fi9vNQKAIxOCjzaG-0)
[rST example](https://github.com/rayangler/cloud-docs/commit/aa19b8cca34a4613fe75a0e3d3c31ab8c76d7345)
[Frontend PR](https://github.com/mongodb/snooty/pull/1225)
[SPIKE doc](https://docs.google.com/document/d/1cR_YWkeEUnVTo5tNFdlt9L_oy1CwpyU9kG1jfBnj1QA/)

### Notes

* The original ticket was supposed to be for the frontend, but it turns out that the parser portion was never formally implemented. Referenced the POC code from the SPIKE doc to help implement.
* The approach is split into two parts:
  * snooty.toml is updated to include parent page paths of a TOC tree as a multi-page tutorial. Immediate children of that page's TOC will be considered grouped into a multi-page tutorial. As outlined in the SPIKE doc (and its comments), children of children will intentionally not be included in the multi-page tutorial. The postprocessor handles this after TOC tree is established.
  * A new postprocess handler relies on a new `multi-page-tutorial` directive that can be added onto a page's reStructuredText. Its options control how the page will appear in the frontend.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
