### PR TITLE
DOP-4967: Contextualize headings in method selector for "On This Page" list

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -478,7 +478,7 @@ class ContentsHandler(Handler):
         self.current_depth = 0
         self.has_contents_directive = False
         self.headings: List[ContentsHandler.HeadingData] = []
-        self.scanned_pattern: List[Tuple[str, Dict[str, str]]] = []
+        self.scanned_pattern: List[str] = []
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.contents_depth = sys.maxsize
@@ -509,8 +509,8 @@ class ContentsHandler(Handler):
             self.current_depth += 1
             return
 
-        if isinstance(node, n.Directive):
-            self.scanned_pattern.append((node.name, node.options))
+        if isinstance(node, n.Directive) and node.name == "method-option":
+            self.scanned_pattern.append(node.options["id"])
 
         if isinstance(node, n.Directive) and node.name == "contents":
             if self.has_contents_directive:
@@ -529,8 +529,7 @@ class ContentsHandler(Handler):
         selector_id = None
         if len(self.scanned_pattern) > 0:
             for item in self.scanned_pattern:
-                if item[0] == "method-option":
-                    selector_id = item[1]["id"]
+                selector_id = item
 
         # Omit title headings (depth = 1) from heading list
         if isinstance(node, n.Heading) and self.current_depth > 1:
@@ -552,7 +551,7 @@ class ContentsHandler(Handler):
             )
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Directive):
+        if isinstance(node, n.Directive) and node.name == "method-option":
             self.scanned_pattern.pop()
         if isinstance(node, n.Section):
             self.current_depth -= 1

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -478,7 +478,7 @@ class ContentsHandler(Handler):
         self.current_depth = 0
         self.has_contents_directive = False
         self.headings: List[ContentsHandler.HeadingData] = []
-        self.scanned_pattern = []
+        self.scanned_pattern: List[Tuple[str, Dict[str, str]]] = []
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.contents_depth = sys.maxsize
@@ -528,14 +528,16 @@ class ContentsHandler(Handler):
 
         selector_id = None
         if len(self.scanned_pattern) > 0:
-                for item in self.scanned_pattern:
-                    if item[0] == "method-option":
-                        selector_id = item[1]["id"]
+            for item in self.scanned_pattern:
+                if item[0] == "method-option":
+                    selector_id = item[1]["id"]
 
         # Omit title headings (depth = 1) from heading list
         if isinstance(node, n.Heading) and self.current_depth > 1:
             self.headings.append(
-                ContentsHandler.HeadingData(self.current_depth, node.id, node.children, selector_id)
+                ContentsHandler.HeadingData(
+                    self.current_depth, node.id, node.children, selector_id
+                )
             )
 
         if isinstance(node, n.Directive) and node.name == "collapsible":
@@ -546,7 +548,7 @@ class ContentsHandler(Handler):
                     self.current_depth,
                     html5_id,
                     [n.Text(node.span, node.options["heading"])],
-                    selector_id
+                    selector_id,
                 )
             )
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3963,6 +3963,97 @@ Testing Tabs Selector
         )
 
 
+def test_method_selector_headings() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. contents::
+    :depth: 2
+
+===================
+Heading of the page
+===================
+
+Subsection heading
+------------------
+
+.. method-selector::
+
+   .. method-option::
+      :id: driver
+
+      WHAT
+      ~~~~
+
+      .. method-description::
+
+         This is an optional description. Learn more about drivers at `MongoDB Documentation <https://www.mongodb.com/docs/drivers/>`__.
+
+      This is content in the Driver method haha.
+
+   .. method-option::
+      :id: cli
+
+      This is a heading
+      ~~~~~~~~~~~~~~~~~
+
+      .. method-description::
+
+         This is a description under the heading for cli.
+      
+      This is content in the CLI method haha.
+
+   .. method-option::
+      :id: mongosh
+
+      Foo
+      
+""",
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        assert (page.ast.options.get("headings")) == [
+            {
+                "depth": 2,
+                "id": "subsection-heading",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 9}},
+                        "value": "Subsection heading",
+                    }
+                ],
+                "selector_id": None,
+            },
+            {
+                "depth": 3,
+                "id": "what",
+                "selector_id": "driver",
+                "title": [
+                    {
+                        "position": {"start": {"line": 17}},
+                        "type": "text",
+                        "value": "WHAT",
+                    }
+                ],
+            },
+            {
+                "depth": 3,
+                "id": "this-is-a-heading",
+                "selector_id": "cli",
+                "title": [
+                    {
+                        "position": {"start": {"line": 29}},
+                        "type": "text",
+                        "value": "This is a heading",
+                    }
+                ],
+            },
+        ]
+
+
 def test_multi_page_tutorials() -> None:
     test_page_template = """
 .. multi-page-tutorial::

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2347,7 +2347,7 @@ A Heading
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page.txt" headings="[{'depth': 2, 'id': 'first-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 9}}, 'value': 'First Heading'}]}, {'depth': 3, 'id': 'second-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 12}}, 'value': 'Second Heading'}]}, {'depth': 2, 'id': 'third-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 18}}, 'value': 'Third Heading'}]}]">
+<root fileid="page.txt" headings="[{'depth': 2, 'id': 'first-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 9}}, 'value': 'First Heading'}], 'selector_id': None}, {'depth': 3, 'id': 'second-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 12}}, 'value': 'Second Heading'}], 'selector_id': None}, {'depth': 2, 'id': 'third-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 18}}, 'value': 'Third Heading'}], 'selector_id': None}]">
 <section>
 <heading id="title"><text>Title</text></heading>
 <directive name="contents" depth="2" />
@@ -3510,6 +3510,7 @@ Subsection heading
                         "value": "Subsection heading",
                     }
                 ],
+                "selector_id": None,
             },
             {
                 "depth": 2,
@@ -3521,6 +3522,7 @@ Subsection heading
                         "value": "Collapsible heading",
                     }
                 ],
+                "selector_id": None,
             },
             {
                 "depth": 3,
@@ -3532,6 +3534,7 @@ Subsection heading
                         "value": "This is content",
                     }
                 ],
+                "selector_id": None,
             },
         ]
 


### PR DESCRIPTION
### Ticket

DOP-4967

### Notes

Adds `selector_id` to heading if they belong to a certain method option. Can be extended to tab options in the future. 

See [PR in Snooty](https://github.com/mongodb/snooty/pull/1237)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
