### PR TITLE
DOP-5130: Collapsible `:expanded:` option as boolean

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -795,12 +795,12 @@ example = """.. facet::
 help = """Card in a card-group. Each card links to the specified URI, and can include an icon, as well as a call-to-action string"""
 options.heading = {type = "string", required = true}
 options.sub_heading = "string"
-options.expanded = "flag"
+options.expanded = "boolean"
 content_type = "block"
 example = """.. collapsible::
-   :heading: ${1:Procdure}
+   :heading: ${1:Procedure}
    :sub_heading: ${2:Description of what is inside the collapsible section}
-   :expanded:
+   :expanded: ${3:Boolean - default true}
 
    ${3:collapsible content block.}
 """

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -802,7 +802,7 @@ example = """.. collapsible::
    :sub_heading: ${2:Description of what is inside the collapsible section}
    :expanded: ${3:Boolean - default true}
 
-   ${3:collapsible content block.}
+   ${0:collapsible content block.}
 """
 
 [directive."mongodb:wayfinding"]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -3921,7 +3921,7 @@ This is the main heading
     )
 
 
-def test_collapsible_options() -> None:
+def test_collapsible_options_true() -> None:
     """Test collapsible directive"""
     path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")
@@ -3933,7 +3933,7 @@ def test_collapsible_options() -> None:
         """
 .. collapsible::
    :heading: This is a heading
-   :expanded:
+   :expanded: true
 
    This is default-expanded collapsible content
 """,


### PR DESCRIPTION
### Ticket

DOP-5130

### Notes

Collapsible expanded option is now a boolean rather than a flag.

Snooty PR [here](https://github.com/mongodb/snooty/pull/1306).

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
