### PR TITLE
DOP-3424: "On this page" subnav incorrectly displays headings for all language tabs

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -463,7 +463,7 @@ class NamedReferenceHandlerPass2(Handler):
         node.refuri = refuri
 
 
-SelectorId = Union[str, Dict[str, "SelectorId"]]
+SelectorId = Dict[str, Union[str, "SelectorId"]]
 
 
 class ContentsHandler(Handler):
@@ -473,7 +473,7 @@ class ContentsHandler(Handler):
         depth: int
         id: str
         title: Sequence[n.InlineNode]
-        selector_ids: Dict[str, SelectorId]
+        selector_ids: SelectorId
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
@@ -483,12 +483,15 @@ class ContentsHandler(Handler):
         self.headings: List[ContentsHandler.HeadingData] = []
         self.scanned_pattern: List[Tuple[str, str]] = []
 
-    def scan_pattern(self, arr: List[Tuple[str, str]]) -> Dict[Any, Any]:
-        if arr is []:
+    def scan_pattern(self, arr: List[Tuple[str, str]]) -> SelectorId:
+        if not arr:
             return {}
         if len(arr) == 1:
             return {arr[0][0]: arr[0][1]}
-        scanned_pattern = {arr[0][0]: arr[0][1], "children": self.scan_pattern(arr[1:])}
+        scanned_pattern: SelectorId = {
+            arr[0][0]: arr[0][1],
+            "children": self.scan_pattern(arr[1:]),
+        }
         return scanned_pattern
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -463,6 +463,9 @@ class NamedReferenceHandlerPass2(Handler):
         node.refuri = refuri
 
 
+SelectorId = Union[str, Dict[str, "SelectorId"]]
+
+
 class ContentsHandler(Handler):
     """Identify all headings on a given page. If a contents directive appears on the page, save list of headings as a page-level option."""
 
@@ -470,7 +473,7 @@ class ContentsHandler(Handler):
         depth: int
         id: str
         title: Sequence[n.InlineNode]
-        selector_ids: Dict[Any, Any]
+        selector_ids: Dict[str, SelectorId]
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -470,7 +470,7 @@ class ContentsHandler(Handler):
         depth: int
         id: str
         title: Sequence[n.InlineNode]
-        selector_ids: List[object]
+        selector_ids: object
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
@@ -479,6 +479,17 @@ class ContentsHandler(Handler):
         self.has_contents_directive = False
         self.headings: List[ContentsHandler.HeadingData] = []
         self.scanned_pattern: List[str] = []
+
+    def scan_pattern(self, arr) -> object:
+        if arr is []: 
+            return {}
+        if len(arr) == 1:
+            return {arr[0][0]: arr[0][1]}
+        scanned_pattern = {
+            arr[0][0]: arr[0][1],
+            "children": self.scan_pattern(arr[1:])
+        }
+        return scanned_pattern
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.contents_depth = sys.maxsize
@@ -531,11 +542,10 @@ class ContentsHandler(Handler):
         if self.current_depth - 1 > self.contents_depth:
             return
 
-        selector_ids = []
+        selector_ids = {}
         if len(self.scanned_pattern) > 0:
-            for item in self.scanned_pattern:
-                selector_ids.append({item[0]: item[1]})
-
+            selector_ids = self.scan_pattern(self.scanned_pattern)
+                
         # Omit title headings (depth = 1) from heading list
         if isinstance(node, n.Heading) and self.current_depth > 1:
             self.headings.append(

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -517,8 +517,6 @@ class ContentsHandler(Handler):
             self.current_depth += 1
             return
 
-        # add tab selectors here as well
-
         if isinstance(node, n.Directive):
             if node.name == "method-option":
                 self.scanned_pattern.append((node.name, node.options["id"]))

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -2347,7 +2347,7 @@ A Heading
         check_ast_testing_string(
             page.ast,
             """
-<root fileid="page.txt" headings="[{'depth': 2, 'id': 'first-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 9}}, 'value': 'First Heading'}], 'selector_id': None}, {'depth': 3, 'id': 'second-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 12}}, 'value': 'Second Heading'}], 'selector_id': None}, {'depth': 2, 'id': 'third-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 18}}, 'value': 'Third Heading'}], 'selector_id': None}]">
+<root fileid="page.txt" headings="[{'depth': 2, 'id': 'first-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 9}}, 'value': 'First Heading'}], 'selector_ids': {}}, {'depth': 3, 'id': 'second-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 12}}, 'value': 'Second Heading'}], 'selector_ids': {}}, {'depth': 2, 'id': 'third-heading', 'title': [{'type': 'text', 'position': {'start': {'line': 18}}, 'value': 'Third Heading'}], 'selector_ids': {}}]">
 <section>
 <heading id="title"><text>Title</text></heading>
 <directive name="contents" depth="2" />
@@ -3557,7 +3557,7 @@ Subsubsection heading
                         "value": "Subsection heading",
                     }
                 ],
-                "selector_id": None,
+                "selector_ids": {},
             },
             {
                 "depth": 3,
@@ -3569,7 +3569,7 @@ Subsubsection heading
                         "value": "Subsubsection heading",
                     }
                 ],
-                "selector_id": None,
+                "selector_ids": {},
             },
         ]
 
@@ -3621,7 +3621,7 @@ Subsubsection heading
                         "value": "Subsection heading",
                     }
                 ],
-                "selector_id": None,
+                "selector_ids": {},
             }
         ]
 
@@ -3659,7 +3659,7 @@ Heading of the page
                         "value": "Collapsible heading",
                     }
                 ],
-                "selector_id": None,
+                "selector_ids": {},
             }
         ]
 
@@ -4070,12 +4070,12 @@ Subsection heading
                         "value": "Subsection heading",
                     }
                 ],
-                "selector_id": None,
+                "selector_ids": {},
             },
             {
                 "depth": 3,
                 "id": "what",
-                "selector_id": "driver",
+                "selector_ids": {"method-option": "driver"},
                 "title": [
                     {
                         "position": {"start": {"line": 17}},
@@ -4087,7 +4087,7 @@ Subsection heading
             {
                 "depth": 3,
                 "id": "this-is-a-heading",
-                "selector_id": "cli",
+                "selector_ids": {"method-option": "cli"},
                 "title": [
                     {
                         "position": {"start": {"line": 29}},
@@ -4095,6 +4095,68 @@ Subsection heading
                         "value": "This is a heading",
                     }
                 ],
+            },
+        ]
+
+def test_tab_headings() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. contents:: On this page
+   :depth: 3
+
+Title here
+==========
+
+.. tabs::
+         
+    .. tab:: tabs1
+        :tabid: tabs1
+
+        Heading here
+        ------------
+        This is content in tab1.
+
+        .. tabs::
+
+            .. tab:: tabby
+                :tabid: tabby
+
+                This is another headinge!
+                ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+                Text ext text
+      
+""",
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        assert (page.ast.options.get("headings")) == [
+            {
+                "depth": 2,
+                "id": "heading-here",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 13}},
+                        "value": "Heading here",
+                    }
+                ],
+                "selector_ids": {"tab": "tabs1"},
+            },
+            {
+                "depth": 3,
+                "id": "this-is-another-headinge-",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 22}},
+                        "value": "This is another headinge!",
+                    }
+                ],
+                "selector_ids": {"tab": "tabs1", "children": {"tab": "tabby"}},
             },
         ]
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4098,6 +4098,7 @@ Subsection heading
             },
         ]
 
+
 def test_tab_headings() -> None:
     with make_test(
         {


### PR DESCRIPTION
### Ticket

DOP-3424

### Notes

Creates a `selector_ids` object that reflects the AST in terms of the order of tabs/method selectors. This object looks something like this:

```
method-option: abc
children: {
     tab: def
     children: {
          tab: efg
     }
}
```

This is used by snooty ([see PR](https://github.com/mongodb/snooty/pull/1262)) to determine correct headings to show.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
