### PR TITLE
DOP-5110: Convert nested list-tables into nested rows

### DIFF
--- a/snooty/n.py
+++ b/snooty/n.py
@@ -324,13 +324,28 @@ class DefinitionList(Parent[DefinitionListItem]):
 
 
 @dataclass
+class Directive(Parent[Node]):
+    __slots__ = ("domain", "name", "argument", "options")
+    type = "directive"
+    domain: str
+    name: str
+    argument: MutableSequence["Text"]
+    options: Dict[str, str]
+
+    def verify(self) -> None:
+        super().verify()
+        for arg in self.argument:
+            arg.verify()
+
+
+@dataclass
 class ListNodeItem(Parent[Node]):
     __slots__ = ()
     type = "listItem"
 
 
 @dataclass
-class ListNode(Parent[ListNodeItem]):
+class ListNode(Parent[Union[ListNodeItem, Directive]]):
     __slots__ = ("enumtype", "startat")
     type = "list"
     enumtype: ListEnumType
@@ -347,21 +362,6 @@ class Line(Parent[InlineNode]):
 class LineBlock(Parent[Line]):
     __slots__ = ()
     type = "line_block"
-
-
-@dataclass
-class Directive(Parent[Node]):
-    __slots__ = ("domain", "name", "argument", "options")
-    type = "directive"
-    domain: str
-    name: str
-    argument: MutableSequence["Text"]
-    options: Dict[str, str]
-
-    def verify(self) -> None:
-        super().verify()
-        for arg in self.argument:
-            arg.verify()
 
 
 class TocTreeDirectiveEntry(NamedTuple):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2149,6 +2149,12 @@ class ListTableHandler(Handler):
 
     def __identify_expandable_content(self, node: n.Directive) -> None:
         # List tables have nested list nodes and list items, so we attempt to destructure them
+       # .. table::
+       #    .. list:: <row list>
+       #       .. list-item:: <row>
+       #          .. list:: <cell list>
+       #             .. list-item:: <cell>
+
         list_node = node.children[0]
         assert isinstance(list_node, n.ListNode)
         rows = list_node.children

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2202,10 +2202,6 @@ class ListTableHandler(Handler):
             return
         self.__identify_expandable_content(node)
 
-    def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
-        if isinstance(node, n.Directive) and node.name == "list-table":
-            self.is_in_list_table = False
-
 
 class PostprocessorResult(NamedTuple):
     pages: Dict[FileId, Page]

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2148,8 +2148,6 @@ class ListTableHandler(Handler):
         super().__init__(context)
 
     def __identify_expandable_content(self, node: n.Directive) -> None:
-        print("HMMM before")
-        print(node.serialize())
         # List tables have nested list nodes and list items, so we attempt to destructure them
         list_node = node.children[0]
         assert isinstance(list_node, n.ListNode)
@@ -2161,11 +2159,11 @@ class ListTableHandler(Handler):
             list_node = row.children[0]
             assert isinstance(list_node, n.ListNode)
             cells = list_node.children
-            nested_row_cells = []
+            nested_row_cells: MutableSequence[n.Node] = []
             found_nested_list_table = False
 
             for cell in cells:
-                nested_row_cell_content = []
+                nested_row_cell_content: MutableSequence[n.Node] = []
                 nested_list_table_index = next(
                     (
                         i

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2197,12 +2197,6 @@ class ListTableHandler(Handler):
                 )
                 cells.append(nested_row)
 
-        print("HMMM after")
-        print(node.serialize())
-
-    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        pass
-
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "list-table":
             return
@@ -2212,9 +2206,6 @@ class ListTableHandler(Handler):
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if isinstance(node, n.Directive) and node.name == "list-table":
             self.is_in_list_table = False
-
-    def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
-        pass
 
 
 class PostprocessorResult(NamedTuple):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2200,8 +2200,7 @@ class ListTableHandler(Handler):
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "list-table":
             return
-        if fileid_stack.current == FileId("test-tables.txt"):
-            self.__identify_expandable_content(node)
+        self.__identify_expandable_content(node)
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if isinstance(node, n.Directive) and node.name == "list-table":

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2152,30 +2152,40 @@ class ListTableHandler(Handler):
         print(node.serialize())
         # List tables have nested list nodes and list items, so we attempt to destructure them
         list_node = node.children[0]
-        assert(isinstance(list_node, n.ListNode))
+        assert isinstance(list_node, n.ListNode)
         rows = list_node.children
 
         # Need to determine if any cell in a row has a nested table. If that's the case, any list-table, and any sibling
         # after it, will be in a nested row directive
         for row in rows:
             list_node = row.children[0]
-            assert(isinstance(list_node, n.ListNode))
+            assert isinstance(list_node, n.ListNode)
             cells = list_node.children
             nested_row_cells = []
             found_nested_list_table = False
 
             for cell in cells:
                 nested_row_cell_content = []
-                nested_list_table_index = next((i for i, cell_content_node in enumerate(cell.children) if isinstance(cell_content_node, n.Directive) and cell_content_node.name == "list-table"), -1)
-                if (cell.children and nested_list_table_index > -1):
+                nested_list_table_index = next(
+                    (
+                        i
+                        for i, cell_content_node in enumerate(cell.children)
+                        if isinstance(cell_content_node, n.Directive)
+                        and cell_content_node.name == "list-table"
+                    ),
+                    -1,
+                )
+                if cell.children and nested_list_table_index > -1:
                     nested_row_cell_content = cell.children[nested_list_table_index:]
                     cell.children = cell.children[:nested_list_table_index]
                     found_nested_list_table = True
-                
-                nested_row_cell = n.Directive((0,), nested_row_cell_content, "mongodb", "cell", [], {})
+
+                nested_row_cell = n.Directive(
+                    (0,), nested_row_cell_content, "mongodb", "cell", [], {}
+                )
                 nested_row_cells.append(nested_row_cell)
 
-            if (found_nested_list_table):
+            if found_nested_list_table:
                 # We append a nested row to the end of the cells to simulate the rST structure:
                 # .. table::
                 #    .. row::
@@ -2184,7 +2194,9 @@ class ListTableHandler(Handler):
                 #       .. row:: (nested)
                 #          ...
                 #    .. row::
-                nested_row = n.Directive((0,), nested_row_cells, "mongodb", "row", [], {})
+                nested_row = n.Directive(
+                    (0,), nested_row_cells, "mongodb", "row", [], {}
+                )
                 cells.append(nested_row)
 
         print("HMMM after")
@@ -2196,7 +2208,7 @@ class ListTableHandler(Handler):
     def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if not isinstance(node, n.Directive) or node.name != "list-table":
             return
-        if (fileid_stack.current == FileId("test-tables.txt")):
+        if fileid_stack.current == FileId("test-tables.txt"):
             self.__identify_expandable_content(node)
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2149,11 +2149,11 @@ class ListTableHandler(Handler):
 
     def __identify_expandable_content(self, node: n.Directive) -> None:
         # List tables have nested list nodes and list items, so we attempt to destructure them
-       # .. table::
-       #    .. list:: <row list>
-       #       .. list-item:: <row>
-       #          .. list:: <cell list>
-       #             .. list-item:: <cell>
+        # .. table::
+        #    .. list:: <row list>
+        #       .. list-item:: <row>
+        #          .. list:: <cell list>
+        #             .. list-item:: <cell>
 
         list_node = node.children[0]
         assert isinstance(list_node, n.ListNode)

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4613,3 +4613,279 @@ Heading of the page
         diagnostics = result.diagnostics[FileId("index.txt")]
         assert len(diagnostics) == 1
         assert isinstance(diagnostics[0], UnknownDefaultTabId)
+
+
+def test_list_table_nesting() -> None:
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+============
+Nested table
+============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Service
+     - Result
+
+   * - PagerDuty
+     - A returned PagerDuty integration configuration object will
+       contain the following fields:
+          
+       .. list-table::
+          :widths: 30 70
+          :header-rows: 1
+             
+          * - Property
+            - Description 
+
+          * - ``type``
+            - ``PAGER_DUTY``
+             
+          * - ``serviceKey``
+            - Your Service Key.
+          
+       Content after list-table.
+
+   * - Slack
+     - A returned Slack integration configuration object will
+       contain no nested list-tables.
+    
+   * - Datadog
+     - A returned Datadog integration configuration object will
+       contain the following fields:
+          
+       .. list-table::
+          :widths: 30 70
+          :header-rows: 1
+        
+          * - Property
+            - Description 
+
+          * - ``type``
+            - ``DATADOG``
+        
+          * - ``apiKey``
+            - Your API Key.
+        
+          * - ``region``
+            - Indicates the API URL to use.
+"""
+        }
+    ) as result:
+        test_fileid = FileId("index.txt")
+        page = result.pages[test_fileid]
+        diagnostics = result.diagnostics[test_fileid]
+        assert len(diagnostics) == 0
+        # Ensure there are nested row directives
+        check_ast_testing_string(
+            page.ast,
+            """
+<root fileid="index.txt">
+	<section>
+		<heading id="nested-table">
+			<text>Nested table</text>
+		</heading>
+		<directive name="list-table" header-rows="1">
+			<list enumtype="unordered">
+				<listItem>
+					<list enumtype="unordered">
+						<listItem>
+							<paragraph>
+								<text>Service</text>
+							</paragraph>
+						</listItem>
+						<listItem>
+							<paragraph>
+								<text>Result</text>
+							</paragraph>
+						</listItem>
+					</list>
+				</listItem>
+				<listItem>
+					<list enumtype="unordered">
+						<listItem>
+							<paragraph>
+								<text>PagerDuty</text>
+							</paragraph>
+						</listItem>
+						<listItem>
+							<paragraph>
+								<text>A returned PagerDuty integration configuration object will
+contain the following fields:</text>
+							</paragraph>
+						</listItem>
+						<directive domain="mongodb" name="row">
+							<directive domain="mongodb" name="cell"></directive>
+							<directive domain="mongodb" name="cell">
+								<directive name="list-table" widths="30 70" header-rows="1">
+									<list enumtype="unordered">
+										<listItem>
+											<list enumtype="unordered">
+												<listItem>
+													<paragraph>
+														<text>Property</text>
+													</paragraph>
+												</listItem>
+												<listItem>
+													<paragraph>
+														<text>Description</text>
+													</paragraph>
+												</listItem>
+											</list>
+										</listItem>
+										<listItem>
+											<list enumtype="unordered">
+												<listItem>
+													<paragraph>
+														<literal>
+															<text>type</text>
+														</literal>
+													</paragraph>
+												</listItem>
+												<listItem>
+													<paragraph>
+														<literal>
+															<text>PAGER_DUTY</text>
+														</literal>
+													</paragraph>
+												</listItem>
+											</list>
+										</listItem>
+										<listItem>
+											<list enumtype="unordered">
+												<listItem>
+													<paragraph>
+														<literal>
+															<text>serviceKey</text>
+														</literal>
+													</paragraph>
+												</listItem>
+												<listItem>
+													<paragraph>
+														<text>Your Service Key.</text>
+													</paragraph>
+												</listItem>
+											</list>
+										</listItem>
+									</list>
+								</directive>
+								<paragraph>
+									<text>Content after list-table.</text>
+								</paragraph>
+							</directive>
+						</directive>
+					</list>
+				</listItem>
+				<listItem>
+					<list enumtype="unordered">
+						<listItem>
+							<paragraph>
+								<text>Slack</text>
+							</paragraph>
+						</listItem>
+						<listItem>
+							<paragraph>
+								<text>A returned Slack integration configuration object will
+contain no nested list-tables.</text>
+							</paragraph>
+						</listItem>
+					</list>
+				</listItem>
+				<listItem>
+					<list enumtype="unordered">
+						<listItem>
+							<paragraph>
+								<text>Datadog</text>
+							</paragraph>
+						</listItem>
+						<listItem>
+							<paragraph>
+								<text>A returned Datadog integration configuration object will
+contain the following fields:</text>
+							</paragraph>
+						</listItem>
+						<directive domain="mongodb" name="row">
+							<directive domain="mongodb" name="cell"></directive>
+							<directive domain="mongodb" name="cell">
+								<directive name="list-table" widths="30 70" header-rows="1">
+									<list enumtype="unordered">
+										<listItem>
+											<list enumtype="unordered">
+												<listItem>
+													<paragraph>
+														<text>Property</text>
+													</paragraph>
+												</listItem>
+												<listItem>
+													<paragraph>
+														<text>Description</text>
+													</paragraph>
+												</listItem>
+											</list>
+										</listItem>
+										<listItem>
+											<list enumtype="unordered">
+												<listItem>
+													<paragraph>
+														<literal>
+															<text>type</text>
+														</literal>
+													</paragraph>
+												</listItem>
+												<listItem>
+													<paragraph>
+														<literal>
+															<text>DATADOG</text>
+														</literal>
+													</paragraph>
+												</listItem>
+											</list>
+										</listItem>
+										<listItem>
+											<list enumtype="unordered">
+												<listItem>
+													<paragraph>
+														<literal>
+															<text>apiKey</text>
+														</literal>
+													</paragraph>
+												</listItem>
+												<listItem>
+													<paragraph>
+														<text>Your API Key.</text>
+													</paragraph>
+												</listItem>
+											</list>
+										</listItem>
+										<listItem>
+											<list enumtype="unordered">
+												<listItem>
+													<paragraph>
+														<literal>
+															<text>region</text>
+														</literal>
+													</paragraph>
+												</listItem>
+												<listItem>
+													<paragraph>
+														<text>Indicates the API URL to use.</text>
+													</paragraph>
+												</listItem>
+											</list>
+										</listItem>
+									</list>
+								</directive>
+							</directive>
+						</directive>
+					</list>
+				</listItem>
+			</list>
+		</directive>
+	</section>
+</root>
+""",
+        )


### PR DESCRIPTION
### Ticket

DOP-5110
[Related frontend PR](https://github.com/mongodb/snooty/pull/1342)

### Notes

* This approach assumes that the first nested `list-table` inside a cell of a `list-table` will be used as the cut-off for a sub/nested row's cell. The nested `list-table` and any subsequent sibling of the nested `list-table` will be included as part of the same sub row cell.
* If we plan on supporting subs rows and expandable content as part of future work, I went ahead and spoofed `row` and `cell` directives that we can potentially reuse and create formal declarations for in `rstspec.toml` whenever needed.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
