### PR TITLE
DOP-4915: add display_name property to facets

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1784,11 +1784,24 @@ class FacetsHandler(Handler):
 
         facet_values = node.options["values"]
         parent = None
+        parent_facets = []
         if self.parent_stack:
             parent = self.parent_stack[-1][0]
+            parent_facets = list(map(lambda tuple: tuple[0], self.parent_stack))
 
         for facet_value in facet_values.split(","):
-            facet_node = Facet(category=node.options["name"], value=facet_value.strip())
+            unparsed_facet = {
+                "value": facet_value.strip(),
+                "category": node.options["name"],
+            }
+            facet_display_name = ProjectConfig.get_facet_display_name(
+                parent_facets, unparsed_facet
+            )
+            facet_node = Facet(
+                category=unparsed_facet["category"],
+                value=unparsed_facet["value"],
+                display_name=facet_display_name,
+            )
 
             if not parent:
                 self.facets.append(facet_node)

--- a/snooty/taxonomy.py
+++ b/snooty/taxonomy.py
@@ -16,9 +16,7 @@ class FacetDefinition:
 
 @checked
 @dataclass
-class TargetProductDefinition:
-    name: str
-    display_name: Optional[str]
+class TargetProductDefinition(FacetDefinition):
     sub_product: Optional[List[FacetDefinition]]
     version: Optional[List[FacetDefinition]]
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3126,7 +3126,11 @@ Facets
                     value="atlas",
                     sub_facets=[
                         Facet(category="version", value="v1.2"),
-                        Facet(category="sub_product", value="charts", display_name="Charts"),
+                        Facet(
+                            category="sub_product",
+                            value="charts",
+                            display_name="Charts",
+                        ),
                     ],
                 ),
             ]
@@ -3212,12 +3216,22 @@ value = "test"
                     value="atlas",
                     sub_facets=[
                         Facet(category="version", value="v1.2", display_name="v1.2"),
-                        Facet(category="sub_product", value="charts", display_name="Charts"),
-                        Facet(category="sub_product", value="atlas-cli", display_name="Atlas CLI"),
+                        Facet(
+                            category="sub_product",
+                            value="charts",
+                            display_name="Charts",
+                        ),
+                        Facet(
+                            category="sub_product",
+                            value="atlas-cli",
+                            display_name="Atlas CLI",
+                        ),
                     ],
-                    display_name="Atlas"
+                    display_name="Atlas",
                 ),
-                Facet(category="programming_language", value="shell", display_name="Shell"),
+                Facet(
+                    category="programming_language", value="shell", display_name="Shell"
+                ),
             ]
         )
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3126,7 +3126,7 @@ Facets
                     value="atlas",
                     sub_facets=[
                         Facet(category="version", value="v1.2"),
-                        Facet(category="sub_product", value="charts"),
+                        Facet(category="sub_product", value="charts", display_name="Charts"),
                     ],
                 ),
             ]
@@ -3153,6 +3153,7 @@ def test_toml_facets() -> None:
 .. facet::
    :name: genre
    :values: reference
+
 .. facet::
    :name: target_product
    :values: atlas
@@ -3160,9 +3161,11 @@ def test_toml_facets() -> None:
    .. facet::
       :name: version
       :values: v1.2
+
    .. facet::
       :name: sub_product
       :values: charts,atlas-cli
+
 .. facet::
    :name: genre
    :values: tutorial
@@ -3202,18 +3205,19 @@ value = "test"
         assert facets is not None
         assert sorted(facets) == sorted(
             [
-                Facet(category="genre", value="reference"),
-                Facet(category="genre", value="tutorial"),
+                Facet(category="genre", value="reference", display_name="Reference"),
+                Facet(category="genre", value="tutorial", display_name="Tutorial"),
                 Facet(
                     category="target_product",
                     value="atlas",
                     sub_facets=[
-                        Facet(category="version", value="v1.2"),
-                        Facet(category="sub_product", value="charts"),
-                        Facet(category="sub_product", value="atlas-cli"),
+                        Facet(category="version", value="v1.2", display_name="v1.2"),
+                        Facet(category="sub_product", value="charts", display_name="Charts"),
+                        Facet(category="sub_product", value="atlas-cli", display_name="Atlas CLI"),
                     ],
+                    display_name="Atlas"
                 ),
-                Facet(category="programming_language", value="shell"),
+                Facet(category="programming_language", value="shell", display_name="Shell"),
             ]
         )
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3104,7 +3104,7 @@ def test_facets() -> None:
 
    .. facet::
       :name: sub_product
-      :values: charts
+      :values: charts, data-federation
 
 
 ===========================
@@ -3130,6 +3130,11 @@ Facets
                             category="sub_product",
                             value="charts",
                             display_name="Charts",
+                        ),
+                        Facet(
+                            category="sub_product",
+                            value="data-federation",
+                            display_name="Data Federation",
                         ),
                     ],
                 ),

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -459,7 +459,7 @@ class ProjectConfig:
                 taxonomy_ref["display_name"]
                 or str(taxonomy_ref["name"]).replace(r"\_", " ").title()
             )
-        except Exception as e:
+        except Exception:
             logger.warning(f"Display name not found for invalid facet {unparsed_facet}")
             return ""
 

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -461,6 +461,7 @@ class ProjectConfig:
             )
         except Exception as e:
             logger.warning(f"Display name not found for invalid facet {unparsed_facet}")
+            return ""
 
     @staticmethod
     def _substitute(

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -445,19 +445,24 @@ class ProjectConfig:
         parent_facets: List[Facet], unparsed_facet: Dict[str, Any]
     ) -> str:
         try:
+            # for version facets, return the version name as is
             if unparsed_facet["category"] == "version":
                 return str(unparsed_facet["value"])
+
+            # start with base taxonomy and iterate through parent facets list
             taxonomy_ref = asdict(taxonomy.TaxonomySpec.get_taxonomy())
             for parent in parent_facets:
                 options_list = taxonomy_ref[parent.category] or []
                 taxonomy_ref = [x for x in options_list if x["name"] == parent.value][0]
+
+            # find target unparsed_facet within taxonomy facet
             options_list = taxonomy_ref[unparsed_facet["category"]]
             taxonomy_ref = [
                 x for x in options_list if x["name"] == str(unparsed_facet["value"])
             ][0]
             return str(
                 taxonomy_ref["display_name"]
-                or str(taxonomy_ref["name"]).replace(r"\_", " ").title()
+                or re.sub("_|-", " ", str(taxonomy_ref["name"])).title()
             )
         except Exception:
             logger.warning(f"Display name not found for invalid facet {unparsed_facet}")

--- a/snooty/types.py
+++ b/snooty/types.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import os.path
 import re
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path, PurePath
 from typing import (
     Any,
@@ -132,6 +132,7 @@ class ParsedBannerConfig:
 class Facet:
     category: str
     value: str
+    display_name: Optional[str] = ""
     sub_facets: Optional[List["Facet"]] = None
 
     def __lt__(self, other: "Facet") -> bool:
@@ -151,6 +152,7 @@ class Facet:
             "category": self.category,
             "value": self.value,
             "sub_facets": None,
+            "display_name": self.display_name,
         }
         if self.sub_facets:
             result["sub_facets"] = [
@@ -346,6 +348,7 @@ class ProjectConfig:
                     category=facet.category,
                     value=facet.value,
                     sub_facets=validated_sub_facets,
+                    display_name=facet.display_name,
                 )
 
                 validated_facets.append(validated_facet)
@@ -362,12 +365,22 @@ class ProjectConfig:
         return validated_facets, diagnostics
 
     @staticmethod
-    def parse_facet(unparsed_facet: Dict[str, Any]) -> Facet:
+    def parse_facet(
+        unparsed_facet: Dict[str, Any], parent_facets: List[Facet]
+    ) -> Facet:
         try:
-            facet = Facet(**unparsed_facet)
+            display_name = ProjectConfig.get_facet_display_name(
+                parent_facets, unparsed_facet
+            )
+            facet = Facet(
+                **unparsed_facet,
+                display_name=display_name,
+            )
             if facet.sub_facets:
+                new_parent_facets = parent_facets + [facet]
                 facet.sub_facets = [
-                    ProjectConfig.parse_facet(f) for f in unparsed_facet["sub_facets"]
+                    ProjectConfig.parse_facet(f, new_parent_facets)
+                    for f in unparsed_facet["sub_facets"]
                 ]
         except Exception as e:
             logger.error(e)
@@ -384,7 +397,7 @@ class ProjectConfig:
         try:
             with path.open("rb") as f:
                 data = tomli.load(f)["facets"]
-                facets = [ProjectConfig.parse_facet(facet) for facet in data]
+                facets = [ProjectConfig.parse_facet(facet, []) for facet in data]
                 (
                     validated_facets_result,
                     validation_diagnostics,
@@ -426,6 +439,28 @@ class ProjectConfig:
                 merged_facets.append(facet)
 
         return merged_facets
+
+    @staticmethod
+    def get_facet_display_name(
+        parent_facets: List[Facet], unparsed_facet: Dict[str, Any]
+    ) -> str:
+        try:
+            if unparsed_facet["category"] == "version":
+                return str(unparsed_facet["value"])
+            taxonomy_ref = asdict(taxonomy.TaxonomySpec.get_taxonomy())
+            for parent in parent_facets:
+                options_list = taxonomy_ref[parent.category] or []
+                taxonomy_ref = [x for x in options_list if x["name"] == parent.value][0]
+            options_list = taxonomy_ref[unparsed_facet["category"]]
+            taxonomy_ref = [
+                x for x in options_list if x["name"] == str(unparsed_facet["value"])
+            ][0]
+            return str(
+                taxonomy_ref["display_name"]
+                or str(taxonomy_ref["name"]).replace(r"\_", " ").title()
+            )
+        except Exception as e:
+            logger.warning(f"Display name not found for invalid facet {unparsed_facet}")
 
     @staticmethod
     def _substitute(


### PR DESCRIPTION
### Ticket

DOP-4915

### Notes

This is a prereq to the structured data being displayed on the front end. (see this tech spec for TechArticle section that specifies that we need to construct Structured Data based on the `target_platform` property of facets.
These changes extract the `display_name` from the [taxonomy file](https://github.com/mongodb/snooty-parser/blob/main/snooty/taxonomy.toml) and appends them to the produced `page.facets`.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
