### PR TITLE
DOCSP-48367 Added relational-dbs for the tab directive

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1879,6 +1879,12 @@ platforms = [
   {id = "rhel", title = "RHEL/CentOS/SLES/AMZ"},
   {id = "linux", title = "Linux"},
 ]
+relational-dbs = [
+  {id = "mysql", title = "MySQL"},
+  {id = "oracle", title = "Oracle"},
+  {id = "postgres", title = "PostgreSQL"},
+  {id = "sql", title = "SQL Server"},
+]
 drivers = [
   {id = "atlas-api", title = "Atlas API"},
   {id = "atlas-cli", title = "Atlas CLI"},

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -374,6 +374,9 @@ inherit = "tabs"
 [directive.tabs-platforms]
 inherit = "tabs"
 
+[directive.tabs-relational-dbs]
+inherit = "tabs"
+
 [directive.tabs-drivers]
 inherit = "tabs"
 


### PR DESCRIPTION
### Ticket

https://jira.mongodb.org/browse/DOCSP-48367

### Notes

* Adds a set of "relational-db" tabs for use in Relational Migrator docs

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
