### PR TITLE
DOP-5240: Ensure default tabids don't persist across pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.18.8] - 2024-11-22
 
 ### Added
+
 - "mongoid-api" role (#633)
 
 ### Changed
+
 - "ruby" role link (#633)
 - Improved onboarding docs (#634)
 - Proxy requests to raw GH content (#635)

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -650,6 +650,7 @@ class TabsSelectorHandler(Handler):
 
     def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.selectors = {}
+        self.default_tabs = {}
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         self.scanned_pattern = []

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4542,10 +4542,40 @@ Heading of the page
 
       Python
 """,
-        }
+            Path(
+                    "source/no-default.txt"
+                ): """
+=================
+No Default Tab ID
+=================
+
+.. tabs-selector:: drivers
+
+.. tabs-drivers::
+
+   .. tab::
+      :tabid: c
+
+      C
+
+   .. tab::
+      :tabid: nodejs
+
+      Node.js
+
+   .. tab::
+      :tabid: python
+
+      Python
+""",
+        },
     ) as result:
         page = result.pages[FileId("index.txt")]
         assert (page.ast.options.get("default_tabs")) == {"drivers": "python"}
+
+        # Ensure previously set default tabs are reset on the next page
+        no_default_page = result.pages[FileId("no-default.txt")]
+        assert (no_default_page.ast.options.get("default_tabs")) == None
 
 
 def test_default_tabs_not_present() -> None:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4543,8 +4543,8 @@ Heading of the page
       Python
 """,
             Path(
-                    "source/no-default.txt"
-                ): """
+                "source/no-default.txt"
+            ): """
 =================
 No Default Tab ID
 =================


### PR DESCRIPTION
### Ticket

DOP-5240

### Notes

* Default tabid was not being reset whenever a new page was entered. The persisted data from a previous page would then affect the validations and default tabid for a subsequent page, even if it did not have a default tabid set.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
