### PR TITLE
DOP-5920: allow None values in defaults, and allow non selected content in composables

### DIFF
--- a/snooty/parser.py
+++ b/snooty/parser.py
@@ -932,9 +932,13 @@ class JSONVisitor:
                 allowed_values_dict = {
                     option.id: option for option in composable_from_spec.options
                 }
-                self.check_valid_option_id(
-                    specified_default_id, node, allowed_values_dict, set()
-                )
+                # Skip validation for "None" as it means "no selection" when composable has dependencies
+                if specified_default_id != "None" or (
+                    not composable_from_spec.dependencies
+                ):
+                    self.check_valid_option_id(
+                        specified_default_id, node, allowed_values_dict, set()
+                    )
                 default_ids_dict[option_id] = (
                     specified_default_id
                     or composable_from_spec.default

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -4822,4 +4822,4 @@ def test_composable_tutorial_errors() -> None:
 """,
     )
     assert len(diagnostics) == 1
-    assert type(diagnostics[0]) == UnknownOptionId
+    assert type(diagnostics[0]) == MissingChild


### PR DESCRIPTION
### Ticket

DOP-5920
DOP-6050

### Notes
- PR skips id validation if a default id specified is "None" while having dependencies for that composable option - this means dependency can be unfulfilled and No Selection is allowed. See added test
- Also removes the check for all children to be `.. selected-content` directives. This allows writers to have repeatable content under the select options in the UI. (front end PR will be linked here)


### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [X] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
