### PR TITLE
DOP-6049 adds new directives called multi-column and column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.20.7] - 2025-08-07
+
 ## [v0.20.6] - 2025-07-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snooty"
-version = "0.20.6.dev"
+version = "0.20.7"
 description = ""
 authors = ["MongoDB, inc. <andrew.aldridge@mongodb.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snooty"
-version = "0.20.7"
+version = "0.20.7.dev"
 description = ""
 authors = ["MongoDB, inc. <andrew.aldridge@mongodb.com>"]
 license = "Apache-2.0"

--- a/snooty/__init__.py
+++ b/snooty/__init__.py
@@ -1,3 +1,3 @@
 """The Snooty documentation writer's tool."""
 
-__version__ = "0.20.6.dev"
+__version__ = "0.20.7"

--- a/snooty/__init__.py
+++ b/snooty/__init__.py
@@ -1,3 +1,3 @@
 """The Snooty documentation writer's tool."""
 
-__version__ = "0.20.7"
+__version__ = "0.20.7.dev"

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -586,7 +586,7 @@ content_type = "block"
 options.title = "string"
 
 [directive."multi-column"]
-help = """A two-column component for the homepage"""
+help = """A multi-column component for the homepage"""
 content_type = "block"
 example = """.. multi-column::
 

--- a/snooty/rstspec.toml
+++ b/snooty/rstspec.toml
@@ -580,6 +580,32 @@ help = """A list of languages that this guide supports."""
 # """
 content_type = "list"
 
+[directive.column]
+help = """column content for the n-column component"""
+content_type = "block"
+options.title = "string"
+
+[directive."multi-column"]
+help = """A two-column component for the homepage"""
+content_type = "block"
+example = """.. multi-column::
+
+   .. column::
+
+      .. code-block:: ${4:language}
+         ${5:First code block content}
+
+      ${6:Paragraph content between code blocks}
+
+      .. code-block:: ${7:language}
+         ${8:Second code block content}
+
+   .. column::
+
+      ${9:title}
+      ${10:Unordered list content}
+"""
+
 
 ##### Guides (LEGACY - do not deprecate until removed in dependent docs repos)
 [directive.hlist]

--- a/snooty/test_parser.py
+++ b/snooty/test_parser.py
@@ -1487,6 +1487,108 @@ def test_banner() -> None:
     )
 
 
+def test_multi_column() -> None:
+    path = FileId("test.rst")
+    project_config = ProjectConfig(ROOT_PATH, "", source="./")
+    parser = rstparser.Parser(project_config, JSONVisitor)
+
+    # Test valid multi-column
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. multi-column::
+
+   .. column::
+      :title: First Column
+
+      .. code-block:: python
+        
+        print("Hello from first column")
+
+      This is a paragraph between code blocks.
+
+      .. code-block:: javascript
+        
+        console.log("Second code block");
+
+   .. column::
+      :title: Second Column
+
+      * List item 1
+      * List item 2
+      * List item 3
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst">
+        <directive name="multi-column">
+            <directive name="column" title="First Column">
+                <code lang="python" copyable="True">print("Hello from first column")</code>
+                <paragraph><text>This is a paragraph between code blocks.</text></paragraph>
+                <code lang="javascript" copyable="True">console.log("Second code block");</code>
+            </directive>
+            <directive name="column" title="Second Column">
+                <list enumtype="unordered">
+                    <listItem><paragraph><text>List item 1</text></paragraph></listItem>
+                    <listItem><paragraph><text>List item 2</text></paragraph></listItem>
+                    <listItem><paragraph><text>List item 3</text></paragraph></listItem>
+                </list>
+            </directive>
+        </directive>
+        </root>""",
+    )
+
+    # Test multi-column with no columns
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. multi-column::
+
+   No columns here, just content.
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst">
+        <directive name="multi-column">
+            <paragraph><text>No columns here, just content.</text></paragraph>
+        </directive>
+        </root>""",
+    )
+
+    # Test column with no title option
+    page, diagnostics = parse_rst(
+        parser,
+        path,
+        """
+.. multi-column::
+
+   .. column::
+
+      Content without title.
+""",
+    )
+    page.finish(diagnostics)
+    assert diagnostics == []
+    check_ast_testing_string(
+        page.ast,
+        """<root fileid="test.rst">
+        <directive name="multi-column">
+            <directive name="column">
+                <paragraph><text>Content without title.</text></paragraph>
+            </directive>
+        </directive>
+        </root>""",
+    )
+
+
 def test_cta_banner() -> None:
     path = FileId("test.rst")
     project_config = ProjectConfig(ROOT_PATH, "", source="./")


### PR DESCRIPTION
### Ticket

DOP-6049

### Notes

Adds two new directives (multi-column, and column).

### README updates

- - [ ] This PR introduces changes that should be reflected in the README.md and/or HACKING.md, and I have made those updates.
- - [x] This PR does not introduce changes that should be reflected in the README.md and/or HACKING.md
