### PR TITLE
DOP-5135: Remove nested directive error for method-selector

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2042,7 +2042,6 @@ class MethodSelectorHandler(Handler):
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
-        self.method_selector_name = "method-selector"
         self.method_option_name = "method-option"
         self.method_description_name = "method-description"
         self.within_description = False
@@ -2072,7 +2071,7 @@ class MethodSelectorHandler(Handler):
             return
 
         option_id = node.options.get("id", "")
-        if node.name == self.method_selector_name:
+        if node.name == "method-selector":
             if self.page_has_method_selector:
                 self.context.diagnostics[fileid_stack.current].append(
                     DuplicateDirective(node.name, node.span[0])

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2037,23 +2037,26 @@ class WayfindingHandler(NestedDirectiveHandler):
         super().__init__(context, "wayfinding", {"include", "sharedinclude"})
 
 
-class MethodSelectorHandler(NestedDirectiveHandler):
+class MethodSelectorHandler(Handler):
     """Handles page-level validations for method-selector directive and its children."""
 
     def __init__(self, context: Context) -> None:
-        super().__init__(context, "method-selector", {"include", "sharedinclude"})
+        super().__init__(context)
+        self.method_selector_name = "method-selector"
         self.method_option_name = "method-option"
         self.method_description_name = "method-description"
         self.within_description = False
         self.current_method_option: Optional[str] = None
         self.pending_diagnostics: List[Diagnostic] = []
+        self.page_has_method_selector = False
 
     def __add_pending_diagnostics(self, fileid: FileId) -> None:
         self.context.diagnostics[fileid].extend(self.pending_diagnostics)
 
-    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        super().enter_node(fileid_stack, node)
+    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
+        self.page_has_method_selector = False
 
+    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive):
             return
 
@@ -2069,14 +2072,19 @@ class MethodSelectorHandler(NestedDirectiveHandler):
             return
 
         option_id = node.options.get("id", "")
-        if node.name == self.method_option_name and option_id:
+        if node.name == self.method_selector_name:
+            if self.page_has_method_selector:
+                self.context.diagnostics[fileid_stack.current].append(
+                    DuplicateDirective(node.name, node.span[0])
+                )
+                return
+            self.page_has_method_selector = True
+        elif node.name == self.method_option_name and option_id:
             self.current_method_option = option_id
         elif node.name == self.method_description_name:
             self.within_description = True
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        super().exit_node(fileid_stack, node)
-
         if not (isinstance(node, n.Directive)):
             return
 
@@ -2086,7 +2094,7 @@ class MethodSelectorHandler(NestedDirectiveHandler):
             self.within_description = False
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        if self.directive_detected:
+        if self.page_has_method_selector:
             page.ast.options["has_method_selector"] = True
             self.__add_pending_diagnostics(fileid_stack.current)
         self.pending_diagnostics = []

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3943,19 +3943,6 @@ Landing page
          Collapsible 2 content.
 """,
             Path(
-                "source/nested_method_selector.txt"
-            ): """
-:orphan:
-
-======================
-Nested Method Selector
-======================
-
-.. note::
-
-   .. include:: /includes/included_method_selector.rst
-""",
-            Path(
                 "source/valid_method_selector.txt"
             ): """
 :orphan:
@@ -4012,19 +3999,12 @@ Testing Tabs Selector
         ]
         assert result.pages[FileId("index.txt")].ast.options.get("has_method_selector")
         assert [
-            type(x)
-            for x in result.diagnostics[FileId("includes/included_method_selector.rst")]
-        ] == [NestedDirective]
-        assert [
             type(x) for x in result.diagnostics[FileId("testing_tabs_selector.txt")]
         ] == [UnexpectedDirectiveOrder]
         assert len(result.diagnostics[FileId("valid_method_selector.txt")]) == 0
 
         target_option_field = "has_method_selector"
         assert result.pages[FileId("index.txt")].ast.options.get(
-            target_option_field, False
-        )
-        assert not result.pages[FileId("nested_method_selector.txt")].ast.options.get(
             target_option_field, False
         )
         assert result.pages[FileId("valid_method_selector.txt")].ast.options.get(


### PR DESCRIPTION
### Ticket

DOP-5135

### Notes

* Removes nested directive error for `method-selector`, as requested by the docs team. Approach was to detach the postprocess handler for `method-selector` from its superclass that handled checking for both nested directives and duplicate directives.
* Removes tests related to instances of `method-selector` nested in other directives.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
