### PR TITLE
DOP-5303: Handle ast file facets in postprocessor

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -193,7 +193,7 @@ def propagate_facets(pages: Dict[FileId, Page], context: Context) -> None:
                 file_path = Path(os.path.join(base, file))
                 fileid = config.get_fileid(file_path)
 
-                if (ext == ".ast"):
+                if ext == ".ast":
                     # .ast files have their .txt fileids spoofed
                     fileid = FileId(fileid.as_posix().replace(".ast", ".txt"))
 

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -187,11 +187,15 @@ def propagate_facets(pages: Dict[FileId, Page], context: Context) -> None:
         if parent_facets:
             for file in files:
                 ext = os.path.splitext(file)[1]
-                if ext not in util.RST_EXTENSIONS:
+                if ext not in util.RST_EXTENSIONS and ext != ".ast":
                     continue
 
                 file_path = Path(os.path.join(base, file))
                 fileid = config.get_fileid(file_path)
+
+                if (ext == ".ast"):
+                    # .ast files have their .txt fileids spoofed
+                    fileid = FileId(fileid.as_posix().replace(".ast", ".txt"))
 
                 page = pages[fileid]
                 page.facets = parent_facets


### PR DESCRIPTION
### Ticket

DOP-5303

### Notes

* There was an additional change that needed to be done to allow facets to be propagated properly to ast files.

**To test:**

1. Go to this [staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/master/java/raymund.rodriguez/DOP-5303/api-documentation/java-sync/com/mongodb/client/package-summary/index.html)
2. Open up dev tools and go to the network tab.
3. Look for `page-data.json` for the current staged page. Navigate to `result.data.page.facets` and the repo-wide facets should now be there, along with the new "reference" genre facet.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
