### PR TITLE
Add category option to code-related directives

### DIFF
--- a/snooty/gizaparser/release.py
+++ b/snooty/gizaparser/release.py
@@ -36,6 +36,7 @@ class ReleaseSpecification(Inheritable):
                     False,
                     None,
                     None,
+                    None,
                 )
             )
         return children

--- a/snooty/gizaparser/steps.py
+++ b/snooty/gizaparser/steps.py
@@ -52,6 +52,7 @@ class Action(HeadingMixin):
                     False,
                     None,
                     None,
+                    None,
                 )
             )
 

--- a/snooty/n.py
+++ b/snooty/n.py
@@ -167,6 +167,7 @@ class Code(Node):
         "linenos",
         "lineno_start",
         "source",
+        "category",
     )
     type = "code"
     lang: Optional[str]
@@ -177,6 +178,7 @@ class Code(Node):
     linenos: bool
     lineno_start: Optional[int]
     source: Optional[str]
+    category: Optional[str]
 
 
 @dataclass

--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -292,6 +292,7 @@ class JSONVisitor:
                 node["linenos"],
                 node["lineno_start"] if "lineno_start" in node else None,
                 node["source"] if "source" in node else None,
+                node["category"] if "category" in node else None,
             )
             top_of_state = self.state[-1]
             assert isinstance(top_of_state, n.Parent)
@@ -1392,6 +1393,7 @@ class JSONVisitor:
                 options["lineno-start"] if "lineno-start" in options else None
             )
             source = options["source"] if "source" in options else None
+            category = options["category"] if "category" in options else None
 
             code = n.Code(
                 span,
@@ -1403,6 +1405,7 @@ class JSONVisitor:
                 linenos,
                 lineno_start,
                 source,
+                category,
             )
 
             doc.children.append(code)
@@ -1731,6 +1734,9 @@ def _validate_io_code_block_children(node: n.Directive) -> List[Diagnostic]:
                     )
                     grandchild.source = (
                         node.options["source"] if "source" in node.options else None
+                    )
+                    grandchild.category = (
+                        node.options["category"] if "category" in node.options else None
                     )
                     new_grandchildren.append(grandchild)
                 child.children = new_grandchildren

--- a/snooty/rstparser.py
+++ b/snooty/rstparser.py
@@ -717,6 +717,8 @@ class BaseCodeDirective(tinydocutils.directives.Directive):
         node["linenos"] = linenos
         if "source" in self.options:
             node["source"] = self.options["source"]
+        if "category" in self.options:
+            node["category"] = self.options["category"]
         node.document = self.state.document
         node.source, node.line = source, line
         return [node]
@@ -766,7 +768,8 @@ class BaseCodeIODirective(tinydocutils.directives.Directive):
             child_code["source"] = "test"
             if "source" in self.options:
                 child_code["source"] = self.options["source"]
-
+            if "category" in self.options:
+                child_code["category"] = self.options["category"]
             child_code.document = self.state.document
             child_code.source, node.line = source, line
             node.append(child_code)

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -205,6 +205,7 @@ options.language = "string"
 options.dedent = ["nonnegative_integer", "flag"]
 options.emphasize-lines = "linenos"
 options.lineno-start = "nonnegative_integer"
+options.category = "string"
 example = """..literalinclude:: ${1:/path/to/file.js}
    :start-after: ${2:text to start after (Optional}}
    :end-before: ${3:text to end before (Optional}}
@@ -213,7 +214,8 @@ example = """..literalinclude:: ${1:/path/to/file.js}
    :caption:
    :dedent:
    :emphasize-lines:
-   :lineno-start:}
+   :lineno-start:
+   :category:}
 """
 
 [directive.replacement]
@@ -453,12 +455,14 @@ options.emphasize-lines = "string"
 options.class = "string"
 options.linenos = "flag"
 options.source = "uri"
+options.category = "string"
 example = """.. code-block:: ${1:language}
    ${2::copyable: (bool)
    :caption: (string)
    :emphasize-lines: (string)
    :class: (string)
    :linenos: (flag)
+   :category: (string)
    :source: ${1: URL to source code}}
 
    ${0:code content}
@@ -473,6 +477,7 @@ example = """.. code:: ${1:language}
    :emphasize-lines: (string)
    :class: (string)
    :linenos: (flag)
+   :category: (string)
    :source: ${1: URL to source code}}
 
    ${0:code content}
@@ -496,6 +501,7 @@ example = """.. io-code-block::
       :language: ${1:language}
       :emphasize-lines: (string)
       :linenos: (flag)
+      :category: (string)
 
    .. output:: ${0:code output or </path/to/file>}
       :language: ${1:language}
@@ -515,6 +521,7 @@ options.dedent = ["nonnegative_integer", "flag"]
 options.lineno-start = "nonnegative_integer"
 options.emphasize-lines = "linenos"
 options.linenos = "flag"
+options.category = "string"
 example = """.. input:: ${0:code input or </path/to/file>}
       :language: ${1:language}
       :start-after: ${2:text to start after (Optional}}
@@ -523,6 +530,7 @@ example = """.. input:: ${0:code input or </path/to/file>}
       :lineno-start: ${5:nonnegative integer to start line numbering from}
       :emphasize-lines: (string)
       :linenos: (flag)
+      :category: (string)
 """
 
 [directive.output]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -731,6 +731,7 @@ hello world4</code></directive>
       :end-before: end example 2
       :dedent: 4
       :lineno-start: 2
+      :category: syntax
 
    .. output:: /test_parser/includes/sample_code.py
       :language: python
@@ -755,7 +756,7 @@ hello world4</code></directive>
         """
 <root fileid="test.rst">
     <directive name="io-code-block">
-        <directive name="input" language="python" linenos="True" start-after="start example 1" end-before="end example 2" dedent="4" lineno-start="2">
+        <directive name="input" language="python" linenos="True" start-after="start example 1" end-before="end example 2" dedent="4" lineno-start="2" category="syntax">
             <text>/test_parser/includes/sample_code.py</text>
             <code lang="python" linenos="True" lineno_start="2">print("test dedent")
 # end example 1
@@ -945,6 +946,40 @@ def test_codeblock() -> None:
     assert len(diagnostics) == 1
     assert isinstance(diagnostics[0], DocUtilsParseError)
 
+    # Test category option
+    page, diagnostics = parse_rst(
+        parser,
+        tabs_path,
+        """
+.. code-block:: java
+   :copyable: false
+   :category: syntax
+
+   foo""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst">
+        <code lang="java" category="syntax">foo</code>
+        </root>""",
+    )
+
+    # Test empty category
+    page, diagnostics = parse_rst(
+        parser,
+        tabs_path,
+        """
+.. code-block:: java
+   :copyable: false
+   :category:
+
+   foo""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    assert isinstance(diagnostics[0], DocUtilsParseError)
 
 def test_literalinclude() -> None:
     path = FileId("test.rst")
@@ -1015,6 +1050,7 @@ for (i = 0; i &lt; 10; i++) {
    :copyable: false
    :emphasize-lines: 1,2-4
    :lineno-start: 17
+   :category: syntax
 """,
     )
     page.finish(diagnostics)
@@ -1024,7 +1060,7 @@ for (i = 0; i &lt; 10; i++) {
         """<root fileid="test.rst">
         <directive name="literalinclude" caption="Sample Code" copyable="False" dedent="4" linenos="True" end-before="end example 1" language="python" start-after="start example 1" emphasize-lines="1,2-4" lineno-start="17">
         <text>/test_parser/includes/sample_code.py</text>
-        <code emphasize_lines="[(1, 1), (2, 4)]" lang="python" caption="Sample Code" linenos="True" lineno_start="17">print("test dedent")</code>
+        <code emphasize_lines="[(1, 1), (2, 4)]" lang="python" caption="Sample Code" linenos="True" lineno_start="17" category="syntax">print("test dedent")</code>
         </directive>
         </root>""",
     )
@@ -1215,6 +1251,19 @@ for (i = 0; i &lt; 10; i++) {
         """
 .. literalinclude:: /test_parser/includes/sample_code.py
    :caption:
+""",
+    )
+    page.finish(diagnostics)
+    assert len(diagnostics) == 1
+    assert isinstance(diagnostics[0], DocUtilsParseError)
+
+    # Test empty category
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. literalinclude:: /test_parser/includes/sample_code.py
+   :category:
 """,
     )
     page.finish(diagnostics)

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1059,7 +1059,7 @@ for (i = 0; i &lt; 10; i++) {
     check_ast_testing_string(
         page.ast,
         """<root fileid="test.rst">
-        <directive name="literalinclude" caption="Sample Code" copyable="False" dedent="4" linenos="True" end-before="end example 1" language="python" start-after="start example 1" emphasize-lines="1,2-4" lineno-start="17">
+        <directive name="literalinclude" caption="Sample Code" copyable="False" dedent="4" linenos="True" end-before="end example 1" language="python" start-after="start example 1" emphasize-lines="1,2-4" lineno-start="17" category="syntax">
         <text>/test_parser/includes/sample_code.py</text>
         <code emphasize_lines="[(1, 1), (2, 4)]" lang="python" caption="Sample Code" linenos="True" lineno_start="17" category="syntax">print("test dedent")</code>
         </directive>

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -981,6 +981,7 @@ def test_codeblock() -> None:
     assert len(diagnostics) == 1
     assert isinstance(diagnostics[0], DocUtilsParseError)
 
+
 def test_literalinclude() -> None:
     path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")


### PR DESCRIPTION
### Notes

Following the changes made in PR #389 , this PR adds a new "category" string option to:
- `code-block`
- The `input` block of `io-code-block`
- `literalinclude`

It intentionally omits a category on the `output` block because that will always be of "Return object" category - no need for writers to specify that.

Writers can use this to supply the category of a code example for internal programmatic tracking. This currently has no frontend use.