### PR TITLE
DOP-5873: Add new oas-bump-atlas roles

### DIFF
--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -1661,6 +1661,12 @@ type = {link = "https://www.mongodb.com/docs/atlas/reference/api-resources-spec/
 [role."oas-atlas-op"]
 type = {link = "https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#operation%s"}
 
+[role."oas-bump-atlas-tag"]
+type = {link = "https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/group/endpoint-%s"}
+
+[role."oas-bump-atlas-op"]
+type = {link = "https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-%s"}
+
 [role."atlascli"]
 help = """Link to a page in the Atlas CLI documentation."""
 type = {link = "https://www.mongodb.com/docs/atlas/cli/current%s", ensure_trailing_slash = true}


### PR DESCRIPTION
### Ticket

DOP-5873

### Notes

* Adds new `oas-bump-atlas` roles that will eventually replace existing `oas-atlas` roles. The new roles should use the URL structure of the new Bump pages. This was desired to be a separate role so that writers can update their usage in the docs when they're ready without introducing breaking changes.
* In case a staging links are needed for testing, I modified some content locally to work (there won't be examples available in prod/preprod):
  * [oas-bump-atlas-tag](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5873-oas-roles/cloud-docs/raymund.rodriguez/main/access-tracking/index.html) - Go to the "Atlas Administration API" tab at the bottom and see the "Access Tracking" link.
  * [oas-bump-atlas-op](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-5873-oas-roles/cloud-docs/raymund.rodriguez/main/configure-api-access/index.html#make-an--call.) - See the "returns all projects" link.

**Old reStructuredText:**

```reStructuredText
To view the database access history using the API, see :oas-atlas-tag:`Access Tracking </Access-Tracking>`.

The following sample ``GET`` request :oas-atlas-op:`returns all projects </listProjects>` in your organization.
```

**New reStructuredText:**

```reStructuredText
To view the database access history using the API, see :oas-bump-atlas-tag:`Access Tracking <access-tracking>`.

The following sample ``GET`` request :oas-bump-atlas-op:`returns all projects <listprojects>` in your organization.
```

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
