### PR TITLE
DOCSP-45974 updated atlas cli link

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1618,7 +1618,7 @@ type = {link = "https://www.mongodb.com/docs/atlas/reference/api-resources-spec/
 
 [role."atlascli"]
 help = """Link to a page in the Atlas CLI documentation."""
-type = {link = "https://www.mongodb.com/docs/atlas/cli/stable%s", ensure_trailing_slash = true}
+type = {link = "https://www.mongodb.com/docs/atlas/cli/current%s", ensure_trailing_slash = true}
 
 [role."mongodb-analyzer"]
 help = """Link to the MongoDB Analyzer documentation."""


### PR DESCRIPTION
### Ticket

[DOCSP-45974](https://jira.mongodb.org/browse/DOCSP-45974)

### Notes

As part of the docs SEO technical fixes, we'd like to update the Atlas CLI link from `/stable` to `/current`.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
