### PR TITLE
DOP-5329: Osiris TOC

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -69,7 +69,7 @@ from .diagnostics import (
 )
 from .eventparser import EventParser, FileIdStack
 from .flutter import check_type, checked
-from .n import FileId, SerializableType
+from .n import FileId, SerializableType, Directive
 from .page import Page
 from .target_database import TargetDatabase
 from .types import Facet, ProjectConfig
@@ -2452,6 +2452,7 @@ class Postprocessor:
         for fileid in context.pages:
             if fileid.suffix != EXT_FOR_PAGE:
                 continue
+
 
             if fileid not in visited_fileids:
                 if "orphan" not in context.pages[fileid].ast.options:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2454,7 +2454,9 @@ class Postprocessor:
                 continue
 
 
+        # TODO: This is being hit for osiris pages with toctrees
             if fileid not in visited_fileids:
+                print(fileid)
                 if "orphan" not in context.pages[fileid].ast.options:
                     context.diagnostics[fileid].append(OrphanedPage())
 
@@ -2706,7 +2708,7 @@ def clean_slug(slug: str) -> str:
     # TODO: remove file extensions in initial parse layer
     # https://jira.mongodb.org/browse/DOCSP-7595
     root, ext = os.path.splitext(slug)
-    if ext in SOURCE_FILE_EXTENSIONS:
+    if ext in SOURCE_FILE_EXTENSIONS or ext == ".ast":
         return root
 
     return slug

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -69,7 +69,7 @@ from .diagnostics import (
 )
 from .eventparser import EventParser, FileIdStack
 from .flutter import check_type, checked
-from .n import FileId, SerializableType, Directive
+from .n import FileId, SerializableType
 from .page import Page
 from .target_database import TargetDatabase
 from .types import Facet, ProjectConfig
@@ -2550,9 +2550,7 @@ class Postprocessor:
                     # Ensure Osiris-built TOC parent nodes are functional
                     if ast.options:
                         if ast.options.get("osiris_parent"):
-                            toctree_node_options = {
-                                "drawer": False
-                            }
+                            toctree_node_options = {"drawer": False}
 
                     # Check if the cleaned slug corresponds to an associated project name, indicating an external node
                     if slug in associated_project_names:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2453,10 +2453,7 @@ class Postprocessor:
             if fileid.suffix != EXT_FOR_PAGE:
                 continue
 
-
-        # TODO: This is being hit for osiris pages with toctrees
             if fileid not in visited_fileids:
-                print(fileid)
                 if "orphan" not in context.pages[fileid].ast.options:
                     context.diagnostics[fileid].append(OrphanedPage())
 
@@ -2545,6 +2542,13 @@ class Postprocessor:
                     toctree_node_options: Dict[str, Any] = {
                         "drawer": slug not in toc_landing_pages
                     }
+
+                    # Ensure Osiris-built TOC parent nodes are functional
+                    if ast.options:
+                        if ast.options.get("osiris_parent"):
+                            toctree_node_options = {
+                                "drawer": False
+                            }
 
                     # Check if the cleaned slug corresponds to an associated project name, indicating an external node
                     if slug in associated_project_names:

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -552,22 +552,21 @@ class NodeDeserializer:
             elif field.name == "entries":
                 deserialized_entries: List[n.TocTreeDirectiveEntry] = []
 
-                for entry in node_value:
-                    if not isinstance(entry, dict):
-                        continue
-                    
-                    title = entry.get("title")
-                    slug = entry.get("slug")
+                if isinstance(node_value, List):
+                    for entry in node_value:
+                        if not isinstance(entry, dict):
+                            continue
 
-                    if not title or not slug:
-                        continue
+                        title = entry.get("title")
+                        slug = entry.get("slug")
 
-                    entryNode = TocTreeDirectiveEntry(title, None, slug, None)
-                    deserialized_entries.append(
-                        entryNode
-                    )
-                
-                filtered_fields[field.name] = deserialized_entries
+                        if not title or not slug:
+                            continue
+
+                        entryNode = TocTreeDirectiveEntry(title, None, slug, None)
+                        deserialized_entries.append(entryNode)
+
+                    filtered_fields[field.name] = deserialized_entries
             else:
                 # Ideally, we validate that the data types of the fields match the data types of the JSON node,
                 # but that requires a more verbose and time-consuming process. For now, we assume data types are correct.

--- a/snooty/util.py
+++ b/snooty/util.py
@@ -566,7 +566,8 @@ class NodeDeserializer:
                     deserialized_entries.append(
                         entryNode
                     )
-                    filtered_fields[field.name] = deserialized_entries
+                
+                filtered_fields[field.name] = deserialized_entries
             else:
                 # Ideally, we validate that the data types of the fields match the data types of the JSON node,
                 # but that requires a more verbose and time-consuming process. For now, we assume data types are correct.


### PR DESCRIPTION
### Ticket

DOP-5329

### Notes

Adds ability to deserialize toctree nodes.

Uses new osiris property `osiris_parent` to delineate which toctree nodes should not be drawers.

Necessary for [this Osiris PR](https://github.com/10gen/osiris/pull/33).

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
