### PR TITLE
Fix sharedinclude proxy

### DIFF
--- a/snooty/util.py
+++ b/snooty/util.py
@@ -334,7 +334,7 @@ class HTTPCache:
         url_netloc = urllib.parse.urlparse(url).netloc
         is_raw_gh_content_url = url_netloc == "raw.githubusercontent.com"
         target_url = (
-            f"https://docs-frontend-stg.netlify.app/.netlify/functions/fetch-url?url={url}"
+            f"https://populate-data-extension.netlify.app/.netlify/functions/fetch-url?url={url}"
             if is_raw_gh_content_url
             else url
         )


### PR DESCRIPTION
### Ticket

N/A

### Notes

* See https://github.com/mongodb/netlify-extensions/pull/124 for more information. Tl;dr is that the old proxy serverless function was getting difficult to maintain and a Netlify backend issue caused the original serverless function to stop working, so we had to move it to make it easier to redeploy.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
