### PR TITLE
DOP-4917: Add video options for video metadata

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -892,11 +892,17 @@ class InvalidVersion(Diagnostic, MakeCorrectionMixin):
 class MissingStructuredDataFields(Diagnostic):
     severity = Diagnostic.Level.warning
 
-    def __init__(self, directive_name: str, fields: List[str], start: Union[int, Tuple[int, int]], end: Union[None, int, Tuple[int, int]] = None) -> None:
+    def __init__(
+        self,
+        directive_name: str,
+        fields: List[str],
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ) -> None:
         super().__init__(
             f"""Fields for {directive_name} structured data SEO are partially defined. Missing the following options: {fields}""",
             start,
-            end
+            end,
         )
 
 

--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -889,6 +889,17 @@ class InvalidVersion(Diagnostic, MakeCorrectionMixin):
         return list(self.major_versions)
 
 
+class MissingStructuredDataFields(Diagnostic):
+    severity = Diagnostic.Level.warning
+
+    def __init__(self, directive_name: str, fields: List[str], start: Union[int, Tuple[int, int]], end: Union[None, int, Tuple[int, int]] = None) -> None:
+        super().__init__(
+            f"""Fields for {directive_name} structured data SEO are partially defined. Missing the following options: {fields}""",
+            start,
+            end
+        )
+
+
 class MissingFacet(Diagnostic):
     severity = Diagnostic.Level.warning
 

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1232,9 +1232,14 @@ class JSONVisitor:
                 self.validate_and_add_asset(doc, icon_argument, line)
 
         elif name == "video":
-            sd_req_option_names = ["title", "thumbnail-url", "upload-date", "description"]
+            sd_req_option_names = [
+                "title",
+                "thumbnail-url",
+                "upload-date",
+                "description",
+            ]
             missing_option_names = []
-            
+
             for option_name in sd_req_option_names:
                 val = options.get(option_name, None)
                 if not val:
@@ -1242,8 +1247,12 @@ class JSONVisitor:
 
             # We want to encourage defining all of these options together or not at all for structured data SEO
             missing_options_len = len(missing_option_names)
-            if (missing_options_len > 0 and missing_options_len != len(sd_req_option_names)):
-                self.diagnostics.append(MissingStructuredDataFields(name, missing_option_names, line))
+            if missing_options_len > 0 and missing_options_len != len(
+                sd_req_option_names
+            ):
+                self.diagnostics.append(
+                    MissingStructuredDataFields(name, missing_option_names, line)
+                )
 
         elif name in {"pubdate", "updated-date"}:
             if "date" in node:

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -71,6 +71,7 @@ from .diagnostics import (
     MissingAssociatedToc,
     MissingChild,
     MissingFacet,
+    MissingStructuredDataFields,
     RemovedLiteralBlockSyntax,
     TabMustBeDirective,
     TodoInfo,
@@ -1229,6 +1230,20 @@ class JSONVisitor:
             icon_argument = options.get("icon")
             if icon_argument:
                 self.validate_and_add_asset(doc, icon_argument, line)
+
+        elif name == "video":
+            sd_req_option_names = ["title", "thumbnail-url", "upload-date", "description"]
+            missing_option_names = []
+            
+            for option_name in sd_req_option_names:
+                val = options.get(option_name, None)
+                if not val:
+                    missing_option_names.append(option_name)
+
+            # We want to encourage defining all of these options together or not at all for structured data SEO
+            missing_options_len = len(missing_option_names)
+            if (missing_options_len > 0 and missing_options_len != len(sd_req_option_names)):
+                self.diagnostics.append(MissingStructuredDataFields(name, missing_option_names, line))
 
         elif name in {"pubdate", "updated-date"}:
             if "date" in node:

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -886,7 +886,12 @@ options.type = "string"
 [directive.video]
 help = "Embed a video in your article"
 argument_type = "uri"
-example = """.. video:: ${1: full video url}"""
+options.thumbnail-url = "uri"
+options.upload-date = "iso_8601"
+example = """.. video:: ${1: full video url}
+   :thumbnail-url: ${2: video's thumbnail url}
+   :upload-date: ${3: video's original upload date in ISO-8601 format}
+"""
 
 [directive.youtube]
 help = "Embed a video from YouTube in your article"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -887,12 +887,14 @@ options.type = "string"
 help = "Embed a video in your article"
 argument_type = "uri"
 options.title = "string"
-options.description = "string"
 options.thumbnail-url = "uri"
 options.upload-date = "iso_8601"
-example = """.. video:: ${1: full video url}
-   :thumbnail-url: ${2: video's thumbnail url}
-   :upload-date: ${3: video's original upload date in ISO-8601 format}
+options.description = "string"
+example = """.. video:: ${1: https://www.youtube.com/embed/XrJG994YxD8}
+   :title: {$2: Mastering Indexing for Perfect Query Matches}
+   :thumbnail-url: ${3: https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg}
+   :upload-date: ${4: 2023-11-08T05:00:28-08:00}
+   :description: {$5: Learn how to make Atlas Search indexes to improve search speed and quality.}
 """
 
 [directive.youtube]

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -886,6 +886,8 @@ options.type = "string"
 [directive.video]
 help = "Embed a video in your article"
 argument_type = "uri"
+options.title = "string"
+options.description = "string"
 options.thumbnail-url = "uri"
 options.upload-date = "iso_8601"
 example = """.. video:: ${1: full video url}

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import (
     Any,
@@ -357,6 +358,12 @@ class Spec:
             return validator
         elif isinstance(option_spec, PrimitiveType):
             return VALIDATORS[option_spec]
+        elif isinstance(option_spec, str) and option_spec == "iso_8601":
+            def validator(argument: str) -> object:
+                # Error is thrown if format is wrong
+                datetime.fromisoformat(argument)
+                return argument
+            return validator
         elif isinstance(option_spec, str) and option_spec in self.enum:
             return lambda argument: tinydocutils.directives.choice(
                 argument, self.enum[option_spec]

--- a/snooty/specparser.py
+++ b/snooty/specparser.py
@@ -359,10 +359,12 @@ class Spec:
         elif isinstance(option_spec, PrimitiveType):
             return VALIDATORS[option_spec]
         elif isinstance(option_spec, str) and option_spec == "iso_8601":
+
             def validator(argument: str) -> object:
                 # Error is thrown if format is wrong
                 datetime.fromisoformat(argument)
                 return argument
+
             return validator
         elif isinstance(option_spec, str) and option_spec in self.enum:
             return lambda argument: tinydocutils.directives.choice(

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4346,6 +4346,8 @@ Test Page
 .. video:: https://www.youtube.com/embed/XrJG994YxD8
    
 .. video:: https://www.youtube.com/embed/XrJG994YxD8
+   :title: Mastering Indexing for Perfect Query Matches
+   :description: In this video, we learn about how Atlas Search indexes can be used to optimize queries.
    :thumbnail-url: https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg
    :upload-date: 2023-11-08T05:00:28-08:00
 
@@ -4367,7 +4369,7 @@ Test Page
                 <text>https://www.youtube.com/embed/XrJG994YxD8</text>
             </reference>
         </directive>
-        <directive name="video" thumbnail-url="https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg" upload-date="2023-11-08T05:00:28-08:00">
+        <directive name="video" title="Mastering Indexing for Perfect Query Matches" description="In this video, we learn about how Atlas Search indexes can be used to optimize queries." thumbnail-url="https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg" upload-date="2023-11-08T05:00:28-08:00">
             <reference refuri="https://www.youtube.com/embed/XrJG994YxD8">
                 <text>https://www.youtube.com/embed/XrJG994YxD8</text>
             </reference>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -25,6 +25,7 @@ from .diagnostics import (
     MalformedRelativePath,
     MissingChild,
     MissingFacet,
+    MissingStructuredDataFields,
     RemovedLiteralBlockSyntax,
     TabMustBeDirective,
     UnexpectedDirectiveOrder,
@@ -4354,10 +4355,18 @@ Test Page
 .. video:: https://www.youtube.com/embed/XrJG994YxD8
    :thumbnail-url: https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg
    :upload-date: 2023-11-08
+
+.. video:: https://www.youtube.com/embed/XrJG994YxD8
+   :description: This is an educational video.
     """,
     )
     page.finish(diagnostics)
-    assert not diagnostics
+    assert len(diagnostics) == 2
+    assert isinstance(diagnostics[0], MissingStructuredDataFields)
+    assert "['title', 'description']" in diagnostics[0].message
+    assert isinstance(diagnostics[1], MissingStructuredDataFields)
+    assert "['title', 'thumbnail-url', 'upload-date']" in diagnostics[1].message
+
     check_ast_testing_string(
         page.ast,
         """
@@ -4375,6 +4384,11 @@ Test Page
             </reference>
         </directive>
         <directive name="video" thumbnail-url="https://i.ytimg.com/vi/XrJG994YxD8/maxresdefault.jpg" upload-date="2023-11-08">
+            <reference refuri="https://www.youtube.com/embed/XrJG994YxD8">
+                <text>https://www.youtube.com/embed/XrJG994YxD8</text>
+            </reference>
+        </directive>
+        <directive name="video" description="This is an educational video.">
             <reference refuri="https://www.youtube.com/embed/XrJG994YxD8">
                 <text>https://www.youtube.com/embed/XrJG994YxD8</text>
             </reference>


### PR DESCRIPTION
### Ticket

DOP-4917
[Related frontend PR](https://github.com/mongodb/snooty/pull/1236)
[Example rST](https://github.com/rayangler/cloud-docs/commit/93ab9b1cc34c1a461e8266da44f07687acc49c49)

### Notes

* I know the original ticket didn't ask for a `description` option, but I saw this [Google Rich Result test](https://search.google.com/test/rich-results/result?id=NWG835UY5-cwJQ_1l8KR-A) that showed a single warning and figured it's worth including for completion.
* All options are not required for the `video` directive to be used on a page, in order to allow for backwards compatibility. However, a warning will be added whenever one of the options is used without the use of all other options for structured data. The frontend will handle whether to show the structured data or not based on the options available.
* This PR should be good to merge without the need for the frontend PR as the existence of the new options shouldn't break anything

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
