### PR TITLE
Omit files in 'code-examples' directory from orphan diagnostic check

### DIFF
--- a/snooty/postprocess.py
+++ b/snooty/postprocess.py
@@ -2547,6 +2547,9 @@ class Postprocessor:
 
         # Locate orphaned files
         for fileid in context.pages:
+            if "code-examples" in fileid.parts:
+                continue
+
             if fileid.suffix != EXT_FOR_PAGE:
                 continue
 

--- a/snooty/test_postprocess.py
+++ b/snooty/test_postprocess.py
@@ -3404,11 +3404,25 @@ A Marked Orphan
 Not An Orphan
 =============
             """,
+            Path(
+                "source/code-examples/includes/connection-string.txt"
+            ): """
+mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
+            """,
         }
     ) as result:
-        assert {
+        diagnostics = {
             k: [type(d) for d in v] for k, v in result.diagnostics.items() if v
-        } == {FileId("orphan.txt"): [OrphanedPage]}
+        }
+
+        assert diagnostics == {FileId("orphan.txt"): [OrphanedPage]}
+
+        # Add a check to ensure a path including `code-examples` does NOT return `OrphanedPage`
+        assert FileId(
+            "code-examples/includes/connection-string.txt"
+        ) not in diagnostics or OrphanedPage not in diagnostics.get(
+            FileId("code-examples/includes/connection-string.txt"), []
+        )
 
 
 def test_slug_to_breadcrumb_labels() -> None:


### PR DESCRIPTION
### Ticket

N/A

### Notes

As part of a code example testing initiative, I am programmatically removing all hard-coded code-block directives in monorepo content. I've written tooling that moves code examples out into files with extensions that vary based on the programming language. Where the programming language is omitted, or the language is `text`, the content of the code-block is written to a `.txt` file. See an example in my test repo here (the dir name has changed from `untested-examples` to `code-examples` since creating this test PR): https://github.com/dacharyc/workflow-testing/pull/3

I'm starting to migrate docs in the monorepo using my tooling, and it's triggering a bunch of build warnings related to orphaned pages - i.e.:

```WARNING(code-examples/includes/fact-connection-strings/1.txt:0ish): Page not included in any toctree and not marked :orphan:```

As it is valid to have `.txt` files that are code examples used in literalincludes, I'd like to omit the orphan diagnostic when the filepath includes the `code-examples` directory. This should ensure we're only applying the orphan diagnostic to docs pages.

If there's another way you'd prefer to handle this, I'm happy to do something different - just wanted to make it easy with a quickie PR!

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [ ] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
