### PR TITLE
DOP-4983: improve heading content and sectioning

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -308,9 +308,6 @@ class JSONVisitor:
             )
         elif isinstance(node, rstparser.directive):
             directive = self.handle_directive(node, line)
-            # if directive and node["name"] == "collapsible":
-            #     self.state.append(n.Section((node.get_line(),), [directive]))
-            # elif directive:
             if directive:
                 self.state.append(directive)
         elif isinstance(node, tinydocutils.nodes.Text):
@@ -576,6 +573,8 @@ class JSONVisitor:
             self.handle_method_option(popped)
 
         elif isinstance(popped, n.Directive) and popped.name == "collapsible":
+            html5_id = util.make_html5_id(popped.options.get("heading", "")).lower()
+            popped.options["id"] = html5_id
             has_section = any(True for _ in popped.get_child_of_type(n.Section))
             has_heading = any(True for _ in popped.get_child_of_type(n.Heading))
             if not has_section and not has_heading:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -575,10 +575,7 @@ class JSONVisitor:
         elif isinstance(popped, n.Directive) and popped.name == "collapsible":
             html5_id = util.make_html5_id(popped.options.get("heading", "")).lower()
             popped.options["id"] = html5_id
-            has_section = any(True for _ in popped.get_child_of_type(n.Section))
-            has_heading = any(True for _ in popped.get_child_of_type(n.Heading))
-            if not has_section and not has_heading:
-                popped.children = [n.Section((node.get_line(),), popped.children)]
+            popped.children = [n.Section((node.get_line(),), popped.children)]
 
     def handle_facet(self, node: rstparser.directive, line: int) -> None:
         if "values" not in node["options"] or "name" not in node["options"]:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -308,6 +308,9 @@ class JSONVisitor:
             )
         elif isinstance(node, rstparser.directive):
             directive = self.handle_directive(node, line)
+            # if directive and node["name"] == "collapsible":
+            #     self.state.append(n.Section((node.get_line(),), [directive]))
+            # elif directive:
             if directive:
                 self.state.append(directive)
         elif isinstance(node, tinydocutils.nodes.Text):
@@ -573,9 +576,9 @@ class JSONVisitor:
             self.handle_method_option(popped)
 
         elif isinstance(popped, n.Directive) and popped.name == "collapsible":
-            section = popped.get_child_of_type(n.Section)
-            heading = popped.get_child_of_type(n.Heading)
-            if not section and not heading:
+            has_section = any(True for _ in popped.get_child_of_type(n.Section))
+            has_heading = any(True for _ in popped.get_child_of_type(n.Heading))
+            if not has_section and not has_heading:
                 popped.children = [n.Section((node.get_line(),), popped.children)]
 
     def handle_facet(self, node: rstparser.directive, line: int) -> None:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -537,9 +537,7 @@ class ContentsHandler(Handler):
             )
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Section) or (
-            isinstance(node, n.Directive) and node.name == "collapsible"
-        ):
+        if isinstance(node, n.Section):
             self.current_depth -= 1
 
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -502,7 +502,7 @@ class ContentsHandler(Handler):
                 page.ast.options["headings"] = heading_list
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Section):
+        if isinstance(node, n.Section) or (isinstance(node, n.Directive) and node.name == "collapsible"):
             self.current_depth += 1
             return
 
@@ -538,7 +538,7 @@ class ContentsHandler(Handler):
             )
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Section):
+        if isinstance(node, n.Section) or (isinstance(node, n.Directive) and node.name == 'collapsible'):
             self.current_depth -= 1
 
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -502,7 +502,9 @@ class ContentsHandler(Handler):
                 page.ast.options["headings"] = heading_list
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Section) or (isinstance(node, n.Directive) and node.name == "collapsible"):
+        if isinstance(node, n.Section) or (
+            isinstance(node, n.Directive) and node.name == "collapsible"
+        ):
             self.current_depth += 1
             return
 
@@ -527,18 +529,18 @@ class ContentsHandler(Handler):
             )
 
         if isinstance(node, n.Directive) and node.name == "collapsible":
-            html5_id = util.make_html5_id(node.options["heading"]).lower()
-            node.options["id"] = html5_id
             self.headings.append(
                 ContentsHandler.HeadingData(
                     self.current_depth,
-                    html5_id,
+                    node.options["id"],
                     [n.Text(node.span, node.options["heading"])],
                 )
             )
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Section) or (isinstance(node, n.Directive) and node.name == 'collapsible'):
+        if isinstance(node, n.Section) or (
+            isinstance(node, n.Directive) and node.name == "collapsible"
+        ):
             self.current_depth -= 1
 
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -527,12 +527,10 @@ class ContentsHandler(Handler):
             )
 
         if isinstance(node, n.Directive) and node.name == "collapsible":
-            self.current_depth += 1
-            if self.current_depth - 1 > self.contents_depth:
-                return
             self.headings.append(
                 ContentsHandler.HeadingData(
-                    self.current_depth,
+                    # Add 1 since section appears as a child
+                    self.current_depth + 1,
                     node.options["id"],
                     [n.Text(node.span, node.options["heading"])],
                 )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -502,9 +502,7 @@ class ContentsHandler(Handler):
                 page.ast.options["headings"] = heading_list
 
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Section) or (
-            isinstance(node, n.Directive) and node.name == "collapsible"
-        ):
+        if isinstance(node, n.Section):
             self.current_depth += 1
             return
 
@@ -529,6 +527,9 @@ class ContentsHandler(Handler):
             )
 
         if isinstance(node, n.Directive) and node.name == "collapsible":
+            self.current_depth += 1
+            if self.current_depth - 1 > self.contents_depth:
+                return
             self.headings.append(
                 ContentsHandler.HeadingData(
                     self.current_depth,

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3909,8 +3909,10 @@ This is the main heading
       <heading id="this-is-the-main-heading"><text>This is the main heading</text></heading>
         <directive domain="mongodb" name="collapsible" heading="This is a heading" sub_heading="This is a subheading" id="this-is-a-heading">
             <section>
-                <heading id="there-is-a-heading-inside"><text>There is a heading inside</text></heading>
-                <paragraph><text>And more content within</text></paragraph>
+                <section>
+                    <heading id="there-is-a-heading-inside"><text>There is a heading inside</text></heading>
+                    <paragraph><text>And more content within</text></paragraph>
+                </section>
             </section>
         </directive>
    </section>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3859,7 +3859,7 @@ def test_collapsible() -> None:
         page.ast,
         """
 <root fileid="test.rst">
-    <directive domain="mongodb" name="collapsible" heading="This is a heading" sub_heading="This is a subheading">
+    <directive domain="mongodb" name="collapsible" heading="This is a heading" sub_heading="This is a subheading" id="this-is-a-heading">
         <section>
             <paragraph><text>This is collapsible content</text></paragraph><code lang="javascript" copyable="True">This is code within collapsible content</code>
         </section>
@@ -3907,7 +3907,7 @@ This is the main heading
 <root fileid="test.rst">
    <section>
       <heading id="this-is-the-main-heading"><text>This is the main heading</text></heading>
-        <directive domain="mongodb" name="collapsible" heading="This is a heading" sub_heading="This is a subheading">
+        <directive domain="mongodb" name="collapsible" heading="This is a heading" sub_heading="This is a subheading" id="this-is-a-heading">
             <section>
                 <heading id="there-is-a-heading-inside"><text>There is a heading inside</text></heading>
                 <paragraph><text>And more content within</text></paragraph>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3859,9 +3859,10 @@ def test_collapsible() -> None:
         page.ast,
         """
 <root fileid="test.rst">
-    <directive name="collapsible" heading="This is a heading" sub_heading="This is a subheading" domain="mongodb">
-            <paragraph><text>This is collapsible content</text></paragraph>
-            <code lang="javascript" copyable="True">This is code within collapsible content</code>
+    <directive domain="mongodb" name="collapsible" heading="This is a heading" sub_heading="This is a subheading">
+        <section>
+            <paragraph><text>This is collapsible content</text></paragraph><code lang="javascript" copyable="True">This is code within collapsible content</code>
+        </section>
     </directive>
 </root>""",
     )
@@ -3878,6 +3879,43 @@ def test_collapsible() -> None:
     )
     assert len(diagnostics) == 1
     assert [type(d) for d in diagnostics] == [MissingChild]
+
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+========================
+This is the main heading
+========================
+
+
+.. collapsible::
+   :heading: This is a heading
+   :sub_heading: This is a subheading
+
+   There is a heading inside
+   -------------------------
+
+   And more content within
+""",
+    )
+    page.finish(diagnostics)
+    assert not diagnostics
+    check_ast_testing_string(
+        page.ast,
+        """
+<root fileid="test.rst">
+   <section>
+      <heading id="this-is-the-main-heading"><text>This is the main heading</text></heading>
+        <directive domain="mongodb" name="collapsible" heading="This is a heading" sub_heading="This is a subheading">
+            <section>
+                <heading id="there-is-a-heading-inside"><text>There is a heading inside</text></heading>
+                <paragraph><text>And more content within</text></paragraph>
+            </section>
+        </directive>
+   </section>
+</root>""",
+    )
 
 
 def test_wayfinding_sorted() -> None:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3484,6 +3484,30 @@ def test_collapsible_headings() -> None:
 Heading of the page
 ===================
 
+.. collapsible::
+    :heading: Collapsible heading
+    :sub_heading: Subheading
+
+    ~~~~~~~~~~~~~~~
+    This is content
+    ~~~~~~~~~~~~~~~
+""",
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. contents::
+    :depth: 2
+
+===================
+Heading of the page
+===================
+
 Subsection heading
 ------------------
 
@@ -3574,7 +3598,18 @@ Subsubsection heading
                         "value": "Subsection heading",
                     }
                 ],
-            }
+            },
+            {
+                "depth": 2,
+                "id": "collapsible-heading-2",
+                "title": [
+                    {
+                        "position": {"start": {"line": 22}},
+                        "type": "text",
+                        "value": "Collapsible heading 2",
+                    }
+                ],
+            },
         ]
 
     with make_test(

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3664,9 +3664,11 @@ There should be a link to section heading :ref:`ref-to-heading`.
         <target_identifier ids="['ref_to_collapsible']"><text>Collapsible heading</text></target_identifier>
       </target>
       <directive domain="mongodb" name="collapsible" heading="Collapsible heading" id="collapsible-heading">
-        <paragraph><text>This is a child paragraph of collapsible</text></paragraph>
         <section>
-          <heading id="there-is-another-heading"><text>There is another heading</text></heading>
+            <paragraph><text>This is a child paragraph of collapsible</text></paragraph>
+            <section>
+            <heading id="there-is-another-heading"><text>There is another heading</text></heading>
+            </section>
         </section>
       </directive>
       <paragraph><text>There should be a link to collapsible </text>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3577,6 +3577,43 @@ Subsubsection heading
             }
         ]
 
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. contents::
+    :depth: 1
+
+===================
+Heading of the page
+===================
+
+.. collapsible::
+    :heading: Collapsible heading
+    :sub_heading: Subheading
+
+    ~~~~~~~~~~~~~~~
+    This is content
+    ~~~~~~~~~~~~~~~
+""",
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        assert page.ast.options.get("headings") == [
+            {
+                "depth": 2,
+                "id": "collapsible-heading",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 8}},
+                        "value": "Collapsible heading",
+                    }
+                ],
+            }
+        ]
+
 
 def test_collapsible_ref() -> None:
     with make_test(

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3612,8 +3612,6 @@ There should be a link to section heading :ref:`ref-to-heading`.
         }
     ) as result:
         page = result.pages[FileId("index.txt")]
-        print(ast_to_testing_string(page.ast))
-        # TODO BELOW: the collapsible should have an id
         check_ast_testing_string(
             page.ast,
             """

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3598,18 +3598,7 @@ Subsubsection heading
                         "value": "Subsection heading",
                     }
                 ],
-            },
-            {
-                "depth": 2,
-                "id": "collapsible-heading-2",
-                "title": [
-                    {
-                        "position": {"start": {"line": 22}},
-                        "type": "text",
-                        "value": "Collapsible heading 2",
-                    }
-                ],
-            },
+            }
         ]
 
     with make_test(

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3478,15 +3478,17 @@ def test_collapsible_headings() -> None:
                 "source/index.txt"
             ): """
 .. contents::
-   :depth: 3
+    :depth: 2
 
--------------------
+===================
 Heading of the page
--------------------
+===================
 
-===================
 Subsection heading
-===================
+------------------
+
+Subsubsection heading
+~~~~~~~~~~~~~~~~~~~~~
 
 .. collapsible::
     :heading: Collapsible heading
@@ -3495,6 +3497,68 @@ Subsection heading
     ~~~~~~~~~~~~~~~
     This is content
     ~~~~~~~~~~~~~~~
+""",
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        assert (page.ast.options.get("headings")) == [
+            {
+                "depth": 2,
+                "id": "subsection-heading",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 9}},
+                        "value": "Subsection heading",
+                    }
+                ],
+            },
+            {
+                "depth": 3,
+                "id": "subsubsection-heading",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 12}},
+                        "value": "Subsubsection heading",
+                    }
+                ],
+            },
+        ]
+
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. contents::
+   :depth: 1
+
+===================
+Heading of the page
+===================
+
+Subsection heading
+------------------
+
+.. collapsible::
+    :heading: Collapsible heading
+    :sub_heading: Subheading
+
+    ~~~~~~~~~~~~~~~
+    This is content
+    ~~~~~~~~~~~~~~~
+
+Subsubsection heading
+~~~~~~~~~~~~~~~~~~~~~
+
+.. collapsible::
+    :heading: Collapsible heading 2
+    :sub_heading: Subheading 2
+
+    ~~~~~~~~~~~~~~~~~
+    This is content 2
+    ~~~~~~~~~~~~~~~~~
             """,
         }
     ) as result:
@@ -3506,33 +3570,11 @@ Subsection heading
                 "title": [
                     {
                         "type": "text",
-                        "position": {"start": {"line": 10}},
+                        "position": {"start": {"line": 9}},
                         "value": "Subsection heading",
                     }
                 ],
-            },
-            {
-                "depth": 2,
-                "id": "collapsible-heading",
-                "title": [
-                    {
-                        "type": "text",
-                        "position": {"start": {"line": 12}},
-                        "value": "Collapsible heading",
-                    }
-                ],
-            },
-            {
-                "depth": 3,
-                "id": "this-is-content",
-                "title": [
-                    {
-                        "type": "text",
-                        "position": {"start": {"line": 18}},
-                        "value": "This is content",
-                    }
-                ],
-            },
+            }
         ]
 
 
@@ -3570,37 +3612,37 @@ There should be a link to section heading :ref:`ref-to-heading`.
         }
     ) as result:
         page = result.pages[FileId("index.txt")]
+        print(ast_to_testing_string(page.ast))
+        # TODO BELOW: the collapsible should have an id
         check_ast_testing_string(
             page.ast,
             """
 <root fileid="index.txt">
-   <section>
-      <heading id="this-is-a-page-heading"><text>This is a page heading</text></heading>
-      <target domain="std" name="label" html_id="std-label-ref_to_heading">
-         <target_identifier ids="['ref_to_heading']"><text>Section heading</text></target_identifier>
+  <section>
+    <heading id="this-is-a-page-heading"><text>This is a page heading</text></heading>
+    <target domain="std" name="label" html_id="std-label-ref_to_heading">
+      <target_identifier ids="['ref_to_heading']"><text>Section heading</text></target_identifier>
+    </target>
+    <section>
+      <heading id="section-heading"><text>Section heading</text></heading>
+      <target domain="std" name="label" html_id="std-label-ref_to_collapsible">
+        <target_identifier ids="['ref_to_collapsible']"><text>Collapsible heading</text></target_identifier>
       </target>
-      <section>
-         <heading id="section-heading"><text>Section heading</text></heading>
-         <target domain="std" name="label" html_id="std-label-ref_to_collapsible">
-            <target_identifier ids="['ref_to_collapsible']"><text>Collapsible heading</text></target_identifier>
-         </target>
-         <directive domain="mongodb" name="collapsible" heading="Collapsible heading" id="collapsible-heading">
-            <paragraph><text>This is a child paragraph of collapsible</text></paragraph>
-            <section>
-               <heading id="there-is-another-heading"><text>There is another heading</text></heading>
-            </section>
-         </directive>
-         <paragraph><text>There should be a link to collapsible </text>
-            <ref_role domain="std" name="label" target="ref_to_collapsible"
-               fileid="['index', 'std-label-ref_to_collapsible']"><text>Collapsible heading</text></ref_role>
-            <text>.</text>
-         </paragraph>
-         <paragraph><text>There should be a link to section heading </text>
-            <ref_role domain="std" name="label" target="ref-to-heading"><text>ref-to-heading</text></ref_role>
-            <text>.</text>
-         </paragraph>
-      </section>
-   </section>
+      <directive domain="mongodb" name="collapsible" heading="Collapsible heading">
+        <paragraph><text>This is a child paragraph of collapsible</text></paragraph>
+        <section>
+          <heading id="there-is-another-heading"><text>There is another heading</text></heading>
+        </section>
+      </directive>
+      <paragraph><text>There should be a link to collapsible </text>
+        <ref_role domain="std" name="label" target="ref_to_collapsible"
+          fileid="['index', 'std-label-ref_to_collapsible']"><text>Collapsible heading</text></ref_role><text>.</text>
+      </paragraph>
+      <paragraph><text>There should be a link to section heading </text>
+        <ref_role domain="std" name="label" target="ref-to-heading"><text>ref-to-heading</text></ref_role><text>.</text>
+      </paragraph>
+    </section>
+  </section>
 </root>
 """,
         )

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3628,7 +3628,7 @@ There should be a link to section heading :ref:`ref-to-heading`.
       <target domain="std" name="label" html_id="std-label-ref_to_collapsible">
         <target_identifier ids="['ref_to_collapsible']"><text>Collapsible heading</text></target_identifier>
       </target>
-      <directive domain="mongodb" name="collapsible" heading="Collapsible heading">
+      <directive domain="mongodb" name="collapsible" heading="Collapsible heading" id="collapsible-heading">
         <paragraph><text>This is a child paragraph of collapsible</text></paragraph>
         <section>
           <heading id="there-is-another-heading"><text>There is another heading</text></heading>

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3484,30 +3484,6 @@ def test_collapsible_headings() -> None:
 Heading of the page
 ===================
 
-.. collapsible::
-    :heading: Collapsible heading
-    :sub_heading: Subheading
-
-    ~~~~~~~~~~~~~~~
-    This is content
-    ~~~~~~~~~~~~~~~
-""",
-        }
-    ) as result:
-        page = result.pages[FileId("index.txt")]
-
-    with make_test(
-        {
-            Path(
-                "source/index.txt"
-            ): """
-.. contents::
-    :depth: 2
-
-===================
-Heading of the page
-===================
-
 Subsection heading
 ------------------
 


### PR DESCRIPTION
### Ticket

DOP-4983

### Notes
- Ticket fixes sectioning depth by adding a section into collapsible content (if one does not already exist in the direct children)
- Ticket addresses heading options for the AST, where wrong headings would be contained within the page options
- Unit tests have been added to identify above situations


### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
