### PR TITLE
DOP-5477 Follow up - strict order on composable options, dedupe selections

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -952,7 +952,7 @@ class JSONVisitor:
         # validate the expected children and options
         valid_children: List[n.ComposableContent] = []
         default_values_found = False
-        for index, child in enumerate(node.children):
+        for child in node.children:
             try:
                 self.check_valid_child(node, child, {"selected-content"})
                 assert isinstance(child, n.ComposableContent)
@@ -1048,10 +1048,10 @@ class JSONVisitor:
                 spec_composable = spec_composables[idx]
             except IndexError:
                 self.diagnostics.append(
-                    UnknownOptionId(
-                        "composable-tutorial",
-                        selection_id,
-                        [],
+                    InvalidChildCount(
+                        "selected-content",
+                        "selections",
+                        str(len(spec_composables)),
                         node.start[0],
                     )
                 )

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -1044,7 +1044,18 @@ class JSONVisitor:
         # validate all selection ids
         for idx in range(len(selection_ids)):
             selection_id = selection_ids[idx]
-            spec_composable = spec_composables[idx]
+            try:
+                spec_composable = spec_composables[idx]
+            except IndexError:
+                self.diagnostics.append(
+                    UnknownOptionId(
+                        "composable-tutorial",
+                        selection_id,
+                        [],
+                        node.start[0],
+                    )
+                )
+                break
             allowed_selection_ids = list(map(lambda x: x.id, spec_composable.options))
             # check if dependencies are met - then None is not allowed
             met_dependencies: bool = all(

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4742,7 +4742,7 @@ def test_composable_tutorial_errors() -> None:
         UnknownOptionId,
         # invalid composable tutorial option cloud-providerr
         UnknownOptionId,
-        # invalid selection gcpp
+        # invalid selection gcppgcpppppp
         UnknownOptionId,
     ]
 

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4603,49 +4603,116 @@ def test_valid_composable_tutorial() -> None:
         path,
         """
 .. composable-tutorial::
-   :options: interface, language, cluster-topology, cloud-provider
-   :defaults: driver, nodejs, repl, gcp
+   :options: interface, language, deployment-type, cloud-provider
+   :defaults: driver, nodejs, atlas, gcp
 
    .. selected-content::
-      :selections: driver, nodejs, repl, gcp
+      :selections: driver, nodejs, atlas, gcp
 
       This content will only be shown when the selections are as follows:
       Interface - Drivers
-      Language - Node
-      Deployment Type - Replication
+      Language - NodeJS
+      Deployment Type - Atlas
       Cloud Provider - GCP
 
    .. selected-content::
-      :selections: atlas-ui, None, repl, aws
+      :selections: driver, c, atlas, gcp
 
       This content will only be shown when the selections are as follows:
-      Interface - Atlas UI
-      Deployment Type - Replication
+      Interface - Drivers
+      Language - C
+      Deployment Type - atlas
       Cloud Provider - GCP
+
+   .. selected-content::
+      :selections: driver, cpp, atlas, aws
+
+      This content will only be shown when the selections are as follows:
+      Interface - Drivers
+      Language - CPP
+      Deployment Type - atlas
+      Cloud Provider - AWS
+
+
+   .. selected-content::
+      :selections: atlas-admin-api, None, atlas, gcp
+
+      This content will only be shown when the selections are as follows:
+      Interface - Atlas Admin API
+      Deployment Type - atlas
+      Cloud Provider - GCP
+
+
+   .. selected-content::
+      :selections: atlas-admin-api, None, atlas, aws
+
+      This content will only be shown when the selections are as follows:
+      Interface - Atlas Admin API
+      Deployment Type - Atlas
+      Cloud Provider - AWS
+
+
+
+   .. selected-content::
+      :selections: atlas-admin-api, None, self, aws
+
+      This content will only be shown when the selections are as follows:
+      Interface - Atlas Admin API
+      Deployment Type - self
+      Cloud Provider - AWS
 """,
     )
-
     assert not diagnostics
     check_ast_testing_string(
         page.ast,
         """
 <root fileid="test.rst">
    <directive domain="mongodb" name="composable-tutorial"
-    composable_options="[{'value': 'interface', 'text': 'Interface', 'default': 'driver', 'dependencies': [], 'selections': [{'value': 'driver', 'text': 'Driver'}, {'value': 'atlas-ui', 'text': 'Atlas UI'}]}, {'value': 'language', 'text': 'Language', 'default': 'nodejs', 'dependencies': [{'interface': 'driver'}], 'selections': [{'value': 'nodejs', 'text': 'Node.js'}]}, {'value': 'cluster-topology', 'text': 'Cluster Topology', 'default': 'repl', 'dependencies': [], 'selections': [{'value': 'repl', 'text': 'Replica Set'}, {'value': 'repl', 'text': 'Replica Set'}]}, {'value': 'cloud-provider', 'text': 'Cloud Provider', 'default': 'gcp', 'dependencies': [], 'selections': [{'value': 'gcp', 'text': 'GCP'}, {'value': 'aws', 'text': 'AWS'}]}]">
+      composable_options="[{'value': 'interface', 'text': 'Interface', 'default': 'driver', 'dependencies': [], 'selections': [{'value': 'driver', 'text': 'Driver'}, {'value': 'atlas-admin-api', 'text': 'Atlas Admin API'}]}, {'value': 'language', 'text': 'Language', 'default': 'nodejs', 'dependencies': [{'interface': 'driver'}], 'selections': [{'value': 'nodejs', 'text': 'Node.js'}, {'value': 'c', 'text': 'C'}, {'value': 'cpp', 'text': 'C++'}]}, {'value': 'deployment-type', 'text': 'Deployment Type', 'default': 'atlas', 'dependencies': [], 'selections': [{'value': 'atlas', 'text': 'Atlas (Cloud)'}, {'value': 'self', 'text': 'Self-Managed (On-premises)'}]}, {'value': 'cloud-provider', 'text': 'Cloud Provider', 'default': 'gcp', 'dependencies': [], 'selections': [{'value': 'gcp', 'text': 'GCP'}, {'value': 'aws', 'text': 'AWS'}]}]">
       <directive domain="mongodb" name="selected-content"
-         selections="{'interface': 'driver', 'language': 'nodejs', 'cluster-topology': 'repl', 'cloud-provider': 'gcp'}">
+         selections="{'interface': 'driver', 'language': 'nodejs', 'deployment-type': 'atlas', 'cloud-provider': 'gcp'}">
          <paragraph><text>This content will only be shown when the selections are as follows:
 Interface - Drivers
-Language - Node
-Deployment Type - Replication
+Language - NodeJS
+Deployment Type - Atlas
 Cloud Provider - GCP</text></paragraph>
       </directive>
       <directive domain="mongodb" name="selected-content"
-         selections="{'interface': 'atlas-ui', 'language': 'None', 'cluster-topology': 'repl', 'cloud-provider': 'aws'}">
+         selections="{'interface': 'driver', 'language': 'c', 'deployment-type': 'atlas', 'cloud-provider': 'gcp'}">
          <paragraph><text>This content will only be shown when the selections are as follows:
-Interface - Atlas UI
-Deployment Type - Replication
+Interface - Drivers
+Language - C
+Deployment Type - atlas
 Cloud Provider - GCP</text></paragraph>
+      </directive>
+      <directive domain="mongodb" name="selected-content"
+         selections="{'interface': 'driver', 'language': 'cpp', 'deployment-type': 'atlas', 'cloud-provider': 'aws'}">
+         <paragraph><text>This content will only be shown when the selections are as follows:
+Interface - Drivers
+Language - CPP
+Deployment Type - atlas
+Cloud Provider - AWS</text></paragraph>
+      </directive>
+      <directive domain="mongodb" name="selected-content"
+         selections="{'interface': 'atlas-admin-api', 'language': 'None', 'deployment-type': 'atlas', 'cloud-provider': 'gcp'}">
+         <paragraph><text>This content will only be shown when the selections are as follows:
+Interface - Atlas Admin API
+Deployment Type - atlas
+Cloud Provider - GCP</text></paragraph>
+      </directive>
+      <directive domain="mongodb" name="selected-content"
+         selections="{'interface': 'atlas-admin-api', 'language': 'None', 'deployment-type': 'atlas', 'cloud-provider': 'aws'}">
+         <paragraph><text>This content will only be shown when the selections are as follows:
+Interface - Atlas Admin API
+Deployment Type - Atlas
+Cloud Provider - AWS</text></paragraph>
+      </directive>
+      <directive domain="mongodb" name="selected-content"
+         selections="{'interface': 'atlas-admin-api', 'language': 'None', 'deployment-type': 'self', 'cloud-provider': 'aws'}">
+         <paragraph><text>This content will only be shown when the selections are as follows:
+Interface - Atlas Admin API
+Deployment Type - self
+Cloud Provider - AWS</text></paragraph>
       </directive>
    </directive>
 </root>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -15,6 +15,7 @@ from .diagnostics import (
     IncorrectLinkSyntax,
     IncorrectMonospaceSyntax,
     InvalidChild,
+    InvalidChildCount,
     InvalidDirectiveStructure,
     InvalidField,
     InvalidLiteralInclude,
@@ -4742,8 +4743,8 @@ def test_composable_tutorial_errors() -> None:
         UnknownOptionId,
         # invalid composable tutorial option cloud-providerr
         UnknownOptionId,
-        # invalid selection gcppgcpppppp
-        UnknownOptionId,
+        # invalid child count gcppgcpppppp
+        InvalidChildCount,
     ]
 
     _page, diagnostics = parse_rst(


### PR DESCRIPTION
### Ticket

DOP-5477

### Notes
This is a follow up to [the previous PR.](https://github.com/mongodb/snooty-parser/pull/652)
This change allows users to define composable options in any order (previously was getting the order defined from the rstspec)
Also dedupes choices in the selections.
Updated the unit tests to reflect these cases


### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
