### PR TITLE
DOP-5589: Composable tutorials dynamic headings

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -533,6 +533,9 @@ class ContentsHandler(Handler):
                 self.scanned_pattern.append((node.name, node.options["id"]))
             elif node.name == "tab":
                 self.scanned_pattern.append((node.name, node.options["tabid"]))
+            elif node.name == "selected-content":
+                selections = cast(Dict[str, str], node.selections)
+                self.scanned_pattern.append((node.name, selections))
 
         if isinstance(node, n.Directive) and node.name == "contents":
             if self.has_contents_directive:
@@ -573,7 +576,7 @@ class ContentsHandler(Handler):
 
     def exit_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
         if isinstance(node, n.Directive) and (
-            node.name == "method-option" or node.name == "tab"
+            node.name in ["method-option", "tab", "selected-content"]
         ):
             self.scanned_pattern.pop()
         if isinstance(node, n.Section):

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -468,7 +468,7 @@ class NamedReferenceHandlerPass2(Handler):
         node.refuri = refuri
 
 
-SelectorId = Dict[str, Union[str, "SelectorId"]]
+SelectorId = Dict[str, Union[str, Dict[str, str], "SelectorId"]]
 
 
 class ContentsHandler(Handler):
@@ -486,9 +486,11 @@ class ContentsHandler(Handler):
         self.current_depth = 0
         self.has_contents_directive = False
         self.headings: List[ContentsHandler.HeadingData] = []
-        self.scanned_pattern: List[Tuple[str, str]] = []
+        self.scanned_pattern: List[Tuple[str, Union[str, Dict[str, str]]]] = []
 
-    def scan_pattern(self, arr: List[Tuple[str, str]]) -> SelectorId:
+    def scan_pattern(
+        self, arr: List[Tuple[str, Union[str, Dict[str, str]]]]
+    ) -> SelectorId:
         if not arr:
             return {}
         if len(arr) == 1:
@@ -534,8 +536,8 @@ class ContentsHandler(Handler):
             elif node.name == "tab":
                 self.scanned_pattern.append((node.name, node.options["tabid"]))
             elif node.name == "selected-content":
-                selections = cast(Dict[str, str], node.selections)
-                self.scanned_pattern.append((node.name, selections))
+                assert isinstance(node, n.ComposableContent)
+                self.scanned_pattern.append((node.name, node.selections))
 
         if isinstance(node, n.Directive) and node.name == "contents":
             if self.has_contents_directive:

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4166,6 +4166,73 @@ Title here
         ]
 
 
+def test_composable_headings():
+    with make_test(
+        {
+            Path(
+                "source/index.txt"
+            ): """
+.. contents:: On this page
+   :local:
+   :depth: 3
+
+======================
+This is the page title
+======================
+   
+.. composable-tutorial::
+   :options: interface, language
+   :defaults: driver, nodejs
+         
+   .. selected-content::
+      :selections: driver, nodejs
+
+      This is a title under selected content
+      --------------------------------------
+
+      This is another heading!
+      ~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+""",
+        }
+    ) as result:
+        test_file_id = FileId("index.txt")
+        page = result.pages[test_file_id]
+        diagnostics = result.diagnostics[test_file_id]
+        assert len(diagnostics) == 0
+        diagnostics = result.diagnostics
+        assert page.ast.options.get("headings") == [
+            {
+                "depth": 2,
+                "id": "this-is-a-title-under-selected-content",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 17}},
+                        "value": "This is a title under selected content",
+                    }
+                ],
+                "selector_ids": {
+                    "selected-content": {"interface": "driver", "language": "nodejs"}
+                },
+            },
+            {
+                "depth": 3,
+                "id": "this-is-another-heading-",
+                "title": [
+                    {
+                        "type": "text",
+                        "position": {"start": {"line": 20}},
+                        "value": "This is another heading!",
+                    }
+                ],
+                "selector_ids": {
+                    "selected-content": {"interface": "driver", "language": "nodejs"}
+                },
+            },
+        ]
+
+
 def test_multi_page_tutorials() -> None:
     test_page_template = """
 .. multi-page-tutorial::

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -4166,7 +4166,7 @@ Title here
         ]
 
 
-def test_composable_headings():
+def test_composable_headings() -> None:
     with make_test(
         {
             Path(
@@ -4200,7 +4200,6 @@ This is the page title
         page = result.pages[test_file_id]
         diagnostics = result.diagnostics[test_file_id]
         assert len(diagnostics) == 0
-        diagnostics = result.diagnostics
         assert page.ast.options.get("headings") == [
             {
                 "depth": 2,


### PR DESCRIPTION
### Ticket

DOP-5589

### Notes
This ticket stores heading info under Composable Tutorials into the page option, so that front end can consume this dynamically. 
See [front end changes here](https://github.com/mongodb/snooty/pull/1412)
See [staged front end here](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5507/landing/seung.park/DOP-5589/composable-tutorials/index.html?deployment-type=self&interface=atlas-admin-api&operator=autocomplete)

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
