### PR TITLE
DOP-4945: Default tab available for drivers tabs

### DIFF
--- a/snooty/diagnostics.py
+++ b/snooty/diagnostics.py
@@ -1042,3 +1042,19 @@ class InvalidChildCount(Diagnostic):
             start,
             end,
         )
+
+
+class UnknownDefaultTabId(Diagnostic):
+    severity = Diagnostic.Level.warning
+
+    def __init__(
+        self,
+        unknown_id: str,
+        start: Union[int, Tuple[int, int]],
+        end: Union[None, int, Tuple[int, int]] = None,
+    ):
+        super().__init__(
+            f"Option :default-tabid: '{unknown_id}' is not present in tabs on page.",
+            start,
+            end,
+        )

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -63,6 +63,7 @@ from .diagnostics import (
     SubstitutionRefError,
     TargetNotFound,
     UnexpectedDirectiveOrder,
+    UnknownDefaultTabId,
     UnnamedPage,
     UnsupportedFormat,
 )
@@ -683,6 +684,16 @@ class TabsSelectorHandler(Handler):
 
                 # If default_tabs are present, append to page options
                 if tabset_name in self.default_tabs:
+                    default_tab_is_in_selectors = (
+                        self.default_tabs[tabset_name]
+                        in page.ast.options["selectors"][tabset_name].keys()
+                    )
+                    if not default_tab_is_in_selectors:
+                        self.context.diagnostics[fileid_stack.current].append(
+                            UnknownDefaultTabId(self.default_tabs[tabset_name] or "", 0)
+                        )
+                        return
+
                     if not page.ast.options.get("default_tabs"):
                         page.ast.options["default_tabs"] = {}
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -620,7 +620,7 @@ class TabsSelectorHandler(Handler):
                 )
                 return
 
-            if tabset_name == "drivers" and node.options.get("default-tabid"):
+            if tabset_name == "drivers" and "default-tabid" in node.options:
                 self.default_tabs[tabset_name] = node.options.get("default-tabid")
 
             self.selectors[tabset_name] = []
@@ -682,7 +682,7 @@ class TabsSelectorHandler(Handler):
                 }
 
                 # If default_tabs are present, append to page options
-                if self.default_tabs.get(tabset_name):
+                if tabset_name in self.default_tabs:
                     if not page.ast.options.get("default_tabs"):
                         page.ast.options["default_tabs"] = {}
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -578,7 +578,7 @@ class ContentsHandler(Handler):
 class TabsSelectorHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.default_tabs: Dict[Optional[str], Optional[str]] = {}
+        self.default_tabs: Dict[str, Optional[str]] = {}
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
         self.scanned_pattern: List[str] = []
         self.target_pattern = ["tabs", "tabs", "procedure"]

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -579,7 +579,7 @@ class ContentsHandler(Handler):
 class TabsSelectorHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.default_tabs: Dict[str, Optional[str]] = {}
+        self.default_tabs: Dict[str, str] = {}
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
         self.scanned_pattern: List[str] = []
         self.target_pattern = ["tabs", "tabs", "procedure"]
@@ -622,7 +622,7 @@ class TabsSelectorHandler(Handler):
                 return
 
             if tabset_name == "drivers" and "default-tabid" in node.options:
-                self.default_tabs[tabset_name] = node.options.get("default-tabid")
+                self.default_tabs[tabset_name] = node.options.get("default-tabid", "")
 
             self.selectors[tabset_name] = []
             return

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -578,6 +578,7 @@ class ContentsHandler(Handler):
 class TabsSelectorHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
+        self.default_tabs: Dict[str, str] = {}
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
         self.scanned_pattern: List[str] = []
         self.target_pattern = ["tabs", "tabs", "procedure"]
@@ -633,6 +634,9 @@ class TabsSelectorHandler(Handler):
                 if tab.name == "tab" and "tabid" in tab.options
             }
             self.selectors[tabset_name].append(tabs)
+        
+        if tabset_name == "drivers" and node.options.get("default-tab-id"):
+            self.default_tabs[tabset_name] = node.options.get("default-tab-id")
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
@@ -676,6 +680,14 @@ class TabsSelectorHandler(Handler):
                     tabid: [node.serialize() for node in title]
                     for tabid, title in tabsets[0].items()
                 }
+
+                # If default_tabs are present, append to page options
+                if self.default_tabs.get(tabset_name):
+                    if not page.ast.options.get("default_tabs"):
+                        page.ast.options["default_tabs"] = {}
+
+                    assert isinstance(page.ast.options["default_tabs"], Dict)
+                    page.ast.options["default_tabs"][tabset_name] = self.default_tabs[tabset_name]
 
 
 class TargetHandler(Handler):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -578,7 +578,7 @@ class ContentsHandler(Handler):
 class TabsSelectorHandler(Handler):
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.default_tabs: Dict[str, str] = {}
+        self.default_tabs: Dict[Optional[str], Optional[str]] = {}
         self.selectors: Dict[str, List[Dict[str, MutableSequence[n.Text]]]] = {}
         self.scanned_pattern: List[str] = []
         self.target_pattern = ["tabs", "tabs", "procedure"]
@@ -620,6 +620,9 @@ class TabsSelectorHandler(Handler):
                 )
                 return
 
+            if tabset_name == "drivers" and node.options.get("default-tabid"):
+                self.default_tabs[tabset_name] = node.options.get("default-tabid")
+
             self.selectors[tabset_name] = []
             return
 
@@ -634,9 +637,6 @@ class TabsSelectorHandler(Handler):
                 if tab.name == "tab" and "tabid" in tab.options
             }
             self.selectors[tabset_name].append(tabs)
-        
-        if tabset_name == "drivers" and node.options.get("default-tab-id"):
-            self.default_tabs[tabset_name] = node.options.get("default-tab-id")
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
@@ -687,7 +687,9 @@ class TabsSelectorHandler(Handler):
                         page.ast.options["default_tabs"] = {}
 
                     assert isinstance(page.ast.options["default_tabs"], Dict)
-                    page.ast.options["default_tabs"][tabset_name] = self.default_tabs[tabset_name]
+                    page.ast.options["default_tabs"][tabset_name] = self.default_tabs[
+                        tabset_name
+                    ]
 
 
 class TargetHandler(Handler):

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -344,6 +344,12 @@ options.glob = "flag"
 [directive.tabs-selector]
 help = """Add dropdown selector used to select the specified tabset."""
 argument_type = "string"
+options.default-tabid = "string"
+example = """.. tabs-selector:: ${1: string}
+   :default-tabid: ${2:id of the default tab (Optional for drivers)}
+
+   ${0:Content block}
+"""
 
 [directive.tabs-pillstrip]
 deprecated = true
@@ -357,7 +363,6 @@ content_type = "block"
 argument_type = "string"
 options.hidden = "boolean"
 options.tabset = "string"
-options.default-tab-id = "string"
 example = """.. tabs:: ${1: string}
    :hidden: ${2|true,false|}
    :tabset: ${3:string}
@@ -373,10 +378,9 @@ inherit = "tabs"
 
 [directive.tabs-drivers]
 inherit = "tabs"
-example = """.. tabs:: ${1: string}
+example = """.. tabs-drivers:: ${1: string}
    :hidden: ${2|true,false|}
    :tabset: ${3:string}
-   :default-tab-id: ${4:id of the default tab (Optional)}
 
    ${0:Content block}
 """

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -357,6 +357,7 @@ content_type = "block"
 argument_type = "string"
 options.hidden = "boolean"
 options.tabset = "string"
+options.default-tab-id = "string"
 example = """.. tabs:: ${1: string}
    :hidden: ${2|true,false|}
    :tabset: ${3:string}
@@ -372,6 +373,13 @@ inherit = "tabs"
 
 [directive.tabs-drivers]
 inherit = "tabs"
+example = """.. tabs:: ${1: string}
+   :hidden: ${2|true,false|}
+   :tabset: ${3:string}
+   :default-tab-id: ${4:id of the default tab (Optional)}
+
+   ${0:Content block}
+"""
 
 [directive.tabs-auth]
 inherit = "tabs"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -378,12 +378,6 @@ inherit = "tabs"
 
 [directive.tabs-drivers]
 inherit = "tabs"
-example = """.. tabs-drivers:: ${1: string}
-   :hidden: ${2|true,false|}
-   :tabset: ${3:string}
-
-   ${0:Content block}
-"""
 
 [directive.tabs-auth]
 inherit = "tabs"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -347,8 +347,6 @@ argument_type = "string"
 options.default-tabid = "string"
 example = """.. tabs-selector:: ${1: string}
    :default-tabid: ${2:id of the default tab (Optional for drivers)}
-
-   ${0:Content block}
 """
 
 [directive.tabs-pillstrip]

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -32,6 +32,7 @@ from .diagnostics import (
     TabMustBeDirective,
     TargetNotFound,
     UnexpectedDirectiveOrder,
+    UnknownDefaultTabId,
 )
 from .n import FileId
 from .util_test import (
@@ -4565,3 +4566,40 @@ Heading of the page
     ) as result:
         page = result.pages[FileId("index.txt")]
         assert (page.ast.options.get("default_tabs")) == {"drivers": "python"}
+
+
+def test_default_tabs_not_present() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+===================
+Heading of the page
+===================
+
+.. tabs-selector:: drivers
+   :default-tabid: no-language
+
+.. tabs-drivers::
+
+   .. tab::
+      :tabid: c
+
+      C
+
+   .. tab::
+      :tabid: nodejs
+
+      Node.js
+
+   .. tab::
+      :tabid: python
+
+      Python
+""",
+        }
+    ) as result:
+        diagnostics = result.diagnostics[FileId("index.txt")]
+        assert len(diagnostics) == 1
+        assert isinstance(diagnostics[0], UnknownDefaultTabId)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4529,3 +4529,39 @@ with another reference to the </text>
 </root>
 """,
         )
+
+
+def test_default_tabs() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+===================
+Heading of the page
+===================
+
+.. tabs-selector:: drivers
+   :default-tabid: python
+
+.. tabs-drivers::
+
+   .. tab::
+      :tabid: c
+
+      C
+
+   .. tab::
+      :tabid: nodejs
+
+      Node.js
+
+   .. tab::
+      :tabid: python
+
+      Python
+""",
+        }
+    ) as result:
+        page = result.pages[FileId("index.txt")]
+        assert (page.ast.options.get("default_tabs")) == {"drivers": "python"}


### PR DESCRIPTION
### Ticket

DOP-4945

### Notes

New optional option `:default-tabid:` for `tabs-selector` and `tabs-pillstrip` directives for use with drivers tabs.

Staging links available on sister PR in snooty [here](https://github.com/mongodb/snooty/pull/1301).

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
