### PR TITLE
DOP-4959: parse literals in titles

### DIFF
--- a/snooty/n.py
+++ b/snooty/n.py
@@ -472,6 +472,9 @@ class Literal(InlineParent):
     __slots__ = ()
     type = "literal"
 
+    def get_text(self) -> str:
+        return "".join(node.value for node in self.children)
+
 
 @dataclass
 class Emphasis(InlineParent):

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -473,7 +473,7 @@ class Literal(InlineParent):
     type = "literal"
 
     def get_text(self) -> str:
-        return "".join(node.value for node in self.children)
+        return "".join(getattr(node, "value", "") for node in self.children)
 
 
 @dataclass

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2065,7 +2065,7 @@ class Postprocessor:
             k: (
                 context[TocTitleHandler].get_title(f"/{k}")
                 if f"/{k}" in context[TocTitleHandler].slug_title_mapping
-                else v[0].get_text()
+                else "".join(node.get_text() for node in v)
             )
             for k, v in context[HeadingHandler].slug_title_mapping.items()
         }

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3445,6 +3445,51 @@ Alrighty
         assert slug_to_breadcrumb_label_entry["page2"] == "Well, You Learned It"
         assert slug_to_breadcrumb_label_entry["ref/page3"] == "Page Three Title"
 
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+==========
+Index Page
+==========
+
+.. toctree::
+   :titlesonly:
+
+   </page1>
+   </page2>
+""",
+            Path(
+                "source/page1.txt"
+            ): """
+==============
+Configure ``mongosh``
+==============
+
+Text for configuration.
+
+""",
+            Path(
+                "source/page2.txt"
+            ): """
+==============
+Customize the :binary:`~bin.mongosh` Prompt
+==============
+
+A very well-written page.
+""",
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        assert len(diagnostics) == 0
+
+        slug_to_breadcrumb_label_entry = cast(
+            Dict[str, str], result.metadata["slugToBreadcrumbLabel"]
+        )
+        assert slug_to_breadcrumb_label_entry["page1"] == "Configure mongosh"
+        assert slug_to_breadcrumb_label_entry["page2"] == "Customize the mongosh Prompt"
+
 
 def test_nested_collapsibles() -> None:
     with make_test(


### PR DESCRIPTION
### Ticket

DOP-4959

### Notes

In prod currently, breadcrumbs and prevnext button text only have the title's first node's text. This works for most titles. This PR includes inline literals.

[Current prod](https://www.mongodb.com/docs/mongodb-shell/reference/configure-shell-settings-global/)
[Staging](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4942-dark-icons-master/mongodb-shell/matt.meigs/main/reference/configure-shell-settings-global/index.html)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
