### PR TITLE
DOP-5250: Consider .ast files as .txt page

### DIFF
--- a/snooty/main.py
+++ b/snooty/main.py
@@ -184,7 +184,7 @@ class ZipBackend(Backend):
         fully_qualified_pageid: str,
         document: Dict[str, Any],
     ) -> None:
-        if page_id.suffix not in [EXT_FOR_PAGE, ".ast"]:
+        if page_id.suffix != EXT_FOR_PAGE:
             return
         super().handle_document(
             build_identifiers, page_id, fully_qualified_pageid, document

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -63,6 +63,9 @@ class Page:
     def fake_full_fileid(self) -> FileId:
         """Return a fictitious path (hopefully) uniquely identifying this output artifact."""
         if self.category:
+            if self.category == "ast":
+                return FileId(self.output_filename)
+
             # Giza wrote out yaml file artifacts under a directory. e.g. steps-foo.yaml becomes
             # steps/foo.rst
             return self.fileid.parent.joinpath(

--- a/snooty/page.py
+++ b/snooty/page.py
@@ -63,9 +63,6 @@ class Page:
     def fake_full_fileid(self) -> FileId:
         """Return a fictitious path (hopefully) uniquely identifying this output artifact."""
         if self.category:
-            if self.category == "ast":
-                return FileId(self.output_filename)
-
             # Giza wrote out yaml file artifacts under a directory. e.g. steps-foo.yaml becomes
             # steps/foo.rst
             return self.fileid.parent.joinpath(

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1878,11 +1878,10 @@ class _Project:
                     )
                     new_page = Page.create(
                         FileId(fileid.as_posix().replace(".ast", ".txt")),
-                        fileid.as_posix().replace(".ast", ".txt"),
+                        None,
                         "",
                         ast_root,
                     )
-                    new_page.category = "ast"
                     self._page_updated(new_page, diagnostics)
                 except Exception as e:
                     logger.error(e)

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1877,11 +1877,12 @@ class _Project:
                         else None
                     )
                     new_page = Page.create(
-                        fileid,
+                        FileId(fileid.as_posix().replace(".ast", ".txt")),
                         fileid.as_posix().replace(".ast", ".txt"),
                         "",
                         ast_root,
                     )
+                    new_page.category = "ast"
                     self._page_updated(new_page, diagnostics)
                 except Exception as e:
                     logger.error(e)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4548,7 +4548,8 @@ def test_parse_ast() -> None:
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "options": \{\}
                 }
             ]
         }

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4549,12 +4549,13 @@ def test_parse_ast() -> None:
                             ]
                         }
                     ],
-                    "options": \{\}
+                    "options": {}
                 }
             ]
         }
     ],
-    "fileid": "test.ast"
+    "fileid": "test.txt",
+    "options": {}
 }
 """,
             Path(
@@ -4579,12 +4580,13 @@ def test_parse_ast() -> None:
             ]
         }
     ],
-    "fileid": "bad-types.ast"
+    "fileid": "bad-types.txt",
+    "options": {}
 }
 """,
         }
     ) as result:
-        diagnostics = result.diagnostics[FileId("test.ast")]
+        diagnostics = result.diagnostics[FileId("test.txt")]
         assert not diagnostics
-        bad_types_diagnostics = result.diagnostics[FileId("bad-types.ast")]
+        bad_types_diagnostics = result.diagnostics[FileId("bad-types.txt")]
         assert [type(d) for d in bad_types_diagnostics] == [UnexpectedNodeType]

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -491,7 +491,6 @@ class NodeDeserializer:
         n.Target,
         n.TargetIdentifier,
         n.Text,
-        n.TocTreeDirective,
         n.Transition,
     ]
     node_classes: Dict[str, Type[n.Node]] = {
@@ -512,7 +511,8 @@ class NodeDeserializer:
             if field.name == "span":
                 continue
 
-            node_value = node.get(field.name)
+            placeholder_span = (0,)
+            node_value = node.get(field.name)        
             has_nested_children = field.name == "children" and issubclass(
                 node_type, n.Parent
             )
@@ -530,6 +530,9 @@ class NodeDeserializer:
 
                     child_type: str = child.get("type", "")
                     child_node_type = cls.node_classes.get(child_type)
+                    if (child_node_type == n.Directive and node.get("name") == "toctree"):
+                        child_node_type = n.TocTreeDirective
+
                     if child_node_type:
                         deserialized_children.append(
                             cls.deserialize(child, child_node_type, diagnostics)
@@ -539,12 +542,20 @@ class NodeDeserializer:
                         continue
 
                 filtered_fields[field.name] = deserialized_children
+            elif field.type == FileId and isinstance(node_value, str):
+                filtered_fields[field.name] = field.type(node_value)
             else:
                 # Ideally, we validate that the data types of the fields match the data types of the JSON node,
                 # but that requires a more verbose and time-consuming process. For now, we assume data types are correct.
                 filtered_fields[field.name] = node_value
 
-        return node_type((0,), **filtered_fields)
+        deserialized_node = node_type(placeholder_span, **filtered_fields)
+
+        # Finalize any needed node types and their fields
+        if isinstance(deserialized_node, n.Heading) and not deserialized_node.id:
+            deserialized_node.id = make_html5_id(deserialized_node.get_text().lower())
+
+        return deserialized_node
 
 
 def bundle(

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -531,7 +531,10 @@ class NodeDeserializer:
                     child_type: str = child.get("type", "")
                     child_node_type = cls.node_classes.get(child_type)
                     if child_node_type:
-                        if child_node_type == n.Directive and node.get("name") == "toctree":
+                        if (
+                            child_node_type == n.Directive
+                            and node.get("name") == "toctree"
+                        ):
                             child_node_type = n.TocTreeDirective
 
                         deserialized_children.append(

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -530,10 +530,10 @@ class NodeDeserializer:
 
                     child_type: str = child.get("type", "")
                     child_node_type = cls.node_classes.get(child_type)
-                    if child_node_type == n.Directive and node.get("name") == "toctree":
-                        child_node_type = n.TocTreeDirective
-
                     if child_node_type:
+                        if child_node_type == n.Directive and node.get("name") == "toctree":
+                            child_node_type = n.TocTreeDirective
+
                         deserialized_children.append(
                             cls.deserialize(child, child_node_type, diagnostics)
                         )

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -512,7 +512,7 @@ class NodeDeserializer:
                 continue
 
             placeholder_span = (0,)
-            node_value = node.get(field.name)        
+            node_value = node.get(field.name)
             has_nested_children = field.name == "children" and issubclass(
                 node_type, n.Parent
             )
@@ -530,7 +530,7 @@ class NodeDeserializer:
 
                     child_type: str = child.get("type", "")
                     child_node_type = cls.node_classes.get(child_type)
-                    if (child_node_type == n.Directive and node.get("name") == "toctree"):
+                    if child_node_type == n.Directive and node.get("name") == "toctree":
                         child_node_type = n.TocTreeDirective
 
                     if child_node_type:


### PR DESCRIPTION
### Ticket

DOP-5250

### Notes

* I originally thought that [this line](https://github.com/mongodb/snooty-parser/blob/2c537a2cdee274f957b11c6ed5e0cdf35b10750e/snooty/parser.py#L1881) was enough to treat pages created from `.ast` files to be the same as `.txt` files, but turns out that was wrong. This PR ensures that `.ast` files have a `.txt` fileid to match the parser's, frontend's, persistence module's, etc.'s, assumptions of a page AST having a `.txt` fileid. 
  * The potential con of this approach is that diagnostics for `.ast` files will now include a fileid with a `txt` extension, which might be confusing for anyone who sees `ast`-related issues and are not familiar with the conversion.
* This PR also fixes uncaught bugs that were happening because `.ast` files weren't properly going through the postprocessor. Notably:
  * Missing ids from `n.Heading`
  * `n.ToctreeDirective` always being chosen as the node type for serialized `directive` node objects

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
