### PR TITLE
DOP-5604: dismissible skills

### DIFF
--- a/snooty/n.py
+++ b/snooty/n.py
@@ -529,3 +529,12 @@ class ComposableDirective(Directive):
 class ComposableContent(Directive):
     __slots__ = "selections"
     selections: Dict[str, str]
+
+@dataclass
+class DismissibleSkillsCard(Node):
+    __slots__ = (
+        "skill",
+        "url",
+    )
+    skill: str
+    url: str

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -40,6 +40,7 @@ from .diagnostics import (
     Diagnostic,
     DuplicatedExternalToc,
     DuplicateDirective,
+    ExpectedOption,
     ExpectedPathArg,
     ExpectedTabs,
     FetchError,
@@ -1986,10 +1987,9 @@ class CollapsibleHandler(Handler):
         if isinstance(node, n.Directive) and node.name == "collapsible":
             self.collapsible_detected = False
 
-# Possible todo: check that url is healthy? Check if both options are there and are strings? Is this built in??
 class DismissibleSkillsCardHandler(Handler):
     """Handles duplicate dismissible skills card directives on a single page.
-    If a page has multiple, raise a diagnostic"""
+    Adds DismissibleSkillsCard node to page options"""
 
     def __init__(self, context: Context) -> None:
         super().__init__(context)
@@ -2011,6 +2011,13 @@ class DismissibleSkillsCardHandler(Handler):
                 "url": node.options["url"],
                 "skill": node.options["skill"]
             }
+        else:
+            for option in ("url", "skill"):
+                if not node.options.get(option):
+                    self.context.diagnostics[fileid_stack.current].append(
+                        ExpectedOption(node.name, option)
+                    )
+
 
     def exit_page(self, fileid_stack: FileIdStack, page: Page) -> None:
         if self.dismissible_skills_card:

--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -1986,6 +1986,26 @@ class CollapsibleHandler(Handler):
         if isinstance(node, n.Directive) and node.name == "collapsible":
             self.collapsible_detected = False
 
+# Possible todo: check that url is healthy? Check if both options are there and are strings? Is this built in??
+class DismissibleSkillsCardHandler(Handler):
+    """Handles duplicate dismissible skills card directives on a single page.
+    If a page has multiple, raise a diagnostic"""
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self.dismissible_skills_card_detected = False
+
+    def enter_page(self, fileid_stack: FileIdStack, page: Page) -> None:
+        self.dismissible_skills_card_detected = False
+
+    def enter_node(self, fileid_stack: FileIdStack, node: n.Node) -> None:
+        if not isinstance(node, n.Directive) or node.name != "dismissible-skills-card":
+            return
+        if self.dismissible_skills_card_detected:
+            self.context.diagnostics[fileid_stack.current].append(
+                DuplicateDirective(node.name, node.span[0])
+            )
+        self.dismissible_skills_card_detected = True
 
 class NestedDirectiveHandler(Handler):
     """Prevents a directive from being nested deeper than intended on a page and from being used twice in a single page."""

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -878,6 +878,17 @@ help = "Content chosen to be displayed"
 options.selections = {type = "string", required = true}
 content_type = "block"
 
+[directive."mongodb:dismissible-skills-card"]
+help = "A dismissible card that links to Skills"
+content_type = "block"
+options.skill = {type = "string", required = true}
+options.url = {type = "string", required = true}
+example = """
+.. dismissible-skills-card::
+   :skill: CRUD Operations
+   :url: https://learn.mongodb.com/courses/crud-operations-in-mongodb
+"""
+
 ###### Misc.
 [directive.atf-image]
 help = "Path to the image to use for the above-the-fold header image"


### PR DESCRIPTION
### Ticket

DOP-5604

### Notes

Creates new `dismissible-skills-card` directive. The subsequently created node is injected into the page options as it is not in the normal page flow on the frontend.

The only necessary information needed is the skill title and the url to the skill.

A PR for Snooty is being worked on - will link here when open.

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
